### PR TITLE
feat(M3): user-level overlap restriction on reservation creation (KIM-330, KIM-338)

### DIFF
--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -84,6 +84,15 @@ function seedState() {
     pos_x: 0,
     pos_y: 0,
   })
+  tablesState.set('t2', {
+    id: 't2',
+    room_id: 'room-1',
+    name: 'Mesa 2',
+    type: 'small',
+    qr_code: 'QR-2',
+    pos_x: 1,
+    pos_y: 0,
+  })
   tablesState.set('t3', {
     id: 't3',
     room_id: 'room-1',
@@ -146,6 +155,31 @@ function buildSelectChain<T>(rows: T[]) {
     or(condition: string) {
       // OR filtering is handled by the actual Supabase client; mock just returns this for chaining
       return this
+    },
+    lt(column: string, value: string) {
+      current = current.filter((row) => {
+        let cellValue = String((row as Record<string, unknown>)[column] ?? '')
+        // Normalize time values for comparison (HH:MM:SS -> HH:MM)
+        if (cellValue.match(/^\d{2}:\d{2}:\d{2}$/)) {
+          cellValue = cellValue.slice(0, 5)
+        }
+        return cellValue < value
+      })
+      return this
+    },
+    gt(column: string, value: string) {
+      current = current.filter((row) => {
+        let cellValue = String((row as Record<string, unknown>)[column] ?? '')
+        // Normalize time values for comparison (HH:MM:SS -> HH:MM)
+        if (cellValue.match(/^\d{2}:\d{2}:\d{2}$/)) {
+          cellValue = cellValue.slice(0, 5)
+        }
+        return cellValue > value
+      })
+      return this
+    },
+    limit(count: number) {
+      return Promise.resolve({ data: current.slice(0, count).map((row) => ({ ...row })), error: null })
     },
     then<TResult1 = { data: T[]; error: null }, TResult2 = never>(
       onfulfilled?: ((value: { data: T[]; error: null }) => TResult1 | PromiseLike<TResult1>) | null,
@@ -479,6 +513,68 @@ describe('reservations service', () => {
         name: 'ServiceError',
         statusCode: 409,
       })
+    })
+
+    it('rejects a reservation that overlaps an existing slot for the same user', async () => {
+      const { createReservationForSession } = await loadReservationModules()
+      await expect(
+        createReservationForSession(memberSession, {
+          tableId: 't2',
+          date: '2026-04-04',
+          startTime: '17:00',
+          endTime: '19:00',
+        })
+      ).rejects.toMatchObject({ name: 'ServiceError', statusCode: 409 })
+    })
+
+    it('allows a reservation on a different date even if times overlap', async () => {
+      const { createReservationForSession } = await loadReservationModules()
+      await expect(
+        createReservationForSession(memberSession, {
+          tableId: 't1',
+          date: '2026-04-05',
+          startTime: '16:00',
+          endTime: '18:00',
+        })
+      ).resolves.toEqual(expect.objectContaining({ date: '2026-04-05' }))
+    })
+
+    it('allows a reservation that starts exactly when another ends', async () => {
+      const { createReservationForSession } = await loadReservationModules()
+      await expect(
+        createReservationForSession(memberSession, {
+          tableId: 't1',
+          date: '2026-04-04',
+          startTime: '18:00',
+          endTime: '20:00',
+        })
+      ).resolves.toEqual(expect.objectContaining({ startTime: '18:00' }))
+    })
+
+    it('ignores cancelled reservations when checking user overlap', async () => {
+      reservationsState[0]!.status = 'cancelled'
+      const { createReservationForSession } = await loadReservationModules()
+      await expect(
+        createReservationForSession(memberSession, {
+          tableId: 't1',
+          date: '2026-04-04',
+          startTime: '17:00',
+          endTime: '18:30',
+        })
+      ).resolves.toEqual(expect.objectContaining({ tableId: 't1' }))
+    })
+
+    it('counts pending reservations as blocking overlaps for the same user', async () => {
+      reservationsState[0]!.status = 'pending'
+      const { createReservationForSession } = await loadReservationModules()
+      await expect(
+        createReservationForSession(memberSession, {
+          tableId: 't2',
+          date: '2026-04-04',
+          startTime: '17:00',
+          endTime: '19:00',
+        })
+      ).rejects.toMatchObject({ name: 'ServiceError', statusCode: 409 })
     })
   })
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -8,17 +8,20 @@
 ## Last updated: 2026-04-11
 
 ## Current branch
-`feat/auto-cancel-grace-period`
+`feat/overlap-restriction`
 
-## Open PR
-[KimoxStudio/alea-webapp#76](https://github.com/KimoxStudio/alea-webapp/pull/76) — feat(M2): auto-cancel grace period constant + cron audit logging (KIM-327)
-- Status: open, awaiting manual merge by user
-- CI: ✅ typecheck, ✅ lint, ✅ 239 tests, ✅ build
+## Open PRs
+| PR | Branch | Status |
+|---|---|---|
+| [#76](https://github.com/KimoxStudio/alea-webapp/pull/76) | `feat/auto-cancel-grace-period` | Open — awaiting merge. Mark KIM-327 Done after merge. |
+| [#77](https://github.com/KimoxStudio/alea-webapp/pull/77) | `feat/overlap-restriction` | Open — awaiting merge. Mark KIM-330 + KIM-338 Done after merge. |
 
 ## Issues in progress
 | Issue | Title | Status |
 |---|---|---|
-| KIM-327 | Auto-cancel reservations not activated within 20-minute grace period | In Progress → mark Done after merge |
+| KIM-327 | Auto-cancel grace period (M2) | In Progress → Done after PR #76 merge |
+| KIM-330 | Overlap restriction per user (M3) | In Progress → Done after PR #77 merge |
+| KIM-338 | Overlap validation backend (M3) | In Progress → Done after PR #77 merge |
 
 ---
 
@@ -32,7 +35,15 @@
 - Test uses `GRACE_PERIOD_MINUTES` constant for the RPC assertion
 - Total: 239 tests passing
 
-## Next milestone after M2 merge: M3 / M5 / M8 / M10 (all parallel-safe from develop)
+## Next milestone: M5 (from develop)
+
+**M3 and M2 are open PRs — start M5 from `develop` immediately.**
+
+**Issue:** KIM-331 + KIM-340 — Cancellation cutoff backend (member cannot cancel within 60 min of start)
+**Branch to create:** `feat/cancellation-cutoff` from `develop`
+**File:** `lib/server/reservations-service.ts` — in `updateReservationForSession`, when `nextStatus === 'cancelled'` and `session.role !== 'admin'`: check if reservation starts within 60 min of now → throw `CANCELLATION_CUTOFF` (403)
+
+## Also available (parallel-safe from develop)
 
 **Any of these can start immediately — they do not depend on M2:**
 

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -31,7 +31,7 @@ type SessionReservationsQuery = {
 }
 type UserSlotOverlapQuery = {
   eq: (column: 'user_id' | 'date', value: string) => UserSlotOverlapQuery
-  not: (column: string, operator: string, value: string) => UserSlotOverlapQuery
+  in: (column: string, values: string[]) => UserSlotOverlapQuery
   lt: (column: string, value: string) => UserSlotOverlapQuery
   gt: (column: string, value: string) => UserSlotOverlapQuery
   then: Promise<{ data: ReservationRow[] | null; error: unknown }>['then']

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -34,6 +34,7 @@ type UserSlotOverlapQuery = {
   in: (column: string, values: string[]) => UserSlotOverlapQuery
   lt: (column: string, value: string) => UserSlotOverlapQuery
   gt: (column: string, value: string) => UserSlotOverlapQuery
+  limit: (count: number) => Promise<{ data: Array<{ id: string }> | null; error: unknown }>
   then: Promise<{ data: ReservationRow[] | null; error: unknown }>['then']
 }
 type UserSlotOverlapTableClient = {
@@ -286,6 +287,7 @@ async function checkUserSlotOverlap(
     .in('status', ['pending', 'active'])
     .lt('start_time', endTime)
     .gt('end_time', startTime)
+    .limit(1)
 
   if (error) {
     serviceError('Internal server error', 500)

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -31,9 +31,9 @@ type SessionReservationsQuery = {
 }
 type UserSlotOverlapQuery = {
   eq: (column: 'user_id' | 'date', value: string) => UserSlotOverlapQuery
-  in: (column: string, values: string[]) => UserSlotOverlapQuery
-  lt: (column: string, value: string) => UserSlotOverlapQuery
-  gt: (column: string, value: string) => UserSlotOverlapQuery
+  in: (column: 'status', values: string[]) => UserSlotOverlapQuery
+  lt: (column: 'start_time' | 'end_time', value: string) => UserSlotOverlapQuery
+  gt: (column: 'start_time' | 'end_time', value: string) => UserSlotOverlapQuery
   limit: (count: number) => Promise<{ data: Array<{ id: string }> | null; error: unknown }>
   then: Promise<{ data: ReservationRow[] | null; error: unknown }>['then']
 }

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -29,6 +29,16 @@ type SessionReservationsQuery = {
   order: (column: string, options: { ascending: boolean }) => SessionReservationsQuery
   then: Promise<{ data: ReservationRow[] | null; error: unknown }>['then']
 }
+type UserSlotOverlapQuery = {
+  eq: (column: 'user_id' | 'date', value: string) => UserSlotOverlapQuery
+  not: (column: string, operator: string, value: string) => UserSlotOverlapQuery
+  lt: (column: string, value: string) => UserSlotOverlapQuery
+  gt: (column: string, value: string) => UserSlotOverlapQuery
+  then: Promise<{ data: ReservationRow[] | null; error: unknown }>['then']
+}
+type UserSlotOverlapTableClient = {
+  select: (columns: string) => UserSlotOverlapQuery
+}
 type SessionReservationsTableClient = {
   select: (columns: string) => SessionReservationsQuery
   insert: (values: TablesInsert<'reservations'>) => {
@@ -262,6 +272,30 @@ export async function listVisibleReservations(input: {
   })
 }
 
+async function checkUserSlotOverlap(
+  userId: string,
+  date: string,
+  startTime: string,
+  endTime: string,
+  supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>,
+) {
+  const { data, error } = await (supabase.from('reservations') as unknown as UserSlotOverlapTableClient)
+    .select('id')
+    .eq('user_id', userId)
+    .eq('date', date)
+    .not('status', 'in', '("cancelled","no_show","completed")')
+    .lt('start_time', endTime)
+    .gt('end_time', startTime)
+
+  if (error) {
+    serviceError('Internal server error', 500)
+  }
+
+  if (data && data.length > 0) {
+    serviceError('USER_ALREADY_HAS_RESERVATION_IN_SLOT', 409)
+  }
+}
+
 export async function createReservationForSession(
   session: SessionUser,
   body: { tableId?: unknown; date?: unknown; startTime?: unknown; endTime?: unknown; surface?: unknown },
@@ -291,12 +325,14 @@ export async function createReservationForSession(
     serviceError('Invalid reservation time range', 400)
   }
 
+  const supabase = await createSupabaseServerClient()
+
+  await checkUserSlotOverlap(session.id, date, startTime, endTime, supabase)
+
   const conflictingReservations = await listActiveReservationsForConflict({ tableId, date })
   if (hasReservationConflict(conflictingReservations, { startTime, endTime, surface })) {
     serviceError('Time slot is already reserved', 409)
   }
-
-  const supabase = await createSupabaseServerClient()
   const insertPayload: TablesInsert<'reservations'> = {
     table_id: tableId,
     user_id: session.id,

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -283,7 +283,7 @@ async function checkUserSlotOverlap(
     .select('id')
     .eq('user_id', userId)
     .eq('date', date)
-    .not('status', 'in', '("cancelled","no_show","completed")')
+    .in('status', ['pending', 'active'])
     .lt('start_time', endTime)
     .gt('end_time', startTime)
 

--- a/supabase/migrations/20260411000004_idx_reservations_user_date_status.sql
+++ b/supabase/migrations/20260411000004_idx_reservations_user_date_status.sql
@@ -1,0 +1,4 @@
+-- Index to support user-level slot overlap check in createReservationForSession.
+-- Covers the (user_id, date, status) filter before start_time/end_time range predicates.
+CREATE INDEX IF NOT EXISTS reservations_user_date_status_idx
+  ON public.reservations (user_id, date, status);

--- a/supabase/migrations/20260411000004_idx_reservations_user_date_status.sql
+++ b/supabase/migrations/20260411000004_idx_reservations_user_date_status.sql
@@ -1,4 +1,6 @@
--- Index to support user-level slot overlap check in createReservationForSession.
+-- Partial index to support user-level slot overlap check in createReservationForSession.
 -- Covers the (user_id, date, status) filter before start_time/end_time range predicates.
+-- Only indexes rows in blocking statuses ('pending', 'active') to reduce index size and write overhead.
 CREATE INDEX IF NOT EXISTS reservations_user_date_status_idx
-  ON public.reservations (user_id, date, status);
+  ON public.reservations (user_id, date, status)
+  WHERE status IN ('pending', 'active');


### PR DESCRIPTION
## Summary

Adds a server-side user-level overlap restriction to prevent a member from holding more than one active/pending reservation in the same time slot.

Closes KIM-330, KIM-338.

## Changes

- `lib/server/reservations-service.ts`
  - New `checkUserSlotOverlap()` function — queries `reservations` by `(user_id, date, status IN ['pending','active'])` with time-range predicates `.lt('start_time', endTime).gt('end_time', startTime).limit(1)` to detect conflicts before insert
  - Called in `createReservationForSession()` before the existing table-level conflict check
  - Returns `USER_ALREADY_HAS_RESERVATION_IN_SLOT` (409) on conflict
  - `UserSlotOverlapQuery` / `UserSlotOverlapTableClient` local types added to work around Supabase generated-type limitations
- `supabase/migrations/20260411000004_idx_reservations_user_date_status.sql`
  - New composite index `(user_id, date, status)` for the overlap query's efficient index path

## Tests

- `__tests__/server/reservations-service.test.ts`
  - `buildSelectChain` extended with `.lt()`, `.gt()`, `.limit()`
  - 5 new overlap tests: same-date overlap → 409, different date → allowed, adjacent times → allowed, cancelled not counted → allowed, pending is blocking → 409
  - 239/239 tests pass

## Notes

- TOCTOU race acknowledged — extremely unlikely for this use case; logged as post-MVP DB-level hardening item
- `updateReservationForSession` reschedule overlap is out of scope for this milestone