### PR TITLE
fix(reservations): allow pending reservations to be cancelled (KIM-362)

### DIFF
--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -854,6 +854,58 @@ describe('reservations service', () => {
         expect(reCancelled.status).toBe('cancelled')
       })
 
+      it('member cancels pending reservation > 60 min away → succeeds', async () => {
+        const { updateReservationForSession } = await loadReservationModules()
+
+        // Set reservation to pending status
+        reservationsState[0]!.status = 'pending'
+
+        // Set current time to 2026-04-04 14:00:00 local time
+        vi.setSystemTime(new Date(2026, 3, 4, 14, 0, 0))
+
+        // Reservation starts at 16:00 (120 minutes from now)
+        // Difference = 120 * 60 * 1000 = 7200000 ms
+        // 7200000 < 3600000 = false, so allowed
+        const updated = await updateReservationForSession(memberSession, 'r1', { status: 'cancelled' })
+
+        expect(updated.status).toBe('cancelled')
+      })
+
+      it('member cancels pending reservation within 60 min → blocked with CANCELLATION_CUTOFF', async () => {
+        const { updateReservationForSession } = await loadReservationModules()
+
+        // Set reservation to pending status
+        reservationsState[0]!.status = 'pending'
+
+        // Set current time to 2026-04-04 15:30:00 local time (30 minutes before 16:00)
+        vi.setSystemTime(new Date(2026, 3, 4, 15, 30, 0))
+
+        // Reservation starts at 16:00
+        // Difference = 1800000 ms (30 min)
+        // 1800000 < 3600000 = true, so blocked with CANCELLATION_CUTOFF
+        await expect(updateReservationForSession(memberSession, 'r1', { status: 'cancelled' })).rejects.toMatchObject({
+          name: 'ServiceError',
+          statusCode: 403,
+          message: expect.stringContaining('CANCELLATION_CUTOFF'),
+        })
+      })
+
+      it('admin cancels pending reservation within 60 min → allowed (bypass)', async () => {
+        const { updateReservationForSession } = await loadReservationModules()
+
+        // Create a new reservation with pending status
+        const pendingAdminReservation = makeReservation({ id: 'r-pending-admin', user_id: '1', table_id: 't2', status: 'pending' })
+        reservationsState.push(pendingAdminReservation)
+
+        // Set current time to 2026-04-04 15:30:00 local time (30 min before 16:00)
+        vi.setSystemTime(new Date(2026, 3, 4, 15, 30, 0))
+
+        // Admin should be able to cancel even within 60 min
+        const updated = await updateReservationForSession(adminSession, 'r-pending-admin', { status: 'cancelled' })
+
+        expect(updated.status).toBe('cancelled')
+      })
+
     })
   })
 

--- a/components/reservations/my-reservations-view.tsx
+++ b/components/reservations/my-reservations-view.tsx
@@ -65,7 +65,7 @@ function ReservationCard({ reservation, onCancel }: ReservationCardProps) {
         </Badge>
       </div>
 
-      {reservation.status === 'active' && (
+      {(reservation.status === 'active' || reservation.status === 'pending') && (
         <Button
           variant="outline"
           size="sm"
@@ -86,8 +86,8 @@ export function MyReservationsView() {
   const cancelReservation = useCancelReservation()
   const [cancelingId, setCancelingId] = useState<string | null>(null)
 
-  const activeReservations = reservations?.filter(r => r.status === 'active') ?? []
-  const pastReservations = reservations?.filter(r => r.status !== 'active') ?? []
+  const activeReservations = reservations?.filter(r => r.status === 'active' || r.status === 'pending') ?? []
+  const pastReservations = reservations?.filter(r => r.status !== 'active' && r.status !== 'pending') ?? []
 
   async function handleCancel(id: string) {
     try {

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -5,7 +5,7 @@
 
 ---
 
-## Last updated: 2026-04-11
+## Last updated: 2026-04-12
 
 ## ⚠️ MVP TARGET: Monday 2026-04-14
 
@@ -15,9 +15,8 @@
 ## Open PRs — ready to merge (team-review clean, all comments resolved)
 | PR | Branch | Issues | Tests |
 |---|---|---|---|
-| [#79](https://github.com/KimoxStudio/alea-webapp/pull/79) | `feat/cancellation-cutoff` | KIM-331, KIM-340, KIM-342 | 266 ✅ |
-| [#80](https://github.com/KimoxStudio/alea-webapp/pull/80) | `chore/seed-data` | KIM-306 | SQL only ✅ |
-| [#81](https://github.com/KimoxStudio/alea-webapp/pull/81) | `feat/overlap-ui-feedback` | KIM-337 | 269 ✅ |
+| [#82](https://github.com/KimoxStudio/alea-webapp/pull/82) | `feat/cancellation-cutoff-ui` | KIM-341 | 279 ✅ — needs manual QA (3 checklist items in PR description) |
+| [#83](https://github.com/KimoxStudio/alea-webapp/pull/83) | `fix/pending-reservation-cancel` | KIM-362 | 279 ✅ ready to merge |
 
 ## Merged this session
 | PR | Branch | Issues |
@@ -25,6 +24,9 @@
 | ~~#76~~ | `feat/auto-cancel-grace-period` | KIM-327 ✅ Done |
 | ~~#77~~ | `feat/overlap-restriction` | KIM-330 ✅ Done · KIM-338 ✅ Done |
 | ~~#78~~ | `fix/auth-i18n-errors` | KIM-325 ✅ Done |
+| ~~#79~~ | `feat/cancellation-cutoff` | KIM-331 ✅ · KIM-340 ✅ · KIM-342 ✅ Done |
+| ~~#80~~ | `chore/seed-data` | KIM-306 ✅ Done |
+| ~~#81~~ | `feat/overlap-ui-feedback` | KIM-337 ✅ Done |
 
 ---
 
@@ -35,27 +37,23 @@
 - **KIM-330 + KIM-338** (M3) — overlap restriction — merged PR #77
 - **KIM-325** — auth i18n double-namespace — merged PR #78
 - **KIM-358** — toGameTable mapper — already in develop (no PR needed)
+- **KIM-331 + KIM-340 + KIM-342** (M5) — cancellation cutoff backend — merged PR #79
+- **KIM-306** — seed data — merged PR #80
+- **KIM-337** — overlap UI feedback — merged PR #81
 
 ### 🟡 Awaiting merge
-- **KIM-331 + KIM-340 + KIM-342** (M5) — cancellation cutoff backend + tests — PR #79 ✅ all comments resolved
-- **KIM-306** — seed data — PR #80 ✅ all comments resolved
-- **KIM-337** — overlap UI feedback — PR #81 ✅ clean
+- **KIM-341** — cancellation cutoff UI — PR #82 ✅ team-review clean · ⚠️ needs manual QA first
+  - Checklist: cancel > 60 min → succeeds, cancel < 60 min → inline error shown, dismiss dialog clears error
+- **KIM-362** — pending reservations cancellable — PR #83 ✅ ready to merge
 
-### 🔴 Next after PR #79 merges: KIM-341 — Cancellation Cutoff UI
-**Branch:** `feat/cancellation-cutoff-ui` from `develop` (after PR #79 merges)
-**Files:** `components/reservations/my-reservations-view.tsx`, `messages/en.json`, `messages/es.json`
-**Skill:** `frontend-design`
-**Add:** Detect `CANCELLATION_CUTOFF` 403 response; show inline warning with `reservations.errors.cancellationCutoff` message
-
-### 🟡 After PRs #79/#80/#81 merge
-Nothing else MVP-critical is blocked. Sunday work:
-- **KIM-341** — cutoff UI (needs M5/PR #79 merged)
-- Final smoke test across all flows
+### 🔴 After PRs merge: Final smoke test → Monday launch
 
 ---
 
 ## Post-MVP (do NOT start before launch)
 
+- **KIM-361** — Spanish translations with missing ñ (open Linear issue)
+- **KIM-317** — 24h time range for reservations (open Linear issue)
 - **KIM-329 epic** (no-show tracking) — KIM-329, 333, 334, 335, 336
 - **KIM-332 epic** (events / room blocking) — KIM-332, 343, 344, 345, 346, 347
 - **KIM-348 epic** (equipment management) — KIM-348–356
@@ -67,23 +65,21 @@ Nothing else MVP-critical is blocked. Sunday work:
 
 ---
 
-## Recommended execution order for MVP weekend
+## Recommended execution order for Monday launch
 
 ```
-Saturday (completed):
-  ✅ Merge #76 (KIM-327)
-  ✅ Merge #77 (KIM-330, KIM-338)
-  ✅ Merge #78 (KIM-325)
-  ✅ Open PR #79 (M5 — KIM-331+340+342) — all comments resolved
-  ✅ Open PR #80 (KIM-306 seed) — all comments resolved
-  ✅ Open PR #81 (KIM-337 overlap UI) — clean
+Sunday (completed):
+  ✅ Merge #79 (KIM-331+340+342)
+  ✅ Merge #80 (KIM-306)
+  ✅ Merge #81 (KIM-337)
+  ✅ Open PR #82 (KIM-341 cutoff UI) — team-review clean
+  ✅ Open PR #83 (KIM-362 pending cancel) — team-review clean
 
-Sunday:
-  → Merge #79, #80, #81
-  → feat/cancellation-cutoff-ui (KIM-341) — after M5 merged
-  → Final smoke tests
-
-Monday: Launch
+Monday:
+  → Manual QA on PR #82 (3 checklist items)
+  → Merge #82 + #83
+  → Final smoke tests across all flows
+  → Launch
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Shows the cancel button for reservations with `pending` status (was only shown for `active`)
- Moves `pending` reservations into the active section of the list (was incorrectly shown in the past/history section)
- Adds 3 service-level tests covering `pending → cancelled` cutoff guard scenarios

## Problem

When a reservation was created but not yet confirmed (`pending`), users had no way to cancel it from the UI even when the cancellation window was open. The cancel button was only rendered for `active` reservations, and the pending reservation appeared in the "past reservations" section.

## Changes

**`components/reservations/my-reservations-view.tsx`**
- Cancel button condition: `active || pending`
- `activeReservations` filter: `active || pending`
- `pastReservations` filter: `!active && !pending`

**`__tests__/server/reservations-service.test.ts`**
- Member cancels `pending` reservation > 60 min away → succeeds
- Member cancels `pending` reservation within 60 min → blocked with `CANCELLATION_CUTOFF`
- Admin cancels `pending` reservation within 60 min → allowed (role bypass)

## Test results

279 tests pass. TypeScript and build clean.

## Notes

The server-side cancellation cutoff guard already covers `pending` status — no service changes needed. This is a UI-only fix.

Closes KIM-362

🤖 Generated with [Claude Code](https://claude.com/claude-code)