### PR TITLE
fix(auth): add memberNumber format constraint and align admin validation (KIM-322, KIM-323)

### DIFF
--- a/__tests__/lib/validations/auth.test.ts
+++ b/__tests__/lib/validations/auth.test.ts
@@ -161,6 +161,27 @@ describe('Auth validation schemas - error keys (KIM-325)', () => {
         expect(result.error.issues.find(i => i.path[0] === 'password')?.message).toBe('errors.passwordMinLength')
       }
     })
+
+    it('rejects memberNumber of 11 digits', () => {
+      const result = registerSchema.safeParse({
+        memberNumber: '12345678901',
+        password: 'SecurePass123!',
+        confirmPassword: 'SecurePass123!'
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues.find(i => i.path[0] === 'memberNumber')?.message).toBe('errors.memberNumberTooLong')
+      }
+    })
+
+    it('accepts memberNumber of exactly 10 digits', () => {
+      const result = registerSchema.safeParse({
+        memberNumber: '1234567890',
+        password: 'SecurePass123!',
+        confirmPassword: 'SecurePass123!'
+      })
+      expect(result.success).toBe(true)
+    })
   })
 
   describe('registerServerSchema', () => {

--- a/__tests__/server/users-service.test.ts
+++ b/__tests__/server/users-service.test.ts
@@ -285,6 +285,30 @@ describe('updateUser', () => {
     })
   })
 
+  it('throws 400 when memberNumber is null (coerced to string "null")', async () => {
+    const { updateUser } = await loadUsersModules()
+
+    await expect(updateUser('u1', { memberNumber: null as unknown as string })).rejects.toMatchObject({
+      name: 'ServiceError',
+      statusCode: 400,
+    })
+  })
+
+  it('throws 400 when memberNumber is an empty string', async () => {
+    const { updateUser } = await loadUsersModules()
+
+    await expect(updateUser('u1', { memberNumber: '' })).rejects.toMatchObject({
+      name: 'ServiceError',
+      statusCode: 400,
+    })
+  })
+
+  it('accepts memberNumber of single digit zero', async () => {
+    const { updateUser } = await loadUsersModules()
+
+    await expect(updateUser('u1', { memberNumber: '0' })).resolves.toBeDefined()
+  })
+
   it('accepts is_active boolean and includes it in the update', async () => {
     let capturedUpdates: Record<string, unknown> | undefined
     vi.mocked(

--- a/__tests__/server/users-service.test.ts
+++ b/__tests__/server/users-service.test.ts
@@ -277,6 +277,14 @@ describe('updateUser', () => {
     await expect(updateUser('1', { memberNumber: '1'.repeat(10) })).resolves.toBeDefined()
   })
 
+  it('throws 400 when memberNumber contains non-numeric characters', async () => {
+    const { updateUser } = await loadUsersModules()
+
+    await expect(updateUser('1', { memberNumber: 'abc12' })).rejects.toMatchObject({
+      statusCode: 400,
+    })
+  })
+
   it('accepts is_active boolean and includes it in the update', async () => {
     let capturedUpdates: Record<string, unknown> | undefined
     vi.mocked(

--- a/__tests__/server/users-service.test.ts
+++ b/__tests__/server/users-service.test.ts
@@ -262,19 +262,19 @@ describe('updateUser', () => {
     })
   })
 
-  it('throws 400 when memberNumber exceeds 20 characters', async () => {
+  it('throws 400 when memberNumber exceeds 10 digits', async () => {
     const { updateUser } = await loadUsersModules()
 
-    await expect(updateUser('1', { memberNumber: 'A'.repeat(21) })).rejects.toMatchObject({
+    await expect(updateUser('1', { memberNumber: '1'.repeat(11) })).rejects.toMatchObject({
       name: 'ServiceError',
       statusCode: 400,
     })
   })
 
-  it('accepts memberNumber of exactly 20 characters', async () => {
+  it('accepts memberNumber of exactly 10 digits', async () => {
     const { updateUser } = await loadUsersModules()
 
-    await expect(updateUser('1', { memberNumber: 'A'.repeat(20) })).resolves.toBeDefined()
+    await expect(updateUser('1', { memberNumber: '1'.repeat(10) })).resolves.toBeDefined()
   })
 
   it('accepts is_active boolean and includes it in the update', async () => {

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -8,7 +8,7 @@ type ReservationRow = Tables<'reservations'>
 type TableRow = Tables<'tables'>
 type PostgrestErrorLike = { code?: string }
 type TablesLookupClient = {
-  select: () => {
+  select: (columns?: string) => {
     eq: (column: 'id', value: string) => {
       maybeSingle: () => Promise<{ data: TableRow | null; error: unknown }>
     }
@@ -143,7 +143,7 @@ async function getTable(tableId: string) {
   const supabase = await createSupabaseServerClient()
   const tables = supabase.from('tables') as unknown as TablesLookupClient
   const { data, error } = await tables
-    .select()
+    .select('id, type')
     .eq('id', tableId)
     .maybeSingle()
 

--- a/lib/server/users-service.ts
+++ b/lib/server/users-service.ts
@@ -1,5 +1,5 @@
 import type { PaginatedResponse, User } from '@/lib/types'
-import { createSupabaseServerAdminClient, createSupabaseServerClient } from '@/lib/supabase/server'
+import { createSupabaseServerAdminClient } from '@/lib/supabase/server'
 import { serviceError } from '@/lib/server/service-error'
 import type { Tables, TablesUpdate } from '@/lib/supabase/types'
 import { memberNumberSchema } from '@/lib/validations/auth'

--- a/lib/server/users-service.ts
+++ b/lib/server/users-service.ts
@@ -104,7 +104,7 @@ export async function listPaginatedUsers(input: {
 
 export async function updateUser(id: string, body: { memberNumber?: unknown; role?: unknown; is_active?: unknown }) {
   const updates: TablesUpdate<'profiles'> = {}
-  if (body.memberNumber) {
+  if (body.memberNumber !== undefined) {
     const parsed = memberNumberSchema.safeParse(String(body.memberNumber))
     if (!parsed.success) {
       serviceError('Invalid member number format', 400)

--- a/lib/server/users-service.ts
+++ b/lib/server/users-service.ts
@@ -2,6 +2,7 @@ import type { PaginatedResponse, User } from '@/lib/types'
 import { createSupabaseServerAdminClient, createSupabaseServerClient } from '@/lib/supabase/server'
 import { serviceError } from '@/lib/server/service-error'
 import type { Tables, TablesUpdate } from '@/lib/supabase/types'
+import { memberNumberSchema } from '@/lib/validations/auth'
 
 type ProfileRow = Tables<'profiles'>
 type PublicProfileRow = Pick<ProfileRow, 'id' | 'member_number' | 'email' | 'role' | 'is_active' | 'created_at' | 'updated_at'>
@@ -104,11 +105,11 @@ export async function listPaginatedUsers(input: {
 export async function updateUser(id: string, body: { memberNumber?: unknown; role?: unknown; is_active?: unknown }) {
   const updates: TablesUpdate<'profiles'> = {}
   if (body.memberNumber) {
-    const memberNumber = String(body.memberNumber)
-    if (memberNumber.length > 20) {
-      serviceError('memberNumber must be at most 20 characters', 400)
+    const parsed = memberNumberSchema.safeParse(String(body.memberNumber))
+    if (!parsed.success) {
+      serviceError('Invalid member number format', 400)
     }
-    updates.member_number = memberNumber
+    updates.member_number = parsed.data
   }
   if (body.role === 'admin' || body.role === 'member') updates.role = body.role
   if (typeof body.is_active === 'boolean') updates.is_active = body.is_active

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -18,7 +18,7 @@ export const loginSchema = z.object({
 const memberNumberSchema = z
   .string()
   .min(1, 'errors.memberNumberRequired')
-  .max(20, 'errors.memberNumberTooLong')
+  .max(10, 'errors.memberNumberTooLong')
   .regex(/^\d+$/, 'errors.memberNumberNumeric')
 
 export const registerSchema = z

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -15,7 +15,7 @@ export const loginSchema = z.object({
   password: z.string().min(1, 'errors.passwordRequired').max(1024, 'errors.passwordMaxLength'),
 })
 
-const memberNumberSchema = z
+export const memberNumberSchema = z
   .string()
   .min(1, 'errors.memberNumberRequired')
   .max(10, 'errors.memberNumberTooLong')

--- a/messages/en.json
+++ b/messages/en.json
@@ -50,7 +50,7 @@
       "passwordMaxLength": "Password must not exceed 1024 characters",
       "passwordsDoNotMatch": "Passwords do not match",
       "memberNumberRequired": "Member number is required",
-      "memberNumberTooLong": "Member number must not exceed 20 characters",
+      "memberNumberTooLong": "Member number must not exceed 10 digits",
       "memberNumberNumeric": "Member number must contain only digits",
       "memberNumberExists": "This member number is already registered"
     }

--- a/messages/es.json
+++ b/messages/es.json
@@ -50,7 +50,7 @@
       "passwordMaxLength": "La contraseña no puede superar los 1024 caracteres",
       "passwordsDoNotMatch": "Las contraseñas no coinciden",
       "memberNumberRequired": "El número de socio es obligatorio",
-      "memberNumberTooLong": "El número de socio no puede superar los 20 caracteres",
+      "memberNumberTooLong": "El número de socio no puede superar los 10 dígitos",
       "memberNumberNumeric": "El número de socio solo puede contener dígitos",
       "memberNumberExists": "Este número de socio ya está registrado"
     }


### PR DESCRIPTION
## Summary

- **KIM-322** — Tightens `memberNumber` validator in `registerSchema` from `.max(20)` to `.max(10)`. The existing `.regex(/^\d+$/)` already blocks non-numeric characters; the tighter max prevents oversized values from reaching the internal email interpolation `${memberNumber}@members.alea.internal`.
- **KIM-322 follow-up** — Exports `memberNumberSchema` so it can be reused across the codebase.
- **KIM-322/admin path** — Replaces the stale manual `> 20` guard in `updateUser` (`lib/server/users-service.ts`) with `memberNumberSchema.safeParse()`, closing the divergence between registration and admin update paths. Also fixes silent-ignore of falsy `memberNumber` values: guard is now `!== undefined` so empty string / null is explicitly validated and returns 400.
- **KIM-323** — Verified already implemented: orphaned Supabase Auth user cleanup is present in all error paths of `register()`.

## Changed files

| File | Change |
|------|--------|
| `lib/validations/auth.ts` | `.max(20)` → `.max(10)` on `memberNumber`; `export` added to schema |
| `lib/server/users-service.ts` | Manual `> 20` guard replaced with `memberNumberSchema.safeParse()`; guard changed to `!== undefined` |
| `lib/server/reservations-service.ts` | `TablesLookupClient.select` type accepts optional column string; `getTable` narrowed to `.select('id, type')` |
| `messages/en.json` + `messages/es.json` | `errors.memberNumberTooLong` updated to reflect new max-10 boundary |
| `__tests__/server/users-service.test.ts` | Boundary tests updated to 10-digit values; non-numeric rejection test added |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 280/280 passed
- [x] `pnpm build` — clean
- [x] Security review (2 cycles) — APPROVE
- [x] qa-engineer follow-up: stale boundary tests updated to max-10; non-numeric memberNumber rejection test added (`test(auth): add non-numeric memberNumber rejection test (KIM-322)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)