### PR TITLE
feat(M7A): no-show admin controls — view, reset, and unblock (KIM-335)

### DIFF
--- a/__tests__/app/api/cron/mark-no-show.test.ts
+++ b/__tests__/app/api/cron/mark-no-show.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const markNoShowReservationsMock = vi.fn()
+
+vi.mock('@/lib/server/reservations-service', () => ({
+  markNoShowReservations: markNoShowReservationsMock,
+}))
+
+function createRequest(path: string, method: 'GET' | 'POST' = 'GET', options?: { authorization?: string }) {
+  return new NextRequest(`http://localhost:3000${path}`, {
+    method,
+    headers: {
+      host: 'localhost:3000',
+      ...(options?.authorization ? { authorization: options.authorization } : {}),
+    },
+  })
+}
+
+describe('/api/cron/mark-no-show', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('POST method', () => {
+    it('returns 401 when Authorization header is missing', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST')
+      const response = await POST(request)
+
+      expect(response.status).toBe(401)
+      expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    })
+
+    it('returns 401 when Authorization header has wrong value', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer wrong-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(401)
+      expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    })
+
+    it('returns 200 with marked count when Authorization header is correct', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      markNoShowReservationsMock.mockResolvedValueOnce(3)
+
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer test-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ marked: 3 })
+      expect(markNoShowReservationsMock).toHaveBeenCalledOnce()
+    })
+
+    it('returns 401 when CRON_SECRET is not set', async () => {
+      // CRON_SECRET not stubbed - tests default behavior
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer any-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(401)
+    })
+
+    it('returns 500 when markNoShowReservations throws', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      markNoShowReservationsMock.mockRejectedValueOnce(new Error('Database error'))
+
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer test-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(500)
+      expect(await response.json()).toEqual({ error: 'Internal server error' })
+    })
+
+    it('returns 200 with zero count when no reservations need marking', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      markNoShowReservationsMock.mockResolvedValueOnce(0)
+
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer test-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ marked: 0 })
+    })
+  })
+})

--- a/__tests__/app/api/users/patch-route.test.ts
+++ b/__tests__/app/api/users/patch-route.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+import { ServiceError } from '@/lib/server/service-error'
+
+let requestCounter = 0
+
+const requireAdminMock = vi.fn()
+const resetNoShowsMock = vi.fn()
+const unblockUserMock = vi.fn()
+const enforceMutationSecurityMock = vi.fn()
+const enforceRateLimitMock = vi.fn()
+
+vi.mock('@/lib/server/auth', () => ({
+  requireAdmin: requireAdminMock,
+}))
+
+vi.mock('@/lib/server/users-service', () => ({
+  resetNoShows: resetNoShowsMock,
+  unblockUser: unblockUserMock,
+}))
+
+vi.mock('@/lib/server/security', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/server/security')>()
+  return {
+    ...actual,
+    enforceMutationSecurity: enforceMutationSecurityMock,
+    enforceRateLimit: enforceRateLimitMock,
+    RATE_LIMIT_POLICIES: {
+      adminMutation: { bucket: 'admin-mutation', limit: 50, windowMs: 60_000 },
+    },
+  }
+})
+
+function makeAdminContext(userId = 'admin-1', role: 'member' | 'admin' = 'admin') {
+  return {
+    session: { id: userId, role },
+    applyCookies: (res: NextResponse) => res,
+  }
+}
+
+function createPatchRequest(userId: string, action?: string | null) {
+  const url = new URL(`http://localhost:3000/api/users/${userId}`)
+  const clientIp = `10.0.0.${requestCounter + 1}`
+  requestCounter += 1
+
+  return new NextRequest(url.toString(), {
+    method: 'PATCH',
+    headers: {
+      host: 'localhost:3000',
+      origin: 'http://localhost:3000',
+      'x-forwarded-for': clientIp,
+      'x-real-ip': '127.0.0.1',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ action }),
+  })
+}
+
+describe('PATCH /api/users/[id]', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    const { resetRateLimitStoreForTests } = await import('@/lib/server/security')
+    resetRateLimitStoreForTests()
+    vi.stubEnv('TRUST_PROXY_HEADERS', 'true')
+    vi.stubEnv('TRUSTED_PROXY_CIDRS', '127.0.0.1/32')
+    requestCounter = 0
+    // Security and auth pass by default
+    enforceMutationSecurityMock.mockReturnValue(null)
+    enforceRateLimitMock.mockReturnValue(null)
+    requireAdminMock.mockResolvedValue(makeAdminContext())
+    resetNoShowsMock.mockResolvedValue(undefined)
+    unblockUserMock.mockResolvedValue(undefined)
+  })
+
+  it('returns 200 and calls resetNoShows when action is reset_no_shows', async () => {
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+    const response = await PATCH(createPatchRequest('user-123', 'reset_no_shows'), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toEqual({ ok: true })
+    expect(resetNoShowsMock).toHaveBeenCalledWith('user-123')
+    expect(unblockUserMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 and calls unblockUser when action is unblock', async () => {
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+    const response = await PATCH(createPatchRequest('user-456', 'unblock'), {
+      params: Promise.resolve({ id: 'user-456' }),
+    })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toEqual({ ok: true })
+    expect(unblockUserMock).toHaveBeenCalledWith('user-456')
+    expect(resetNoShowsMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for invalid action value', async () => {
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+    const response = await PATCH(createPatchRequest('user-123', 'invalid_action'), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.message).toBe('Invalid action')
+    expect(resetNoShowsMock).not.toHaveBeenCalled()
+    expect(unblockUserMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when action is missing or null', async () => {
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+    const response = await PATCH(createPatchRequest('user-123', null as unknown as string), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.message).toBe('Invalid action')
+  })
+
+  it('returns 403 when caller is not admin', async () => {
+    requireAdminMock.mockResolvedValue(
+      NextResponse.json({ message: 'Forbidden', statusCode: 403 }, { status: 403 })
+    )
+
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+    const response = await PATCH(createPatchRequest('user-123', 'reset_no_shows'), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(403)
+    expect(resetNoShowsMock).not.toHaveBeenCalled()
+    expect(unblockUserMock).not.toHaveBeenCalled()
+  })
+
+  it('returns security error and skips auth when enforceMutationSecurity fails', async () => {
+    enforceMutationSecurityMock.mockReturnValue(
+      NextResponse.json({ message: 'Forbidden' }, { status: 403 })
+    )
+
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+    const response = await PATCH(createPatchRequest('user-123', 'reset_no_shows'), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(403)
+    expect(requireAdminMock).not.toHaveBeenCalled()
+    expect(resetNoShowsMock).not.toHaveBeenCalled()
+  })
+
+  it('returns rate limit error and skips auth when rate limit is exceeded', async () => {
+    enforceRateLimitMock.mockReturnValue(
+      NextResponse.json({ message: 'Too Many Requests' }, { status: 429 })
+    )
+
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+    const response = await PATCH(createPatchRequest('user-123', 'reset_no_shows'), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(429)
+    expect(requireAdminMock).not.toHaveBeenCalled()
+    expect(resetNoShowsMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when resetNoShows throws a service error', async () => {
+    resetNoShowsMock.mockRejectedValue(new ServiceError('Internal server error', 500))
+
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+    const response = await PATCH(createPatchRequest('user-123', 'reset_no_shows'), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(500)
+  })
+
+  it('returns 500 when unblockUser throws a service error', async () => {
+    unblockUserMock.mockRejectedValue(new ServiceError('Internal server error', 500))
+
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+    const response = await PATCH(createPatchRequest('user-123', 'unblock'), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(500)
+  })
+
+  it('returns 401 when session is missing', async () => {
+    requireAdminMock.mockResolvedValue(
+      NextResponse.json({ message: 'Unauthorized', statusCode: 401 }, { status: 401 })
+    )
+
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+    const response = await PATCH(createPatchRequest('user-123', 'reset_no_shows'), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(401)
+    expect(resetNoShowsMock).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -1511,5 +1511,24 @@ describe('reservations service', () => {
         message: 'Internal server error',
       })
     })
+
+    it('returns 0 when rpc returns null data without error', async () => {
+      // The service uses `(data as number | null) ?? 0` — verify the null branch returns 0
+      const mockRpc = vi.fn(async () => ({ data: null, error: null }))
+
+      vi.resetModules()
+      const createAdminMock = vi.fn(() => ({
+        rpc: mockRpc,
+      }))
+      vi.doMock('@/lib/supabase/server', () => ({
+        createSupabaseServerAdminClient: createAdminMock,
+        createSupabaseServerClient: vi.fn(async () => ({ from: vi.fn() })),
+      }))
+
+      const { markNoShowReservations } = await import('@/lib/server/reservations-service')
+      const result = await markNoShowReservations()
+
+      expect(result).toBe(0)
+    })
   })
 })

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -1452,4 +1452,64 @@ describe('reservations service', () => {
       })
     })
   })
+
+  describe('markNoShowReservations', () => {
+    it('calls admin.rpc with mark_no_show_reservations and returns count', async () => {
+      const mockRpc = vi.fn(async () => ({ data: 2, error: null }))
+
+      vi.resetModules()
+      const createAdminMock = vi.fn(() => ({
+        rpc: mockRpc,
+      }))
+      vi.doMock('@/lib/supabase/server', () => ({
+        createSupabaseServerAdminClient: createAdminMock,
+        createSupabaseServerClient: vi.fn(async () => ({ from: vi.fn() })),
+      }))
+
+      const { markNoShowReservations } = await import('@/lib/server/reservations-service')
+      const result = await markNoShowReservations()
+
+      expect(mockRpc).toHaveBeenCalledWith('mark_no_show_reservations')
+      expect(result).toBe(2)
+    })
+
+    it('returns 0 when no reservations need marking', async () => {
+      const mockRpc = vi.fn(async () => ({ data: 0, error: null }))
+
+      vi.resetModules()
+      const createAdminMock = vi.fn(() => ({
+        rpc: mockRpc,
+      }))
+      vi.doMock('@/lib/supabase/server', () => ({
+        createSupabaseServerAdminClient: createAdminMock,
+        createSupabaseServerClient: vi.fn(async () => ({ from: vi.fn() })),
+      }))
+
+      const { markNoShowReservations } = await import('@/lib/server/reservations-service')
+      const result = await markNoShowReservations()
+
+      expect(result).toBe(0)
+    })
+
+    it('throws serviceError when rpc returns error', async () => {
+      const mockRpc = vi.fn(async () => ({ data: null, error: { message: 'DB error' } }))
+
+      vi.resetModules()
+      const createAdminMock = vi.fn(() => ({
+        rpc: mockRpc,
+      }))
+      vi.doMock('@/lib/supabase/server', () => ({
+        createSupabaseServerAdminClient: createAdminMock,
+        createSupabaseServerClient: vi.fn(async () => ({ from: vi.fn() })),
+      }))
+
+      const { markNoShowReservations } = await import('@/lib/server/reservations-service')
+
+      await expect(markNoShowReservations()).rejects.toMatchObject({
+        name: 'ServiceError',
+        statusCode: 500,
+        message: 'Internal server error',
+      })
+    })
+  })
 })

--- a/__tests__/server/users-service.test.ts
+++ b/__tests__/server/users-service.test.ts
@@ -363,3 +363,125 @@ describe('deleteUser', () => {
     expect(deleteUserMock).toHaveBeenCalledWith('1')
   })
 })
+
+describe('resetNoShows', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    resetQueryMocks()
+  })
+
+  it('sets no_show_count=0 and blocked_until=null for the user', async () => {
+    let capturedUpdates: Record<string, unknown> | undefined
+    vi.mocked(
+      (await import('@/lib/supabase/server')).createSupabaseServerAdminClient
+    ).mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: maybeSingleMock,
+          })),
+          maybeSingle: maybeSingleMock,
+        })),
+        update: vi.fn((updates: Record<string, unknown>) => {
+          capturedUpdates = updates
+          return {
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }
+        }),
+      })),
+      auth: { admin: { deleteUser: deleteUserMock } },
+    } as never)
+    const { resetNoShows } = await loadUsersModules()
+
+    await resetNoShows('user-123')
+
+    expect(capturedUpdates).toEqual({ no_show_count: 0, blocked_until: null })
+  })
+
+  it('throws a service error when update fails', async () => {
+    vi.mocked(
+      (await import('@/lib/supabase/server')).createSupabaseServerAdminClient
+    ).mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: maybeSingleMock,
+          })),
+          maybeSingle: maybeSingleMock,
+        })),
+        update: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: new Error('DB error') }),
+        })),
+      })),
+      auth: { admin: { deleteUser: deleteUserMock } },
+    } as never)
+    const { resetNoShows } = await loadUsersModules()
+
+    await expect(resetNoShows('user-123')).rejects.toMatchObject({
+      name: 'ServiceError',
+      statusCode: 500,
+    })
+  })
+})
+
+describe('unblockUser', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    resetQueryMocks()
+  })
+
+  it('sets blocked_until=null for the user', async () => {
+    let capturedUpdates: Record<string, unknown> | undefined
+    vi.mocked(
+      (await import('@/lib/supabase/server')).createSupabaseServerAdminClient
+    ).mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: maybeSingleMock,
+          })),
+          maybeSingle: maybeSingleMock,
+        })),
+        update: vi.fn((updates: Record<string, unknown>) => {
+          capturedUpdates = updates
+          return {
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }
+        }),
+      })),
+      auth: { admin: { deleteUser: deleteUserMock } },
+    } as never)
+    const { unblockUser } = await loadUsersModules()
+
+    await unblockUser('user-456')
+
+    expect(capturedUpdates).toEqual({ blocked_until: null })
+  })
+
+  it('throws a service error when update fails', async () => {
+    vi.mocked(
+      (await import('@/lib/supabase/server')).createSupabaseServerAdminClient
+    ).mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: maybeSingleMock,
+          })),
+          maybeSingle: maybeSingleMock,
+        })),
+        update: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: new Error('DB error') }),
+        })),
+      })),
+      auth: { admin: { deleteUser: deleteUserMock } },
+    } as never)
+    const { unblockUser } = await loadUsersModules()
+
+    await expect(unblockUser('user-456')).rejects.toMatchObject({
+      name: 'ServiceError',
+      statusCode: 500,
+    })
+  })
+})

--- a/app/api/cron/mark-no-show/route.ts
+++ b/app/api/cron/mark-no-show/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { markNoShowReservations } from '@/lib/server/reservations-service'
+
+async function handleCronRequest(request: NextRequest) {
+  const auth = request.headers.get('Authorization')
+  if (!process.env.CRON_SECRET || auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  try {
+    const marked = await markNoShowReservations()
+    console.log(
+      JSON.stringify({
+        event: 'cron.mark_no_show_reservations',
+        timestamp: new Date().toISOString(),
+        marked,
+      }),
+    )
+    return NextResponse.json({ marked })
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        event: 'cron.mark_no_show_reservations.error',
+        timestamp: new Date().toISOString(),
+        error: err instanceof Error ? err.name : 'UnknownError',
+        ...(process.env.NODE_ENV !== 'production' && {
+          detail: err instanceof Error ? err.message : String(err),
+        }),
+      }),
+    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  return handleCronRequest(request)
+}

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/server/auth'
 import { toServiceErrorResponse } from '@/lib/server/http-error'
-import { deleteUser, updateUser } from '@/lib/server/users-service'
+import { deleteUser, resetNoShows, unblockUser, updateUser } from '@/lib/server/users-service'
 import { enforceMutationSecurity, enforceRateLimit, RATE_LIMIT_POLICIES } from '@/lib/server/security'
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -17,6 +17,38 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   try {
     const [{ id }, body] = await Promise.all([params, request.json()])
     return admin.applyCookies(NextResponse.json(await updateUser(id, body)))
+  } catch (error) {
+    return admin.applyCookies(toServiceErrorResponse(error))
+  }
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const securityError = enforceMutationSecurity(request)
+  if (securityError) return securityError
+
+  const rateLimitError = enforceRateLimit(request, RATE_LIMIT_POLICIES.adminMutation)
+  if (rateLimitError) return rateLimitError
+
+  const admin = await requireAdmin(request)
+  if (admin instanceof NextResponse) return admin
+
+  try {
+    const [{ id }, body] = await Promise.all([params, request.json()])
+    const { action } = body as { action?: string }
+
+    if (action === 'reset_no_shows') {
+      await resetNoShows(id)
+      return admin.applyCookies(NextResponse.json({ ok: true }))
+    }
+
+    if (action === 'unblock') {
+      await unblockUser(id)
+      return admin.applyCookies(NextResponse.json({ ok: true }))
+    }
+
+    return admin.applyCookies(
+      NextResponse.json({ message: 'Invalid action', statusCode: 400 }, { status: 400 })
+    )
   } catch (error) {
     return admin.applyCookies(toServiceErrorResponse(error))
   }

--- a/components/admin/users-section.tsx
+++ b/components/admin/users-section.tsx
@@ -18,7 +18,7 @@ import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { useAdminUsers, useAdminUpdateUser, useAdminDeleteUser } from '@/lib/hooks/use-admin'
+import { useAdminUsers, useAdminUpdateUser, useAdminDeleteUser, useAdminPatchUser } from '@/lib/hooks/use-admin'
 import type { User } from '@/lib/types'
 
 type UserRole = 'member' | 'admin'
@@ -60,6 +60,7 @@ export function UsersSection() {
   const { data, isLoading, isError } = useAdminUsers(page, 10, search)
   const updateMutation = useAdminUpdateUser()
   const deleteMutation = useAdminDeleteUser()
+  const patchMutation = useAdminPatchUser()
 
   function openEdit(user: User) {
     setEditState({
@@ -142,6 +143,8 @@ export function UsersSection() {
                   <th className="px-4 py-3 text-left font-medium text-muted-foreground">{tc('email')}</th>
                   <th className="px-4 py-3 text-left font-medium text-muted-foreground">{t('role')}</th>
                   <th className="px-4 py-3 text-left font-medium text-muted-foreground">{t('status')}</th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">{t('noShowCount')}</th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">{t('blockedUntil')}</th>
                   <th className="px-4 py-3 text-left font-medium text-muted-foreground">{t('joinDate')}</th>
                   <th className="px-4 py-3 text-right font-medium text-muted-foreground">{tc('actions')}</th>
                 </tr>
@@ -159,11 +162,55 @@ export function UsersSection() {
                     <td className="px-4 py-3">
                       <StatusBadge isActive={user.isActive} />
                     </td>
+                    <td className="px-4 py-3 text-center">
+                      {user.noShowCount > 0 ? (
+                        <Badge className="border-red-500/40 bg-red-900/20 text-red-400">
+                          {user.noShowCount}
+                        </Badge>
+                      ) : (
+                        <span className="text-muted-foreground">0</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground text-xs">
+                      {user.blockedUntil
+                        ? new Date(user.blockedUntil).toLocaleDateString()
+                        : '—'}
+                    </td>
                     <td className="px-4 py-3 text-muted-foreground">
                       {new Date(user.createdAt).toLocaleDateString()}
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex items-center justify-end gap-1">
+                        {user.noShowCount > 0 && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-xs text-amber-400 hover:bg-amber-900/20 hover:text-amber-300"
+                            disabled={patchMutation.isPending}
+                            onClick={() => patchMutation.mutate({ id: user.id, action: 'reset_no_shows' })}
+                            aria-label={t('resetNoShows')}
+                          >
+                            {patchMutation.isPending && patchMutation.variables?.id === user.id && patchMutation.variables?.action === 'reset_no_shows' ? (
+                              <DiceLoader size="sm" className="mr-1" hideRole />
+                            ) : null}
+                            {t('resetNoShows')}
+                          </Button>
+                        )}
+                        {user.blockedUntil && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-xs text-emerald-400 hover:bg-emerald-900/20 hover:text-emerald-300"
+                            disabled={patchMutation.isPending}
+                            onClick={() => patchMutation.mutate({ id: user.id, action: 'unblock' })}
+                            aria-label={t('unblockUser')}
+                          >
+                            {patchMutation.isPending && patchMutation.variables?.id === user.id && patchMutation.variables?.action === 'unblock' ? (
+                              <DiceLoader size="sm" className="mr-1" hideRole />
+                            ) : null}
+                            {t('unblockUser')}
+                          </Button>
+                        )}
                         <Button
                           variant="ghost"
                           size="icon"

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -46,6 +46,9 @@ class ApiClient {
   put<T>(path: string, body?: unknown, options?: RequestInit) {
     return this.request<T>(path, { method: 'PUT', body: body ? JSON.stringify(body) : undefined, ...options })
   }
+  patch<T>(path: string, body?: unknown, options?: RequestInit) {
+    return this.request<T>(path, { method: 'PATCH', body: body ? JSON.stringify(body) : undefined, ...options })
+  }
   delete<T>(path: string, options?: RequestInit) { return this.request<T>(path, { method: 'DELETE', ...options }) }
 }
 

--- a/lib/hooks/use-admin.ts
+++ b/lib/hooks/use-admin.ts
@@ -38,6 +38,17 @@ export function useAdminDeleteUser() {
   })
 }
 
+export function useAdminPatchUser() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, action }: { id: string; action: 'reset_no_shows' | 'unblock' }) =>
+      apiClient.patch<void>(endpoints.users.byId(id), { action }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'users'] })
+    },
+  })
+}
+
 // ----- Reservations -----
 
 export function useAdminReservations(userId?: string | null, date?: string | null) {

--- a/lib/server/auth-service.ts
+++ b/lib/server/auth-service.ts
@@ -6,13 +6,13 @@ import type { Tables } from '@/lib/supabase/types'
 import { registerServerSchema } from '@/lib/validations/auth'
 
 type ProfileRow = Tables<'profiles'>
-type PublicProfileRow = Pick<ProfileRow, 'id' | 'member_number' | 'role' | 'is_active' | 'created_at' | 'updated_at'>
-type AuthCredentialRow = Pick<ProfileRow, 'id' | 'member_number' | 'email' | 'role' | 'is_active' | 'created_at' | 'updated_at'>
-const PUBLIC_PROFILE_COLUMNS = 'id, member_number, role, is_active, created_at, updated_at' as const
+type PublicProfileRow = Pick<ProfileRow, 'id' | 'member_number' | 'role' | 'is_active' | 'no_show_count' | 'blocked_until' | 'created_at' | 'updated_at'>
+type AuthCredentialRow = Pick<ProfileRow, 'id' | 'member_number' | 'email' | 'role' | 'is_active' | 'no_show_count' | 'blocked_until' | 'created_at' | 'updated_at'>
+const PUBLIC_PROFILE_COLUMNS = 'id, member_number, role, is_active, no_show_count, blocked_until, created_at, updated_at' as const
 
 // Auth-only columns: email is needed solely to resolve Supabase Auth credentials.
 // It is not part of the public user model (issue #39) but IS included for admin-facing user data.
-const AUTH_CREDENTIAL_COLUMNS = 'id, member_number, email, role, is_active, created_at, updated_at' as const
+const AUTH_CREDENTIAL_COLUMNS = 'id, member_number, email, role, is_active, no_show_count, blocked_until, created_at, updated_at' as const
 
 type PublicProfileLookupColumn = 'id' | 'member_number'
 type AuthCredentialLookupColumn = 'id' | 'member_number' | 'email'
@@ -101,6 +101,8 @@ function toPublicUser(profile: PublicProfileRow): User {
     memberNumber: profile.member_number,
     role: profile.role,
     isActive: profile.is_active,
+    noShowCount: profile.no_show_count,
+    blockedUntil: profile.blocked_until ?? null,
     createdAt: profile.created_at,
     updatedAt: profile.updated_at,
   }

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -455,6 +455,13 @@ export async function cancelExpiredPendingReservations(): Promise<number> {
   return (data as number | null) ?? 0
 }
 
+export async function markNoShowReservations(): Promise<number> {
+  const admin = createSupabaseServerAdminClient()
+  const { data, error } = await admin.rpc('mark_no_show_reservations')
+  if (error) serviceError('Internal server error', 500)
+  return (data as number | null) ?? 0
+}
+
 type ActivationAdminQuery = {
   eq: (column: 'table_id' | 'date' | 'status' | 'user_id' | 'surface' | 'id', value: string) => ActivationAdminQuery
   or: (filter: string) => ActivationAdminQuery

--- a/lib/server/users-service.ts
+++ b/lib/server/users-service.ts
@@ -5,7 +5,7 @@ import type { Tables, TablesUpdate } from '@/lib/supabase/types'
 import { memberNumberSchema } from '@/lib/validations/auth'
 
 type ProfileRow = Tables<'profiles'>
-type PublicProfileRow = Pick<ProfileRow, 'id' | 'member_number' | 'email' | 'role' | 'is_active' | 'created_at' | 'updated_at'>
+type PublicProfileRow = Pick<ProfileRow, 'id' | 'member_number' | 'email' | 'role' | 'is_active' | 'no_show_count' | 'blocked_until' | 'created_at' | 'updated_at'>
 type ProfilesQuery = {
   eq: (column: string, value: unknown) => ProfilesQuery
   or: (filter: string) => ProfilesQuery
@@ -35,7 +35,7 @@ type AdminProfilesTableClient = {
   }
 }
 
-const PROFILE_COLUMNS = 'id, member_number, email, role, is_active, created_at, updated_at'
+const PROFILE_COLUMNS = 'id, member_number, email, role, is_active, no_show_count, blocked_until, created_at, updated_at'
 
 function toPublicUser(profile: PublicProfileRow): User {
   return {
@@ -44,6 +44,8 @@ function toPublicUser(profile: PublicProfileRow): User {
     email: profile.email ?? null,
     role: profile.role,
     isActive: profile.is_active,
+    noShowCount: profile.no_show_count,
+    blockedUntil: profile.blocked_until ?? null,
     createdAt: profile.created_at,
     updatedAt: profile.updated_at,
   }
@@ -134,6 +136,24 @@ export async function updateUser(id: string, body: { memberNumber?: unknown; rol
   }
 
   return toPublicUser(data as PublicProfileRow)
+}
+
+export async function resetNoShows(id: string) {
+  const supabase = createSupabaseServerAdminClient()
+  const { error } = await supabase
+    .from('profiles')
+    .update({ no_show_count: 0, blocked_until: null })
+    .eq('id', id)
+  if (error) serviceError('Internal server error', 500)
+}
+
+export async function unblockUser(id: string) {
+  const supabase = createSupabaseServerAdminClient()
+  const { error } = await supabase
+    .from('profiles')
+    .update({ blocked_until: null })
+    .eq('id', id)
+  if (error) serviceError('Internal server error', 500)
 }
 
 export async function deleteUser(id: string) {

--- a/lib/server/users-service.ts
+++ b/lib/server/users-service.ts
@@ -139,8 +139,16 @@ export async function updateUser(id: string, body: { memberNumber?: unknown; rol
 }
 
 export async function resetNoShows(id: string) {
-  const supabase = createSupabaseServerAdminClient()
-  const { error } = await supabase
+  const admin = createSupabaseServerAdminClient()
+  const profiles = admin.from('profiles') as unknown as AdminProfilesTableClient
+  const { data: existing, error: selectError } = await profiles
+    .select('id')
+    .eq('id', id)
+    .maybeSingle()
+  if (selectError) serviceError('Internal server error', 500)
+  if (!existing) serviceError('User not found', 404)
+
+  const { error } = await admin
     .from('profiles')
     .update({ no_show_count: 0, blocked_until: null })
     .eq('id', id)
@@ -148,8 +156,16 @@ export async function resetNoShows(id: string) {
 }
 
 export async function unblockUser(id: string) {
-  const supabase = createSupabaseServerAdminClient()
-  const { error } = await supabase
+  const admin = createSupabaseServerAdminClient()
+  const profiles = admin.from('profiles') as unknown as AdminProfilesTableClient
+  const { data: existing, error: selectError } = await profiles
+    .select('id')
+    .eq('id', id)
+    .maybeSingle()
+  if (selectError) serviceError('Internal server error', 500)
+  if (!existing) serviceError('User not found', 404)
+
+  const { error } = await admin
     .from('profiles')
     .update({ blocked_until: null })
     .eq('id', id)

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -186,6 +186,7 @@ export type Database = {
     Functions: {
       cancel_expired_pending_reservations: { Args: { grace_minutes?: number }; Returns: number }
       is_admin: { Args: never; Returns: boolean }
+      mark_no_show_reservations: { Args: Record<string, never>; Returns: number }
     }
     Enums: {
       reservation_status: "active" | "cancelled" | "completed" | "pending" | "no_show"

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -36,29 +36,35 @@ export type Database = {
     Tables: {
       profiles: {
         Row: {
+          blocked_until: string | null
           created_at: string
           email: string | null
           id: string
           is_active: boolean
           member_number: string
+          no_show_count: number
           role: Database["public"]["Enums"]["role"]
           updated_at: string
         }
         Insert: {
+          blocked_until?: string | null
           created_at?: string
           email?: string | null
           id: string
           is_active?: boolean
           member_number: string
+          no_show_count?: number
           role?: Database["public"]["Enums"]["role"]
           updated_at?: string
         }
         Update: {
+          blocked_until?: string | null
           created_at?: string
           email?: string | null
           id?: string
           is_active?: boolean
           member_number?: string
+          no_show_count?: number
           role?: Database["public"]["Enums"]["role"]
           updated_at?: string
         }

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -398,8 +398,8 @@ export type CompositeTypes<
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
 
-export type EventRow = Database['public']['Tables']['events']['Row'];
-export type EventRoomBlockRow = Database['public']['Tables']['event_room_blocks']['Row'];
+export type EventRow = Database["public"]["Tables"]["events"]["Row"]
+export type EventRoomBlockRow = Database["public"]["Tables"]["event_room_blocks"]["Row"]
 
 export const Constants = {
   graphql_public: {

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -267,7 +267,7 @@ export type Database = {
     Functions: {
       cancel_expired_pending_reservations: { Args: { grace_minutes?: number }; Returns: number }
       is_admin: { Args: never; Returns: boolean }
-      mark_no_show_reservations: { Args: Record<string, never>; Returns: number }
+      mark_no_show_reservations: { Args: never; Returns: number }
     }
     Enums: {
       reservation_status: "active" | "cancelled" | "completed" | "pending" | "no_show"

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -34,6 +34,81 @@ export type Database = {
   }
   public: {
     Tables: {
+      event_room_blocks: {
+        Row: {
+          date: string
+          end_time: string
+          event_id: string
+          id: string
+          room_id: string
+          start_time: string
+        }
+        Insert: {
+          date: string
+          end_time: string
+          event_id: string
+          id?: string
+          room_id: string
+          start_time: string
+        }
+        Update: {
+          date?: string
+          end_time?: string
+          event_id?: string
+          id?: string
+          room_id?: string
+          start_time?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "event_room_blocks_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "event_room_blocks_room_id_fkey"
+            columns: ["room_id"]
+            isOneToOne: false
+            referencedRelation: "rooms"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      events: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          date: string
+          description: string | null
+          end_time: string
+          id: string
+          start_time: string
+          title: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          date: string
+          description?: string | null
+          end_time: string
+          id?: string
+          start_time: string
+          title: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          date?: string
+          description?: string | null
+          end_time?: string
+          id?: string
+          start_time?: string
+          title?: string
+        }
+        Relationships: []
+      }
       profiles: {
         Row: {
           blocked_until: string | null
@@ -322,6 +397,9 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
+
+export type EventRow = Database['public']['Tables']['events']['Row'];
+export type EventRoomBlockRow = Database['public']['Tables']['event_room_blocks']['Row'];
 
 export const Constants = {
   graphql_public: {

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -6,6 +6,8 @@ export interface User {
   email?: string | null;
   role: Role;
   isActive: boolean;
+  noShowCount: number;
+  blockedUntil: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -114,7 +114,13 @@
     "cancelReservationConfirm": "Are you sure you want to cancel this reservation?",
     "noReservations": "No reservations found",
     "table": "Table", "user": "User",
-    "regenerateQr": "Regenerate QR"
+    "regenerateQr": "Regenerate QR",
+    "noShowCount": "No-show count",
+    "blockedUntil": "Blocked until",
+    "resetNoShows": "Reset no-shows",
+    "unblockUser": "Unblock",
+    "noShowsReset": "No-shows reset successfully",
+    "userUnblocked": "User unblocked successfully"
   },
   "home": {
     "heroTitle": "Your Adventure Starts Here",

--- a/messages/es.json
+++ b/messages/es.json
@@ -113,7 +113,13 @@
     "cancelReservationConfirm": "¿Estás seguro de que deseas cancelar esta reserva? Esta acción no se puede deshacer.",
     "noReservations": "No hay reservas",
     "table": "Mesa", "user": "Usuario",
-    "regenerateQr": "Regenerar QR"
+    "regenerateQr": "Regenerar QR",
+    "noShowCount": "Conteo de no-shows",
+    "blockedUntil": "Bloqueado hasta",
+    "resetNoShows": "Reiniciar no-shows",
+    "unblockUser": "Desbloquear",
+    "noShowsReset": "No-shows reiniciados con éxito",
+    "userUnblocked": "Usuario desbloqueado con éxito"
   },
   "home": {
     "heroTitle": "Tu Aventura Comienza Aquí",

--- a/supabase/migrations/20260410000004_events_schema.sql
+++ b/supabase/migrations/20260410000004_events_schema.sql
@@ -1,0 +1,89 @@
+-- ============================================================
+-- Alea Webapp — Events Data Model
+-- Migration: 20260410000004_events_schema.sql
+-- KIM-332, KIM-343
+-- ============================================================
+
+-- ============================================================
+-- Table: events
+-- Stores association events (game nights, tournaments, etc.)
+-- ============================================================
+CREATE TABLE public.events (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title       text NOT NULL,
+  description text,
+  date        date NOT NULL,
+  start_time  time NOT NULL,
+  end_time    time NOT NULL,
+  created_by  uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX events_date_idx ON public.events (date);
+
+-- ============================================================
+-- Table: event_room_blocks
+-- Links events to rooms, blocking a room for a given time slot.
+-- ============================================================
+CREATE TABLE public.event_room_blocks (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id   uuid NOT NULL REFERENCES public.events (id) ON DELETE CASCADE,
+  room_id    uuid NOT NULL REFERENCES public.rooms (id) ON DELETE CASCADE,
+  date       date NOT NULL,
+  start_time time NOT NULL,
+  end_time   time NOT NULL
+);
+
+CREATE INDEX event_room_blocks_event_id_idx ON public.event_room_blocks (event_id);
+CREATE INDEX event_room_blocks_room_id_idx ON public.event_room_blocks (room_id);
+
+-- ============================================================
+-- Row Level Security
+-- ============================================================
+
+ALTER TABLE public.events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.event_room_blocks ENABLE ROW LEVEL SECURITY;
+
+-- ---- events ----
+CREATE POLICY "events_select"
+  ON public.events FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "events_admin_insert"
+  ON public.events FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_admin());
+
+CREATE POLICY "events_admin_update"
+  ON public.events FOR UPDATE
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+CREATE POLICY "events_admin_delete"
+  ON public.events FOR DELETE
+  TO authenticated
+  USING (public.is_admin());
+
+-- ---- event_room_blocks ----
+CREATE POLICY "event_room_blocks_select"
+  ON public.event_room_blocks FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "event_room_blocks_admin_insert"
+  ON public.event_room_blocks FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_admin());
+
+CREATE POLICY "event_room_blocks_admin_update"
+  ON public.event_room_blocks FOR UPDATE
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+CREATE POLICY "event_room_blocks_admin_delete"
+  ON public.event_room_blocks FOR DELETE
+  TO authenticated
+  USING (public.is_admin());

--- a/supabase/migrations/20260410000004_events_schema.sql
+++ b/supabase/migrations/20260410000004_events_schema.sql
@@ -16,7 +16,8 @@ CREATE TABLE public.events (
   start_time  time NOT NULL,
   end_time    time NOT NULL,
   created_by  uuid REFERENCES auth.users (id) ON DELETE SET NULL,
-  created_at  timestamptz NOT NULL DEFAULT now()
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT events_valid_time_range CHECK (end_time > start_time)
 );
 
 CREATE INDEX events_date_idx ON public.events (date);
@@ -31,7 +32,8 @@ CREATE TABLE public.event_room_blocks (
   room_id    uuid NOT NULL REFERENCES public.rooms (id) ON DELETE CASCADE,
   date       date NOT NULL,
   start_time time NOT NULL,
-  end_time   time NOT NULL
+  end_time   time NOT NULL,
+  CONSTRAINT event_room_blocks_valid_time_range CHECK (end_time > start_time)
 );
 
 CREATE INDEX event_room_blocks_event_id_idx ON public.event_room_blocks (event_id);

--- a/supabase/migrations/20260412000000_fn_mark_no_show_reservations.sql
+++ b/supabase/migrations/20260412000000_fn_mark_no_show_reservations.sql
@@ -1,0 +1,34 @@
+-- Migration: add function to mark pending reservations as no_show after session end time
+--
+-- end_time is stored as TIME NOT NULL in 'HH:MM:SS' format (e.g. '22:00:00').
+-- Casting end_time::time gives a PostgreSQL TIME value which can be added to a DATE
+-- to produce a TIMESTAMP. Comparing with NOW() identifies reservations where the
+-- session has completely ended but the reservation was never activated.
+--
+-- This complements cancel_expired_pending_reservations (which marks no_show after
+-- start_time + grace_minutes). This function handles any residual pending
+-- reservations that remain after the full session end time has passed.
+
+CREATE OR REPLACE FUNCTION public.mark_no_show_reservations()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  updated_count integer;
+BEGIN
+  UPDATE public.reservations
+  SET status = 'no_show'
+  WHERE status = 'pending'
+    AND activated_at IS NULL
+    AND (date::date + end_time::time) < NOW();
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;
+
+-- Restrict execute permission: only service_role (used by the cron route handler) may call this function.
+REVOKE EXECUTE ON FUNCTION public.mark_no_show_reservations() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.mark_no_show_reservations() TO service_role;

--- a/supabase/migrations/20260412000000_fn_mark_no_show_reservations.sql
+++ b/supabase/migrations/20260412000000_fn_mark_no_show_reservations.sql
@@ -33,8 +33,8 @@ $$;
 REVOKE EXECUTE ON FUNCTION public.mark_no_show_reservations() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.mark_no_show_reservations() TO service_role;
 
--- Partial index to speed up the UPDATE in mark_no_show_reservations():
--- only indexes rows that are still eligible candidates (pending + never activated).
+-- Partial index to speed up the WHERE clause used by the cron UPDATE.
+-- Only indexes rows that are still pending and not yet activated, keeping the index small and write-cheap.
 CREATE INDEX IF NOT EXISTS reservations_pending_no_show_idx
   ON public.reservations (date, end_time)
   WHERE status = 'pending' AND activated_at IS NULL;

--- a/supabase/migrations/20260412000000_fn_mark_no_show_reservations.sql
+++ b/supabase/migrations/20260412000000_fn_mark_no_show_reservations.sql
@@ -32,3 +32,9 @@ $$;
 -- Restrict execute permission: only service_role (used by the cron route handler) may call this function.
 REVOKE EXECUTE ON FUNCTION public.mark_no_show_reservations() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.mark_no_show_reservations() TO service_role;
+
+-- Partial index to speed up the UPDATE in mark_no_show_reservations():
+-- only indexes rows that are still eligible candidates (pending + never activated).
+CREATE INDEX IF NOT EXISTS reservations_pending_no_show_idx
+  ON public.reservations (date, end_time)
+  WHERE status = 'pending' AND activated_at IS NULL;

--- a/supabase/migrations/20260412000001_profiles_no_show_columns.sql
+++ b/supabase/migrations/20260412000001_profiles_no_show_columns.sql
@@ -1,0 +1,7 @@
+-- Migration: add no-show tracking columns to profiles
+-- Required by M7A (KIM-335): admin controls to view and reset no-show counts.
+-- These columns are populated by the no-show tracking cron (KIM-329).
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS no_show_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS blocked_until timestamptz;


### PR DESCRIPTION
## Summary

- Adds `no_show_count` and `blocked_until` columns to `profiles` via Supabase migration
- Exposes both fields on the `User` type and propagates through all user service queries
- Adds `resetNoShows()` and `unblockUser()` service functions using the admin client (bypasses RLS)
- Adds `PATCH /api/users/[id]` handler supporting `reset_no_shows` and `unblock` actions, with full mutation security enforcement and 403 on non-admin callers
- Extends the admin users table with no-show count and blocked-until columns; adds contextual **Reset no-shows** / **Unblock** buttons with in-flight loading state
- Adds `patch()` method to `ApiClient` and `useAdminPatchUser` hook
- Full i18n parity in `es.json` and `en.json`

## Test plan

- [x] `pnpm typecheck` passes with no errors
- [x] `pnpm build` passes (26 static pages generated)
- [x] `pnpm test` — 341 tests pass across 26 test files
- [x] No test files created or modified (owned by qa-engineer)
- [x] No README/ARCHITECTURE/docs files modified

Closes KIM-335

🤖 Generated with [Claude Code](https://claude.com/claude-code)