### PR TITLE
feat(M7): no-show tracking — cron job and service layer (KIM-329, KIM-333, KIM-334)

### DIFF
--- a/__tests__/app/api/cron/mark-no-show.test.ts
+++ b/__tests__/app/api/cron/mark-no-show.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const markNoShowReservationsMock = vi.fn()
+
+vi.mock('@/lib/server/reservations-service', () => ({
+  markNoShowReservations: markNoShowReservationsMock,
+}))
+
+function createRequest(path: string, method: 'GET' | 'POST' = 'GET', options?: { authorization?: string }) {
+  return new NextRequest(`http://localhost:3000${path}`, {
+    method,
+    headers: {
+      host: 'localhost:3000',
+      ...(options?.authorization ? { authorization: options.authorization } : {}),
+    },
+  })
+}
+
+describe('/api/cron/mark-no-show', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('POST method', () => {
+    it('returns 401 when Authorization header is missing', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST')
+      const response = await POST(request)
+
+      expect(response.status).toBe(401)
+      expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    })
+
+    it('returns 401 when Authorization header has wrong value', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer wrong-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(401)
+      expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    })
+
+    it('returns 200 with marked count when Authorization header is correct', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      markNoShowReservationsMock.mockResolvedValueOnce(3)
+
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer test-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ marked: 3 })
+      expect(markNoShowReservationsMock).toHaveBeenCalledOnce()
+    })
+
+    it('returns 401 when CRON_SECRET is not set', async () => {
+      // CRON_SECRET not stubbed - tests default behavior
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer any-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(401)
+    })
+
+    it('returns 500 when markNoShowReservations throws', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      markNoShowReservationsMock.mockRejectedValueOnce(new Error('Database error'))
+
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer test-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(500)
+      expect(await response.json()).toEqual({ error: 'Internal server error' })
+    })
+
+    it('returns 200 with zero count when no reservations need marking', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      markNoShowReservationsMock.mockResolvedValueOnce(0)
+
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer test-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ marked: 0 })
+    })
+  })
+})

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -1511,5 +1511,24 @@ describe('reservations service', () => {
         message: 'Internal server error',
       })
     })
+
+    it('returns 0 when rpc returns null data without error', async () => {
+      // The service uses `(data as number | null) ?? 0` — verify the null branch returns 0
+      const mockRpc = vi.fn(async () => ({ data: null, error: null }))
+
+      vi.resetModules()
+      const createAdminMock = vi.fn(() => ({
+        rpc: mockRpc,
+      }))
+      vi.doMock('@/lib/supabase/server', () => ({
+        createSupabaseServerAdminClient: createAdminMock,
+        createSupabaseServerClient: vi.fn(async () => ({ from: vi.fn() })),
+      }))
+
+      const { markNoShowReservations } = await import('@/lib/server/reservations-service')
+      const result = await markNoShowReservations()
+
+      expect(result).toBe(0)
+    })
   })
 })

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -1452,4 +1452,64 @@ describe('reservations service', () => {
       })
     })
   })
+
+  describe('markNoShowReservations', () => {
+    it('calls admin.rpc with mark_no_show_reservations and returns count', async () => {
+      const mockRpc = vi.fn(async () => ({ data: 2, error: null }))
+
+      vi.resetModules()
+      const createAdminMock = vi.fn(() => ({
+        rpc: mockRpc,
+      }))
+      vi.doMock('@/lib/supabase/server', () => ({
+        createSupabaseServerAdminClient: createAdminMock,
+        createSupabaseServerClient: vi.fn(async () => ({ from: vi.fn() })),
+      }))
+
+      const { markNoShowReservations } = await import('@/lib/server/reservations-service')
+      const result = await markNoShowReservations()
+
+      expect(mockRpc).toHaveBeenCalledWith('mark_no_show_reservations')
+      expect(result).toBe(2)
+    })
+
+    it('returns 0 when no reservations need marking', async () => {
+      const mockRpc = vi.fn(async () => ({ data: 0, error: null }))
+
+      vi.resetModules()
+      const createAdminMock = vi.fn(() => ({
+        rpc: mockRpc,
+      }))
+      vi.doMock('@/lib/supabase/server', () => ({
+        createSupabaseServerAdminClient: createAdminMock,
+        createSupabaseServerClient: vi.fn(async () => ({ from: vi.fn() })),
+      }))
+
+      const { markNoShowReservations } = await import('@/lib/server/reservations-service')
+      const result = await markNoShowReservations()
+
+      expect(result).toBe(0)
+    })
+
+    it('throws serviceError when rpc returns error', async () => {
+      const mockRpc = vi.fn(async () => ({ data: null, error: { message: 'DB error' } }))
+
+      vi.resetModules()
+      const createAdminMock = vi.fn(() => ({
+        rpc: mockRpc,
+      }))
+      vi.doMock('@/lib/supabase/server', () => ({
+        createSupabaseServerAdminClient: createAdminMock,
+        createSupabaseServerClient: vi.fn(async () => ({ from: vi.fn() })),
+      }))
+
+      const { markNoShowReservations } = await import('@/lib/server/reservations-service')
+
+      await expect(markNoShowReservations()).rejects.toMatchObject({
+        name: 'ServiceError',
+        statusCode: 500,
+        message: 'Internal server error',
+      })
+    })
+  })
 })

--- a/app/api/cron/mark-no-show/route.ts
+++ b/app/api/cron/mark-no-show/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { markNoShowReservations } from '@/lib/server/reservations-service'
+
+async function handleCronRequest(request: NextRequest) {
+  const auth = request.headers.get('Authorization')
+  if (!process.env.CRON_SECRET || auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  try {
+    const marked = await markNoShowReservations()
+    console.log(
+      JSON.stringify({
+        event: 'cron.mark_no_show_reservations',
+        timestamp: new Date().toISOString(),
+        marked,
+      }),
+    )
+    return NextResponse.json({ marked })
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        event: 'cron.mark_no_show_reservations.error',
+        timestamp: new Date().toISOString(),
+        error: err instanceof Error ? err.name : 'UnknownError',
+        ...(process.env.NODE_ENV !== 'production' && {
+          detail: err instanceof Error ? err.message : String(err),
+        }),
+      }),
+    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  return handleCronRequest(request)
+}

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -455,6 +455,13 @@ export async function cancelExpiredPendingReservations(): Promise<number> {
   return (data as number | null) ?? 0
 }
 
+export async function markNoShowReservations(): Promise<number> {
+  const admin = createSupabaseServerAdminClient()
+  const { data, error } = await admin.rpc('mark_no_show_reservations')
+  if (error) serviceError('Internal server error', 500)
+  return (data as number | null) ?? 0
+}
+
 type ActivationAdminQuery = {
   eq: (column: 'table_id' | 'date' | 'status' | 'user_id' | 'surface' | 'id', value: string) => ActivationAdminQuery
   or: (filter: string) => ActivationAdminQuery

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -186,6 +186,7 @@ export type Database = {
     Functions: {
       cancel_expired_pending_reservations: { Args: { grace_minutes?: number }; Returns: number }
       is_admin: { Args: never; Returns: boolean }
+      mark_no_show_reservations: { Args: Record<string, never>; Returns: number }
     }
     Enums: {
       reservation_status: "active" | "cancelled" | "completed" | "pending" | "no_show"

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -186,7 +186,7 @@ export type Database = {
     Functions: {
       cancel_expired_pending_reservations: { Args: { grace_minutes?: number }; Returns: number }
       is_admin: { Args: never; Returns: boolean }
-      mark_no_show_reservations: { Args: Record<string, never>; Returns: number }
+      mark_no_show_reservations: { Args: never; Returns: number }
     }
     Enums: {
       reservation_status: "active" | "cancelled" | "completed" | "pending" | "no_show"

--- a/supabase/migrations/20260412000000_fn_mark_no_show_reservations.sql
+++ b/supabase/migrations/20260412000000_fn_mark_no_show_reservations.sql
@@ -1,0 +1,34 @@
+-- Migration: add function to mark pending reservations as no_show after session end time
+--
+-- end_time is stored as TIME NOT NULL in 'HH:MM:SS' format (e.g. '22:00:00').
+-- Casting end_time::time gives a PostgreSQL TIME value which can be added to a DATE
+-- to produce a TIMESTAMP. Comparing with NOW() identifies reservations where the
+-- session has completely ended but the reservation was never activated.
+--
+-- This complements cancel_expired_pending_reservations (which marks no_show after
+-- start_time + grace_minutes). This function handles any residual pending
+-- reservations that remain after the full session end time has passed.
+
+CREATE OR REPLACE FUNCTION public.mark_no_show_reservations()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  updated_count integer;
+BEGIN
+  UPDATE public.reservations
+  SET status = 'no_show'
+  WHERE status = 'pending'
+    AND activated_at IS NULL
+    AND (date::date + end_time::time) < NOW();
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;
+
+-- Restrict execute permission: only service_role (used by the cron route handler) may call this function.
+REVOKE EXECUTE ON FUNCTION public.mark_no_show_reservations() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.mark_no_show_reservations() TO service_role;

--- a/supabase/migrations/20260412000000_fn_mark_no_show_reservations.sql
+++ b/supabase/migrations/20260412000000_fn_mark_no_show_reservations.sql
@@ -32,3 +32,9 @@ $$;
 -- Restrict execute permission: only service_role (used by the cron route handler) may call this function.
 REVOKE EXECUTE ON FUNCTION public.mark_no_show_reservations() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.mark_no_show_reservations() TO service_role;
+
+-- Partial index to speed up the WHERE clause used by the cron UPDATE.
+-- Only indexes rows that are still pending and not yet activated, keeping the index small and write-cheap.
+CREATE INDEX IF NOT EXISTS reservations_pending_no_show_idx
+  ON public.reservations (date, end_time)
+  WHERE status = 'pending' AND activated_at IS NULL;


### PR DESCRIPTION
## Summary

- Adds `mark_no_show_reservations()` PostgreSQL function (migration `20260412000000`) that marks `pending` reservations as `no_show` when their `end_time` has passed
- Adds `markNoShowReservations()` service function in `lib/server/reservations-service.ts` calling the RPC via the admin client
- Adds `POST /api/cron/mark-no-show` route handler following the same pattern as `/api/cron/cancel-pending` (CRON_SECRET auth, structured audit logging)
- Updates `lib/supabase/types.ts` to register the new RPC under `public.Functions`

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes (route `/api/cron/mark-no-show` appears in build output)
- [ ] `pnpm test` — 331 tests pass (no regressions)
- [ ] `POST /api/cron/mark-no-show` with correct `Authorization: Bearer <CRON_SECRET>` returns `{ marked: N }`
- [ ] `POST /api/cron/mark-no-show` without / with wrong token returns `401`
- [ ] qa-engineer to add unit tests for route handler and `markNoShowReservations()` (test files not created by backend-developer per test ownership rules)

Closes KIM-329, KIM-333, KIM-334

🤖 Generated with [Claude Code](https://claude.com/claude-code)