### PR TITLE
fix(layout): preserve current route when switching locale (KIM-360)

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { Suspense } from 'react'
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages } from 'next-intl/server'
 import { notFound } from 'next/navigation'
@@ -43,7 +44,9 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
           <Providers>
             <AuthProvider initialUser={initialUser}>
               <NavigationProgress />
-              <Header locale={locale} />
+              <Suspense fallback={null}>
+                <Header locale={locale} />
+              </Suspense>
               <main id="main-content" className="flex-1">
                 {children}
               </main>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { Sword, Menu, Globe, LogOut, LayoutDashboard } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -14,6 +15,9 @@ export function Header({ locale }: HeaderProps) {
   const { user, logout, isAuthenticated } = useAuth()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const otherLocale = locale === 'es' ? 'en' : 'es'
+  const pathname = usePathname()
+  const pathWithoutLocale = pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '')
+  const switchHref = `/${otherLocale}${pathWithoutLocale}`
 
   return (
     <header className="sticky top-0 z-40 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -45,7 +49,7 @@ export function Header({ locale }: HeaderProps) {
         </nav>
 
         <div className="flex items-center gap-2">
-          <Link href={`/${otherLocale}`} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label={`Switch to ${otherLocale}`}>
+          <Link href={switchHref} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label={`Switch to ${otherLocale}`}>
             <Globe className="h-3.5 w-3.5" aria-hidden="true" />
             <span className="uppercase font-medium">{otherLocale}</span>
           </Link>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { Sword, Menu, Globe, LogOut, LayoutDashboard } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -16,8 +16,10 @@ export function Header({ locale }: HeaderProps) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const otherLocale = locale === 'es' ? 'en' : 'es'
   const pathname = usePathname()
+  const searchParams = useSearchParams()
   const pathWithoutLocale = pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '')
-  const switchHref = `/${otherLocale}${pathWithoutLocale}`
+  const qs = searchParams.toString()
+  const switchHref = `/${otherLocale}${pathWithoutLocale}${qs ? `?${qs}` : ''}`
 
   return (
     <header className="sticky top-0 z-40 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">


### PR DESCRIPTION
## Summary

Fixes the locale switcher in `Header` redirecting to home (`/en`) instead of preserving the current route when changing language.

**Root cause:** the locale switcher `Link` used `/${otherLocale}` (hardcoded home) instead of replacing the locale segment in the current path.

**Fix:** reads the current pathname via `usePathname()`, strips the two-letter locale prefix with a regex lookahead, and builds the target href as `/${otherLocale}${pathWithoutLocale}`.

**Query string fix (caught in review):** `useSearchParams()` is used to preserve query parameters across locale switches. `Header` is wrapped in a `<Suspense>` boundary in the locale layout (required by Next.js App Router for static rendering compatibility).

## Changed files

| File | Change |
|------|--------|
| `components/layout/header.tsx` | Added `usePathname()` + `useSearchParams()` imports; path-preserving + query-preserving href computation |
| `app/[locale]/layout.tsx` | Wrapped `<Header>` in `<Suspense fallback={null}>` (required by `useSearchParams()`) |

## Acceptance criteria

- [x] `/es/rooms` → switch to EN → `/en/rooms`
- [x] `/es/reservations` → switch to EN → `/en/reservations`
- [x] Root locale `/es` → switch to EN → `/en`
- [x] EN → ES direction works correctly
- [x] Query parameters are preserved across locale switches

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 279/279 passed
- [x] `pnpm build` — clean
- [x] Security review — APPROVE (origin-relative href, no redirect risk)
- [x] QA review — APPROVE
- [x] Manual QA: navigate to `/es/rooms`, switch locale, verify landing on `/en/rooms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)