### PR TITLE
feat(M7): migrate CSS design tokens to Stitch color system

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -28,6 +28,28 @@
     --popover: #201f1f;
     --popover-foreground: #e5e2e1;
     --radius: 0.125rem;
+    /* RGB channel variables — enable Tailwind opacity modifiers (e.g. bg-primary/10) */
+    --background-rgb: 19 19 19;
+    --background-secondary-rgb: 32 31 31;
+    --background-surface-rgb: 28 27 27;
+    --foreground-rgb: 229 226 225;
+    --primary-rgb: 255 183 123;
+    --primary-foreground-rgb: 77 39 0;
+    --secondary-rgb: 32 31 31;
+    --secondary-foreground-rgb: 229 226 225;
+    --muted-rgb: 42 42 42;
+    --muted-foreground-rgb: 216 195 180;
+    --accent-rgb: 200 128 63;
+    --accent-foreground-rgb: 255 220 194;
+    --destructive-rgb: 255 180 171;
+    --destructive-foreground-rgb: 105 0 5;
+    --border-rgb: 82 68 57;
+    --input-rgb: 42 42 42;
+    --ring-rgb: 255 183 123;
+    --card-rgb: 28 27 27;
+    --card-foreground-rgb: 229 226 225;
+    --popover-rgb: 32 31 31;
+    --popover-foreground-rgb: 229 226 225;
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,42 +12,42 @@ const config: Config = {
     extend: {
       colors: {
         background: {
-          DEFAULT: 'var(--background)',
-          secondary: 'var(--background-secondary)',
-          surface: 'var(--background-surface)',
+          DEFAULT: 'rgb(var(--background-rgb) / <alpha-value>)',
+          secondary: 'rgb(var(--background-secondary-rgb) / <alpha-value>)',
+          surface: 'rgb(var(--background-surface-rgb) / <alpha-value>)',
         },
-        foreground: 'var(--foreground)',
+        foreground: 'rgb(var(--foreground-rgb) / <alpha-value>)',
         card: {
-          DEFAULT: 'var(--card)',
-          foreground: 'var(--card-foreground)',
+          DEFAULT: 'rgb(var(--card-rgb) / <alpha-value>)',
+          foreground: 'rgb(var(--card-foreground-rgb) / <alpha-value>)',
         },
         popover: {
-          DEFAULT: 'var(--popover)',
-          foreground: 'var(--popover-foreground)',
+          DEFAULT: 'rgb(var(--popover-rgb) / <alpha-value>)',
+          foreground: 'rgb(var(--popover-foreground-rgb) / <alpha-value>)',
         },
         primary: {
-          DEFAULT: 'var(--primary)',
-          foreground: 'var(--primary-foreground)',
+          DEFAULT: 'rgb(var(--primary-rgb) / <alpha-value>)',
+          foreground: 'rgb(var(--primary-foreground-rgb) / <alpha-value>)',
         },
         secondary: {
-          DEFAULT: 'var(--secondary)',
-          foreground: 'var(--secondary-foreground)',
+          DEFAULT: 'rgb(var(--secondary-rgb) / <alpha-value>)',
+          foreground: 'rgb(var(--secondary-foreground-rgb) / <alpha-value>)',
         },
         muted: {
-          DEFAULT: 'var(--muted)',
-          foreground: 'var(--muted-foreground)',
+          DEFAULT: 'rgb(var(--muted-rgb) / <alpha-value>)',
+          foreground: 'rgb(var(--muted-foreground-rgb) / <alpha-value>)',
         },
         accent: {
-          DEFAULT: 'var(--accent)',
-          foreground: 'var(--accent-foreground)',
+          DEFAULT: 'rgb(var(--accent-rgb) / <alpha-value>)',
+          foreground: 'rgb(var(--accent-foreground-rgb) / <alpha-value>)',
         },
         destructive: {
-          DEFAULT: 'var(--destructive)',
-          foreground: 'var(--destructive-foreground)',
+          DEFAULT: 'rgb(var(--destructive-rgb) / <alpha-value>)',
+          foreground: 'rgb(var(--destructive-foreground-rgb) / <alpha-value>)',
         },
-        border: 'var(--border)',
-        input: 'var(--input)',
-        ring: 'var(--ring)',
+        border: 'rgb(var(--border-rgb) / <alpha-value>)',
+        input: 'rgb(var(--input-rgb) / <alpha-value>)',
+        ring: 'rgb(var(--ring-rgb) / <alpha-value>)',
         gold: {
           50: '#FFF9E6', 100: '#FFF0BF', 200: '#FFE080', 300: '#FFD040',
           400: '#FFBF00', 500: '#C9A84C', 600: '#A07830', 700: '#7A5820',


### PR DESCRIPTION
Closes #25

## Summary

- Adds 44 Stitch "Alea dos" color tokens as hex values in `tailwind.config.ts` (surface hierarchy, primary/secondary/tertiary, error, fixed variants, inverse tokens)
- Updates `borderRadius`: full scale — sm 1px, DEFAULT 2px, md 3px, lg 4px, xl 8px, 2xl 12px; `full` kept at 9999px
- Updates `:root` CSS variables in `globals.css` from HSL to hex values aligned with Stitch tokens
- Adds `--background-secondary` and `--background-surface` CSS variables (were referenced in `tailwind.config.ts` but missing from `:root`)
- Adds 6 utility classes: `glass-panel`, `glass-effect`, `hero-gradient`, `heraldic-watermark`, `copper-shimmer`, `bg-neo-classical`
- Keeps `gold`, `emerald`, `crimson`, `arcane` palettes (table availability states) and Cinzel + Inter typography
- Merged latest `develop` (includes auth hardening, security, and Supabase config changes from M3+)

## Review fixes

**`6bc8bfa`**:
1. Added missing `--background-secondary: #201f1f` and `--background-surface: #1c1b1b` to `:root` — these were referenced by Tailwind config but undefined, causing transparent backgrounds on the stats and CTA sections.
2. Replaced hard-coded `rgba(255, 183, 123, ...)` in `.rpg-card:hover` with `color-mix(in srgb, var(--primary) 40%, transparent)` and `color-mix(in srgb, var(--primary) 5%, transparent)`. Removed redundant `hover:shadow-lg` from `@apply`.

**`beeb985`**:
3. Added `sm: '0.0625rem'` and `md: '0.1875rem'` to `borderRadius` — fills the gap so `rounded-sm` (checkboxes, dialog, dropdown items) and `rounded-md` (buttons, inputs, tabs, popovers) use Stitch scale values instead of Tailwind defaults.

## Validation

| Gate | Result |
|------|--------|
| Lint | ✅ Pass |
| Typecheck | ✅ Pass |
| Build | ✅ 22 static pages |
| Tests | ✅ 154/154 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)