### PR TITLE
feat(overlap-ui-feedback): show distinct error message for user slot conflict (KIM-337)

### DIFF
--- a/__tests__/components/rooms/reservation-dialog.test.tsx
+++ b/__tests__/components/rooms/reservation-dialog.test.tsx
@@ -176,10 +176,7 @@ describe('ReservationDialog', () => {
     await waitFor(() => {
       const alert = screen.getByRole('alert')
       expect(alert).toBeInTheDocument()
-      // This test validates the error handling structure
-      // When the feature is implemented, it should show 'errors.userSlotConflict'
-      // For now, the component shows 'errors.conflictTime' for all errors
-      expect(alert.textContent).toMatch(/errors\.(userSlotConflict|conflictTime)/)
+      expect(alert).toHaveTextContent('errors.userSlotConflict')
     })
   })
 
@@ -246,7 +243,7 @@ describe('ReservationDialog', () => {
       statusCode: 409,
     })
 
-    render(
+    const { unmount } = render(
       <ReservationDialog
         table={mockTable}
         open={true}
@@ -285,6 +282,33 @@ describe('ReservationDialog', () => {
     await user.click(cancelButton)
 
     expect(onClose).toHaveBeenCalled()
+
+    // Unmount and re-render to verify error state is cleared
+    unmount()
+
+    mockMutateAsync.fn = vi.fn().mockResolvedValueOnce({
+      id: 'res-456',
+      tableId: 't1',
+      userId: 'user-123',
+      date: '2025-01-16',
+      startTime: '10:00',
+      endTime: '11:00',
+      status: 'pending',
+      surface: null,
+      createdAt: new Date().toISOString(),
+      activatedAt: null,
+    })
+
+    render(
+      <ReservationDialog
+        table={mockTable}
+        open={true}
+        onClose={vi.fn()}
+      />
+    )
+
+    // Verify no error alert is present in the fresh dialog
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
   it('submit button is disabled when time range not selected', () => {

--- a/__tests__/components/rooms/reservation-dialog.test.tsx
+++ b/__tests__/components/rooms/reservation-dialog.test.tsx
@@ -15,10 +15,15 @@ vi.mock('@/lib/auth/auth-context', () => ({
   }),
 }))
 
-// Store the mock function for dynamic updates
-const mockMutateAsync = {
-  fn: vi.fn(),
-}
+// Declare mock functions using vi.hoisted() so they're available during vi.mock() hoisting
+const { mockMutateAsync } = vi.hoisted(() => {
+  const mockMutateAsyncFn = vi.fn()
+  return {
+    mockMutateAsync: {
+      fn: mockMutateAsyncFn,
+    },
+  }
+})
 
 // Mock the hooks
 vi.mock('@/lib/hooks/use-reservations', () => ({

--- a/__tests__/components/rooms/reservation-dialog.test.tsx
+++ b/__tests__/components/rooms/reservation-dialog.test.tsx
@@ -1,0 +1,383 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { GameTable } from '@/lib/types'
+
+// Mock next-intl
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+// Mock the auth context
+vi.mock('@/lib/auth/auth-context', () => ({
+  useAuth: () => ({
+    user: { id: 'user-123', email: 'test@example.com' },
+  }),
+}))
+
+// Store the mock function for dynamic updates
+const mockMutateAsync = {
+  fn: vi.fn(),
+}
+
+// Mock the hooks
+vi.mock('@/lib/hooks/use-reservations', () => ({
+  useTableAvailability: () => ({
+    data: {
+      tableId: 't1',
+      date: '2025-01-15',
+      slots: [
+        { startTime: '09:00', available: true },
+        { startTime: '10:00', available: true },
+        { startTime: '11:00', available: true },
+        { startTime: '12:00', available: true },
+      ],
+      top: undefined,
+      bottom: undefined,
+    },
+    isLoading: false,
+  }),
+  useCreateReservation: () => ({
+    mutateAsync: mockMutateAsync.fn,
+    isPending: false,
+  }),
+}))
+
+// Import after mocks are set up
+import { ReservationDialog } from '@/components/rooms/reservation-dialog'
+
+const mockTable: GameTable = {
+  id: 't1',
+  roomId: 'room-1',
+  name: 'Table 1',
+  type: 'large',
+  qrCode: 'QR_T1',
+  position: { x: 0, y: 0 },
+}
+
+describe('ReservationDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMutateAsync.fn = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders dialog when open is true', () => {
+    render(
+      <ReservationDialog
+        table={mockTable}
+        open={true}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('does not render when table is null', () => {
+    render(
+      <ReservationDialog
+        table={null}
+        open={true}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('displays error alert when mutation throws generic error', async () => {
+    const user = userEvent.setup()
+    mockMutateAsync.fn = vi.fn().mockRejectedValueOnce({
+      message: 'Time slot is already reserved',
+      statusCode: 409,
+    })
+
+    render(
+      <ReservationDialog
+        table={mockTable}
+        open={true}
+        onClose={vi.fn()}
+      />
+    )
+
+    // Select date (tomorrow to avoid past date validation)
+    const dateInput = screen.getByLabelText('selectDate') as HTMLInputElement
+    const today = new Date()
+    const tomorrow = new Date(today)
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    const dateString = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, '0')}-${String(tomorrow.getDate()).padStart(2, '0')}`
+
+    await user.clear(dateInput)
+    await user.type(dateInput, dateString)
+
+    // Click on time slots to select start and end times
+    const timeButtons = screen.getAllByRole('button', { name: /\d{2}:\d{2}.*/ })
+    if (timeButtons.length >= 2) {
+      await user.click(timeButtons[0]) // Start time
+      await user.click(timeButtons[1]) // End time
+    }
+
+    // Submit
+    const submitButton = screen.getByRole('button', { name: 'makeReservation' })
+    await user.click(submitButton)
+
+    // Wait for error to appear
+    await waitFor(() => {
+      const alert = screen.getByRole('alert')
+      expect(alert).toBeInTheDocument()
+      expect(alert).toHaveTextContent('errors.conflictTime')
+    })
+  })
+
+  it('displays userSlotConflict error when mutation throws USER_ALREADY_HAS_RESERVATION_IN_SLOT error', async () => {
+    const user = userEvent.setup()
+    mockMutateAsync.fn = vi.fn().mockRejectedValueOnce({
+      message: 'USER_ALREADY_HAS_RESERVATION_IN_SLOT',
+      statusCode: 409,
+    })
+
+    render(
+      <ReservationDialog
+        table={mockTable}
+        open={true}
+        onClose={vi.fn()}
+      />
+    )
+
+    // Select date (tomorrow to avoid past date validation)
+    const dateInput = screen.getByLabelText('selectDate') as HTMLInputElement
+    const today = new Date()
+    const tomorrow = new Date(today)
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    const dateString = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, '0')}-${String(tomorrow.getDate()).padStart(2, '0')}`
+
+    await user.clear(dateInput)
+    await user.type(dateInput, dateString)
+
+    // Click on time slots to select start and end times
+    const timeButtons = screen.getAllByRole('button', { name: /\d{2}:\d{2}.*/ })
+    if (timeButtons.length >= 2) {
+      await user.click(timeButtons[0]) // Start time
+      await user.click(timeButtons[1]) // End time
+    }
+
+    // Submit
+    const submitButton = screen.getByRole('button', { name: 'makeReservation' })
+    await user.click(submitButton)
+
+    // Wait for error to appear
+    await waitFor(() => {
+      const alert = screen.getByRole('alert')
+      expect(alert).toBeInTheDocument()
+      // This test validates the error handling structure
+      // When the feature is implemented, it should show 'errors.userSlotConflict'
+      // For now, the component shows 'errors.conflictTime' for all errors
+      expect(alert.textContent).toMatch(/errors\.(userSlotConflict|conflictTime)/)
+    })
+  })
+
+  it('does not display error when mutation succeeds', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    mockMutateAsync.fn = vi.fn().mockResolvedValueOnce({
+      id: 'res-123',
+      tableId: 't1',
+      userId: 'user-123',
+      date: '2025-01-15',
+      startTime: '10:00',
+      endTime: '11:00',
+      status: 'pending',
+      surface: null,
+      createdAt: new Date().toISOString(),
+      activatedAt: null,
+    })
+
+    render(
+      <ReservationDialog
+        table={mockTable}
+        open={true}
+        onClose={onClose}
+      />
+    )
+
+    // Select date (tomorrow to avoid past date validation)
+    const dateInput = screen.getByLabelText('selectDate') as HTMLInputElement
+    const today = new Date()
+    const tomorrow = new Date(today)
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    const dateString = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, '0')}-${String(tomorrow.getDate()).padStart(2, '0')}`
+
+    await user.clear(dateInput)
+    await user.type(dateInput, dateString)
+
+    // Click on time slots to select start and end times
+    const timeButtons = screen.getAllByRole('button', { name: /\d{2}:\d{2}.*/ })
+    if (timeButtons.length >= 2) {
+      await user.click(timeButtons[0]) // Start time
+      await user.click(timeButtons[1]) // End time
+    }
+
+    // Submit
+    const submitButton = screen.getByRole('button', { name: 'makeReservation' })
+    await user.click(submitButton)
+
+    // Error should not appear
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+    // Success message should appear
+    await waitFor(() => {
+      const status = screen.getByRole('status')
+      expect(status).toBeInTheDocument()
+    })
+  })
+
+  it('clears error when closing dialog after failed submission', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    mockMutateAsync.fn = vi.fn().mockRejectedValueOnce({
+      message: 'Time slot is already reserved',
+      statusCode: 409,
+    })
+
+    render(
+      <ReservationDialog
+        table={mockTable}
+        open={true}
+        onClose={onClose}
+      />
+    )
+
+    // Select date (tomorrow to avoid past date validation)
+    const dateInput = screen.getByLabelText('selectDate') as HTMLInputElement
+    const today = new Date()
+    const tomorrow = new Date(today)
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    const dateString = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, '0')}-${String(tomorrow.getDate()).padStart(2, '0')}`
+
+    await user.clear(dateInput)
+    await user.type(dateInput, dateString)
+
+    // Click on time slots to select start and end times
+    const timeButtons = screen.getAllByRole('button', { name: /\d{2}:\d{2}.*/ })
+    if (timeButtons.length >= 2) {
+      await user.click(timeButtons[0]) // Start time
+      await user.click(timeButtons[1]) // End time
+    }
+
+    // Submit
+    const submitButton = screen.getByRole('button', { name: 'makeReservation' })
+    await user.click(submitButton)
+
+    // Wait for error to appear
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+
+    // Close dialog
+    const cancelButton = screen.getByRole('button', { name: 'cancel' })
+    await user.click(cancelButton)
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('submit button is disabled when time range not selected', () => {
+    render(
+      <ReservationDialog
+        table={mockTable}
+        open={true}
+        onClose={vi.fn()}
+      />
+    )
+
+    const submitButton = screen.getByRole('button', { name: 'makeReservation' })
+    expect(submitButton).toBeDisabled()
+  })
+
+  it('displays surface selector for removable_top tables', () => {
+    const removableTable: GameTable = {
+      ...mockTable,
+      type: 'removable_top',
+    }
+
+    render(
+      <ReservationDialog
+        table={removableTable}
+        open={true}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(screen.getByLabelText('selectSurface')).toBeInTheDocument()
+  })
+
+  it('does not display surface selector for large tables', () => {
+    render(
+      <ReservationDialog
+        table={mockTable}
+        open={true}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByLabelText('selectSurface')).not.toBeInTheDocument()
+  })
+
+  it('calls mutateAsync with correct parameters on submission', async () => {
+    const user = userEvent.setup()
+    mockMutateAsync.fn = vi.fn().mockResolvedValueOnce({
+      id: 'res-123',
+      tableId: 't1',
+      userId: 'user-123',
+      date: '2025-01-15',
+      startTime: '10:00',
+      endTime: '11:00',
+      status: 'pending',
+      surface: null,
+      createdAt: new Date().toISOString(),
+      activatedAt: null,
+    })
+
+    render(
+      <ReservationDialog
+        table={mockTable}
+        open={true}
+        onClose={vi.fn()}
+      />
+    )
+
+    // Select date (tomorrow to avoid past date validation)
+    const dateInput = screen.getByLabelText('selectDate') as HTMLInputElement
+    const today = new Date()
+    const tomorrow = new Date(today)
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    const dateString = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, '0')}-${String(tomorrow.getDate()).padStart(2, '0')}`
+
+    await user.clear(dateInput)
+    await user.type(dateInput, dateString)
+
+    // Click on time slots to select start and end times
+    const timeButtons = screen.getAllByRole('button', { name: /\d{2}:\d{2}.*/ })
+    if (timeButtons.length >= 2) {
+      await user.click(timeButtons[0]) // Start time
+      await user.click(timeButtons[1]) // End time
+    }
+
+    // Submit
+    const submitButton = screen.getByRole('button', { name: 'makeReservation' })
+    await user.click(submitButton)
+
+    // Verify mutateAsync was called with correct structure
+    await waitFor(() => {
+      expect(mockMutateAsync.fn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tableId: 't1',
+          date: dateString,
+          startTime: expect.any(String),
+          endTime: expect.any(String),
+        })
+      )
+    })
+  })
+})

--- a/components/rooms/reservation-dialog.tsx
+++ b/components/rooms/reservation-dialog.tsx
@@ -92,8 +92,13 @@ export function ReservationDialog({ table, open, onClose }: ReservationDialogPro
         setSelectedEndTime(null)
         setSelectedSurface(null)
       }, 1500)
-    } catch {
-      setError(t('errors.conflictTime'))
+    } catch (err) {
+      const errorCode = (err as { message?: string })?.message
+      if (errorCode === 'USER_ALREADY_HAS_RESERVATION_IN_SLOT') {
+        setError(t('errors.userSlotConflict'))
+      } else {
+        setError(t('errors.conflictTime'))
+      }
     }
   }
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -85,7 +85,8 @@
     "errors": {
       "conflictTime": "A reservation already exists at that time",
       "pastDate": "You cannot book dates in the past",
-      "invalidTime": "End time must be after start time"
+      "invalidTime": "End time must be after start time",
+      "userSlotConflict": "You already have a reservation in this time slot"
     }
   },
   "admin": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -85,7 +85,8 @@
     "errors": {
       "conflictTime": "Ya existe una reserva en ese horario",
       "pastDate": "No puedes reservar en fechas pasadas",
-      "invalidTime": "La hora de fin debe ser posterior a la de inicio"
+      "invalidTime": "La hora de fin debe ser posterior a la de inicio",
+      "userSlotConflict": "Ya tienes una reserva en este horario"
     }
   },
   "admin": {


### PR DESCRIPTION
## Summary

- Reservation dialog now shows a user-specific conflict message when a member tries to book a time slot they already have a reservation for
- Distinguishes `USER_ALREADY_HAS_RESERVATION_IN_SLOT` (user's own conflict) from generic table-level slot conflicts

## Changes

### `components/rooms/reservation-dialog.tsx`
In the `handleSubmit` catch block, added check for `error.message === 'USER_ALREADY_HAS_RESERVATION_IN_SLOT'` — shows `t('errors.userSlotConflict')` instead of the generic `t('errors.conflictTime')`. All other errors fall through to existing behavior.

### `messages/en.json` + `messages/es.json`
Added `reservations.errors.userSlotConflict`:
- EN: `"You already have a reservation in this time slot"`
- ES: `"Ya tienes una reserva en este horario"`

### `__tests__/components/rooms/reservation-dialog.test.tsx` (new)
10 component tests covering:
- Error differentiation: USER_ALREADY_HAS_RESERVATION_IN_SLOT → userSlotConflict
- Generic 409 → conflictTime
- Success path, form state, surface selector, submit parameters
- Uses `vi.hoisted()` for correct Vitest mock hoisting

## Test plan

- [x] 269 tests passing (23 test files)
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] Security review: APPROVE (no XSS, error rendered via t(), no raw API strings in DOM)
- [x] Performance review: APPROVE (single string equality check, negligible overhead)
- [x] QA review: APPROVE (all error paths tested, i18n parity confirmed)

Closes KIM-337

🤖 Generated with [Claude Code](https://claude.com/claude-code)