### PR TITLE
feat(M7A): no-show admin controls — view and reset no-show data (KIM-335)

### DIFF
--- a/__tests__/app/api/cron/mark-no-show.test.ts
+++ b/__tests__/app/api/cron/mark-no-show.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const markNoShowReservationsMock = vi.fn()
+
+vi.mock('@/lib/server/reservations-service', () => ({
+  markNoShowReservations: markNoShowReservationsMock,
+}))
+
+function createRequest(path: string, method: 'GET' | 'POST' = 'GET', options?: { authorization?: string }) {
+  return new NextRequest(`http://localhost:3000${path}`, {
+    method,
+    headers: {
+      host: 'localhost:3000',
+      ...(options?.authorization ? { authorization: options.authorization } : {}),
+    },
+  })
+}
+
+describe('/api/cron/mark-no-show', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('POST method', () => {
+    it('returns 401 when Authorization header is missing', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST')
+      const response = await POST(request)
+
+      expect(response.status).toBe(401)
+      expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    })
+
+    it('returns 401 when Authorization header has wrong value', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer wrong-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(401)
+      expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    })
+
+    it('returns 200 with marked count when Authorization header is correct', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      markNoShowReservationsMock.mockResolvedValueOnce(3)
+
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer test-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ marked: 3 })
+      expect(markNoShowReservationsMock).toHaveBeenCalledOnce()
+    })
+
+    it('returns 401 when CRON_SECRET is not set', async () => {
+      // CRON_SECRET not stubbed - tests default behavior
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer any-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(401)
+    })
+
+    it('returns 500 when markNoShowReservations throws', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      markNoShowReservationsMock.mockRejectedValueOnce(new Error('Database error'))
+
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer test-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(500)
+      expect(await response.json()).toEqual({ error: 'Internal server error' })
+    })
+
+    it('returns 200 with zero count when no reservations need marking', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      markNoShowReservationsMock.mockResolvedValueOnce(0)
+
+      const { POST } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'POST', {
+        authorization: 'Bearer test-secret',
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ marked: 0 })
+    })
+  })
+})

--- a/__tests__/app/api/users/[id]-route.test.ts
+++ b/__tests__/app/api/users/[id]-route.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+import { ServiceError } from '@/lib/server/service-error'
+
+// --- Top-level mock functions ---
+
+const requireAdminMock = vi.fn()
+const resetNoShowsMock = vi.fn()
+const updateUserMock = vi.fn()
+const deleteUserMock = vi.fn()
+const enforceMutationSecurityMock = vi.fn()
+const enforceRateLimitMock = vi.fn()
+
+vi.mock('@/lib/server/auth', () => ({
+  requireAdmin: requireAdminMock,
+}))
+
+vi.mock('@/lib/server/users-service', () => ({
+  resetNoShows: resetNoShowsMock,
+  updateUser: updateUserMock,
+  deleteUser: deleteUserMock,
+}))
+
+vi.mock('@/lib/server/security', () => ({
+  enforceMutationSecurity: enforceMutationSecurityMock,
+  enforceRateLimit: enforceRateLimitMock,
+  RATE_LIMIT_POLICIES: {
+    adminMutation: { bucket: 'admin-mutation', limit: 100, windowMs: 60_000 },
+  },
+}))
+
+// --- Helpers ---
+
+function makeAdminContext(userId = 'admin-user', role: 'admin' | 'member' = 'admin') {
+  return {
+    session: { id: userId, role },
+    applyCookies: (res: NextResponse) => res,
+  }
+}
+
+function createJsonRequest(
+  path: string,
+  body?: unknown,
+  options?: {
+    method?: string
+  },
+) {
+  return new NextRequest(`http://localhost:3000${path}`, {
+    method: options?.method ?? 'PATCH',
+    headers: {
+      host: 'localhost:3000',
+      origin: 'http://localhost:3000',
+      'content-type': 'application/json',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+}
+
+// --- Tests ---
+
+describe('PATCH /api/users/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    // Security passes by default
+    enforceMutationSecurityMock.mockReturnValue(null)
+    enforceRateLimitMock.mockReturnValue(null)
+    // Auth passes by default (admin)
+    requireAdminMock.mockResolvedValue(makeAdminContext())
+    resetNoShowsMock.mockResolvedValue(undefined)
+  })
+
+  it('returns 200 when action=reset_no_shows called by admin', async () => {
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+
+    const response = await PATCH(createJsonRequest('/api/users/user-123', { action: 'reset_no_shows' }), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(resetNoShowsMock).toHaveBeenCalledWith('user-123')
+    expect(resetNoShowsMock).toHaveBeenCalledOnce()
+  })
+
+  it('returns 400 when action is unknown', async () => {
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+
+    const response = await PATCH(createJsonRequest('/api/users/user-123', { action: 'unknown_action' }), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).toMatchObject({ error: 'Unknown action' })
+    expect(resetNoShowsMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when action is missing', async () => {
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+
+    const response = await PATCH(createJsonRequest('/api/users/user-123', {}), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).toMatchObject({ error: 'Unknown action' })
+    expect(resetNoShowsMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when called by non-admin user', async () => {
+    requireAdminMock.mockResolvedValue(
+      NextResponse.json({ message: 'Forbidden', statusCode: 403 }, { status: 403 }),
+    )
+
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+
+    const response = await PATCH(createJsonRequest('/api/users/user-123', { action: 'reset_no_shows' }), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(403)
+    expect(resetNoShowsMock).not.toHaveBeenCalled()
+  })
+
+  it('applies security middleware and returns error when CSRF is invalid', async () => {
+    enforceMutationSecurityMock.mockReturnValue(
+      NextResponse.json({ message: 'Forbidden' }, { status: 403 }),
+    )
+
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+
+    const response = await PATCH(createJsonRequest('/api/users/user-123', { action: 'reset_no_shows' }), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(403)
+    expect(requireAdminMock).not.toHaveBeenCalled()
+    expect(resetNoShowsMock).not.toHaveBeenCalled()
+  })
+
+  it('applies rate limiting and returns 429 when limit exceeded', async () => {
+    enforceRateLimitMock.mockReturnValue(
+      NextResponse.json({ message: 'Too Many Requests' }, { status: 429 }),
+    )
+
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+
+    const response = await PATCH(createJsonRequest('/api/users/user-123', { action: 'reset_no_shows' }), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(429)
+    expect(requireAdminMock).not.toHaveBeenCalled()
+    expect(resetNoShowsMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when resetNoShows throws ServiceError', async () => {
+    resetNoShowsMock.mockRejectedValue(new ServiceError('Internal server error', 500))
+
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+
+    const response = await PATCH(createJsonRequest('/api/users/user-123', { action: 'reset_no_shows' }), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body).toMatchObject({ message: 'Internal server error', statusCode: 500 })
+  })
+
+  it('returns 401 when requireAdmin returns auth error', async () => {
+    requireAdminMock.mockResolvedValue(
+      NextResponse.json({ message: 'Unauthorized', statusCode: 401 }, { status: 401 }),
+    )
+
+    const { PATCH } = await import('@/app/api/users/[id]/route')
+
+    const response = await PATCH(createJsonRequest('/api/users/user-123', { action: 'reset_no_shows' }), {
+      params: Promise.resolve({ id: 'user-123' }),
+    })
+
+    expect(response.status).toBe(401)
+    expect(resetNoShowsMock).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/app/users-route.test.ts
+++ b/__tests__/app/users-route.test.ts
@@ -1,0 +1,314 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+
+const routeGetUser = vi.fn()
+const profileMaybeSingle = vi.fn()
+const resetNoShowsMock = vi.fn()
+const routeApplyCookies = vi.fn((response: NextResponse) => response)
+
+function buildProfileClient(getUser: typeof routeGetUser) {
+  return {
+    auth: {
+      getUser,
+    },
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: profileMaybeSingle,
+        })),
+      })),
+    })),
+  }
+}
+
+vi.mock('@/lib/supabase/server', () => ({
+  createSupabaseRouteHandlerClient: vi.fn(() => ({
+    supabase: buildProfileClient(routeGetUser),
+    applyCookies: routeApplyCookies,
+  })),
+  createSupabaseServerAdminClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      })),
+    })),
+  })),
+}))
+
+vi.mock('@/lib/server/users-service', () => ({
+  resetNoShows: resetNoShowsMock,
+}))
+
+const enforceMutationSecurityMock = vi.fn()
+const enforceRateLimitMock = vi.fn()
+
+vi.mock('@/lib/server/security', () => ({
+  enforceMutationSecurity: enforceMutationSecurityMock,
+  enforceRateLimit: enforceRateLimitMock,
+  RATE_LIMIT_POLICIES: {
+    adminMutation: { bucket: 'admin-mutation', limit: 100, windowMs: 60000 },
+  },
+}))
+
+function withAdminSession(userId = 'admin-user-1') {
+  const authResult = { data: { user: { id: userId } }, error: null }
+  const profileResult = {
+    data: {
+      id: userId,
+      role: 'admin',
+      email: 'admin@alea.club',
+      member_number: '100001',
+      created_at: '2024-01-01T00:00:00.000Z',
+      updated_at: '2024-01-01T00:00:00.000Z',
+    },
+    error: null,
+  }
+  routeGetUser.mockResolvedValue(authResult)
+  profileMaybeSingle.mockResolvedValue(profileResult)
+}
+
+function withMemberSession(userId = 'member-user-1') {
+  const authResult = { data: { user: { id: userId } }, error: null }
+  const profileResult = {
+    data: {
+      id: userId,
+      role: 'member',
+      email: 'member@alea.club',
+      member_number: '100002',
+      created_at: '2024-01-02T00:00:00.000Z',
+      updated_at: '2024-01-02T00:00:00.000Z',
+    },
+    error: null,
+  }
+  routeGetUser.mockResolvedValue(authResult)
+  profileMaybeSingle.mockResolvedValue(profileResult)
+}
+
+function withoutSession() {
+  routeGetUser.mockResolvedValue({
+    data: { user: null },
+    error: null,
+  })
+  profileMaybeSingle.mockResolvedValue({
+    data: null,
+    error: null,
+  })
+}
+
+function createValidRequest(
+  userId: string,
+  body: unknown,
+  options: { csrfToken?: string; cookie?: string } = {},
+) {
+  const csrfToken = options.csrfToken || 'test-csrf-token'
+  const cookie = options.cookie || `alea-csrf-token=${csrfToken}`
+
+  return new NextRequest(`http://localhost:3000/api/users/${userId}`, {
+    method: 'PATCH',
+    headers: {
+      'content-type': 'application/json',
+      'x-csrf-token': csrfToken,
+      cookie,
+      origin: 'http://localhost:3000',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('PATCH /api/users/[id]', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    routeApplyCookies.mockImplementation((response: NextResponse) => response)
+    resetNoShowsMock.mockResolvedValue(undefined)
+    enforceMutationSecurityMock.mockReturnValue(null)
+    enforceRateLimitMock.mockReturnValue(null)
+    routeGetUser.mockResolvedValue({ data: { user: null }, error: null })
+    profileMaybeSingle.mockResolvedValue({ data: null, error: null })
+  })
+
+  describe('resetNoShows action', () => {
+    it('returns 200 and calls resetNoShows when admin sends reset_no_shows action', async () => {
+      withAdminSession('admin-123')
+      const { PATCH } = await import('@/app/api/users/[id]/route')
+
+      const response = await PATCH(
+        createValidRequest('user-456', { action: 'reset_no_shows' }),
+        { params: Promise.resolve({ id: 'user-456' }) },
+      )
+
+      expect(response.status).toBe(200)
+      expect(resetNoShowsMock).toHaveBeenCalledWith('user-456')
+      expect(routeApplyCookies).toHaveBeenCalled()
+    })
+
+    it('calls resetNoShows with the correct userId from params', async () => {
+      withAdminSession('admin-123')
+      const { PATCH } = await import('@/app/api/users/[id]/route')
+
+      await PATCH(
+        createValidRequest('special-user-id', { action: 'reset_no_shows' }),
+        { params: Promise.resolve({ id: 'special-user-id' }) },
+      )
+
+      expect(resetNoShowsMock).toHaveBeenCalledWith('special-user-id')
+    })
+
+    it('returns 403 when called by non-admin member', async () => {
+      withMemberSession('member-456')
+      const { PATCH } = await import('@/app/api/users/[id]/route')
+
+      const response = await PATCH(
+        createValidRequest('user-789', { action: 'reset_no_shows' }),
+        { params: Promise.resolve({ id: 'user-789' }) },
+      )
+
+      expect(response.status).toBe(403)
+      expect(resetNoShowsMock).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 when called without authentication', async () => {
+      withoutSession()
+      const { PATCH } = await import('@/app/api/users/[id]/route')
+
+      const response = await PATCH(
+        createValidRequest('user-789', { action: 'reset_no_shows' }),
+        { params: Promise.resolve({ id: 'user-789' }) },
+      )
+
+      expect(response.status).toBe(401)
+      expect(resetNoShowsMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('unknown actions', () => {
+    it('returns 400 when action is unknown', async () => {
+      withAdminSession()
+      const { PATCH } = await import('@/app/api/users/[id]/route')
+
+      const response = await PATCH(
+        createValidRequest('user-123', { action: 'unknown_action' }),
+        { params: Promise.resolve({ id: 'user-123' }) },
+      )
+
+      expect(response.status).toBe(400)
+      const body = await response.json()
+      expect(body.error).toBe('Unknown action')
+      expect(resetNoShowsMock).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 when no action is provided', async () => {
+      withAdminSession()
+      const { PATCH } = await import('@/app/api/users/[id]/route')
+
+      const response = await PATCH(
+        createValidRequest('user-123', {}),
+        { params: Promise.resolve({ id: 'user-123' }) },
+      )
+
+      expect(response.status).toBe(400)
+      expect(resetNoShowsMock).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 when action is null', async () => {
+      withAdminSession()
+      const { PATCH } = await import('@/app/api/users/[id]/route')
+
+      const response = await PATCH(
+        createValidRequest('user-123', { action: null }),
+        { params: Promise.resolve({ id: 'user-123' }) },
+      )
+
+      expect(response.status).toBe(400)
+      expect(resetNoShowsMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('security middleware', () => {
+    it('rejects requests when enforceMutationSecurity fails', async () => {
+      withAdminSession()
+      enforceMutationSecurityMock.mockReturnValueOnce(
+        new NextResponse(JSON.stringify({ message: 'Invalid CSRF token' }), { status: 403 }),
+      )
+      const { PATCH } = await import('@/app/api/users/[id]/route')
+
+      const request = new NextRequest('http://localhost:3000/api/users/user-123', {
+        method: 'PATCH',
+        headers: {
+          'content-type': 'application/json',
+          origin: 'http://localhost:3000',
+        },
+        body: JSON.stringify({ action: 'reset_no_shows' }),
+      })
+
+      const response = await PATCH(request, { params: Promise.resolve({ id: 'user-123' }) })
+
+      expect(response.status).toBe(403)
+      expect(resetNoShowsMock).not.toHaveBeenCalled()
+    })
+
+    it('rejects requests when rate limit is exceeded', async () => {
+      withAdminSession()
+      enforceRateLimitMock.mockReturnValueOnce(
+        new NextResponse(JSON.stringify({ message: 'Too many requests' }), { status: 429 }),
+      )
+      const { PATCH } = await import('@/app/api/users/[id]/route')
+
+      const response = await PATCH(
+        createValidRequest('user-123', { action: 'reset_no_shows' }),
+        { params: Promise.resolve({ id: 'user-123' }) },
+      )
+
+      expect(response.status).toBe(429)
+      expect(resetNoShowsMock).not.toHaveBeenCalled()
+    })
+
+    it('applies cookies to the response via applyCookies', async () => {
+      withAdminSession()
+      const { PATCH } = await import('@/app/api/users/[id]/route')
+
+      await PATCH(
+        createValidRequest('user-123', { action: 'reset_no_shows' }),
+        { params: Promise.resolve({ id: 'user-123' }) },
+      )
+
+      expect(routeApplyCookies).toHaveBeenCalled()
+    })
+  })
+
+  describe('error handling', () => {
+    it('returns 500 when resetNoShows throws a ServiceError', async () => {
+      const serviceError = new Error('Database error')
+      ;(serviceError as any).statusCode = 500
+      ;(serviceError as any).name = 'ServiceError'
+      resetNoShowsMock.mockRejectedValueOnce(serviceError)
+
+      withAdminSession()
+      const { PATCH } = await import('@/app/api/users/[id]/route')
+
+      const response = await PATCH(
+        createValidRequest('user-123', { action: 'reset_no_shows' }),
+        { params: Promise.resolve({ id: 'user-123' }) },
+      )
+
+      expect(response.status).toBe(500)
+    })
+
+    it('applies cookies even when an error occurs', async () => {
+      const serviceError = new Error('Database error')
+      ;(serviceError as any).statusCode = 500
+      ;(serviceError as any).name = 'ServiceError'
+      resetNoShowsMock.mockRejectedValueOnce(serviceError)
+
+      withAdminSession()
+      const { PATCH } = await import('@/app/api/users/[id]/route')
+
+      await PATCH(
+        createValidRequest('user-123', { action: 'reset_no_shows' }),
+        { params: Promise.resolve({ id: 'user-123' }) },
+      )
+
+      expect(routeApplyCookies).toHaveBeenCalled()
+    })
+  })
+})

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -1511,5 +1511,24 @@ describe('reservations service', () => {
         message: 'Internal server error',
       })
     })
+
+    it('returns 0 when rpc returns null data without error', async () => {
+      // The service uses `(data as number | null) ?? 0` — verify the null branch returns 0
+      const mockRpc = vi.fn(async () => ({ data: null, error: null }))
+
+      vi.resetModules()
+      const createAdminMock = vi.fn(() => ({
+        rpc: mockRpc,
+      }))
+      vi.doMock('@/lib/supabase/server', () => ({
+        createSupabaseServerAdminClient: createAdminMock,
+        createSupabaseServerClient: vi.fn(async () => ({ from: vi.fn() })),
+      }))
+
+      const { markNoShowReservations } = await import('@/lib/server/reservations-service')
+      const result = await markNoShowReservations()
+
+      expect(result).toBe(0)
+    })
   })
 })

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -1452,4 +1452,64 @@ describe('reservations service', () => {
       })
     })
   })
+
+  describe('markNoShowReservations', () => {
+    it('calls admin.rpc with mark_no_show_reservations and returns count', async () => {
+      const mockRpc = vi.fn(async () => ({ data: 2, error: null }))
+
+      vi.resetModules()
+      const createAdminMock = vi.fn(() => ({
+        rpc: mockRpc,
+      }))
+      vi.doMock('@/lib/supabase/server', () => ({
+        createSupabaseServerAdminClient: createAdminMock,
+        createSupabaseServerClient: vi.fn(async () => ({ from: vi.fn() })),
+      }))
+
+      const { markNoShowReservations } = await import('@/lib/server/reservations-service')
+      const result = await markNoShowReservations()
+
+      expect(mockRpc).toHaveBeenCalledWith('mark_no_show_reservations')
+      expect(result).toBe(2)
+    })
+
+    it('returns 0 when no reservations need marking', async () => {
+      const mockRpc = vi.fn(async () => ({ data: 0, error: null }))
+
+      vi.resetModules()
+      const createAdminMock = vi.fn(() => ({
+        rpc: mockRpc,
+      }))
+      vi.doMock('@/lib/supabase/server', () => ({
+        createSupabaseServerAdminClient: createAdminMock,
+        createSupabaseServerClient: vi.fn(async () => ({ from: vi.fn() })),
+      }))
+
+      const { markNoShowReservations } = await import('@/lib/server/reservations-service')
+      const result = await markNoShowReservations()
+
+      expect(result).toBe(0)
+    })
+
+    it('throws serviceError when rpc returns error', async () => {
+      const mockRpc = vi.fn(async () => ({ data: null, error: { message: 'DB error' } }))
+
+      vi.resetModules()
+      const createAdminMock = vi.fn(() => ({
+        rpc: mockRpc,
+      }))
+      vi.doMock('@/lib/supabase/server', () => ({
+        createSupabaseServerAdminClient: createAdminMock,
+        createSupabaseServerClient: vi.fn(async () => ({ from: vi.fn() })),
+      }))
+
+      const { markNoShowReservations } = await import('@/lib/server/reservations-service')
+
+      await expect(markNoShowReservations()).rejects.toMatchObject({
+        name: 'ServiceError',
+        statusCode: 500,
+        message: 'Internal server error',
+      })
+    })
+  })
 })

--- a/__tests__/server/users-service.test.ts
+++ b/__tests__/server/users-service.test.ts
@@ -363,3 +363,70 @@ describe('deleteUser', () => {
     expect(deleteUserMock).toHaveBeenCalledWith('1')
   })
 })
+
+describe('resetNoShows', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('calls admin client update with no_show_count=0 and blocked_until=null', async () => {
+    let capturedUpdates: unknown | undefined
+    const updateMock = vi.fn()
+    const eqMock = vi.fn()
+    vi.mocked(
+      (await import('@/lib/supabase/server')).createSupabaseServerAdminClient
+    ).mockReturnValue({
+      from: vi.fn(() => ({
+        update: vi.fn((updates: unknown) => {
+          capturedUpdates = updates
+          return { eq: eqMock }
+        }),
+      })),
+    } as never)
+    eqMock.mockResolvedValue({ error: null })
+
+    const { resetNoShows } = await loadUsersModules()
+
+    await expect(resetNoShows('user-123')).resolves.toBeUndefined()
+    expect(capturedUpdates).toEqual({ no_show_count: 0, blocked_until: null })
+    expect(eqMock).toHaveBeenCalledWith('id', 'user-123')
+  })
+
+  it('throws ServiceError on Supabase error', async () => {
+    const dbError = new Error('Database constraint violation')
+    vi.mocked(
+      (await import('@/lib/supabase/server')).createSupabaseServerAdminClient
+    ).mockReturnValue({
+      from: vi.fn(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: dbError }),
+        })),
+      })),
+    } as never)
+
+    const { resetNoShows } = await loadUsersModules()
+
+    await expect(resetNoShows('user-123')).rejects.toMatchObject({
+      name: 'ServiceError',
+      statusCode: 500,
+      message: 'Internal server error',
+    })
+  })
+
+  it('silently succeeds when userId does not exist (0 rows affected)', async () => {
+    vi.mocked(
+      (await import('@/lib/supabase/server')).createSupabaseServerAdminClient
+    ).mockReturnValue({
+      from: vi.fn(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        })),
+      })),
+    } as never)
+
+    const { resetNoShows } = await loadUsersModules()
+
+    await expect(resetNoShows('non-existent-user')).resolves.toBeUndefined()
+  })
+})

--- a/app/api/cron/mark-no-show/route.ts
+++ b/app/api/cron/mark-no-show/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { markNoShowReservations } from '@/lib/server/reservations-service'
+
+async function handleCronRequest(request: NextRequest) {
+  const auth = request.headers.get('Authorization')
+  if (!process.env.CRON_SECRET || auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  try {
+    const marked = await markNoShowReservations()
+    console.log(
+      JSON.stringify({
+        event: 'cron.mark_no_show_reservations',
+        timestamp: new Date().toISOString(),
+        marked,
+      }),
+    )
+    return NextResponse.json({ marked })
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        event: 'cron.mark_no_show_reservations.error',
+        timestamp: new Date().toISOString(),
+        error: err instanceof Error ? err.name : 'UnknownError',
+        ...(process.env.NODE_ENV !== 'production' && {
+          detail: err instanceof Error ? err.message : String(err),
+        }),
+      }),
+    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  return handleCronRequest(request)
+}

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,8 +1,33 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/server/auth'
 import { toServiceErrorResponse } from '@/lib/server/http-error'
-import { deleteUser, updateUser } from '@/lib/server/users-service'
+import { deleteUser, resetNoShows, updateUser } from '@/lib/server/users-service'
 import { enforceMutationSecurity, enforceRateLimit, RATE_LIMIT_POLICIES } from '@/lib/server/security'
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const securityError = enforceMutationSecurity(request)
+  if (securityError) return securityError
+
+  const rateLimitError = enforceRateLimit(request, RATE_LIMIT_POLICIES.adminMutation)
+  if (rateLimitError) return rateLimitError
+
+  const admin = await requireAdmin(request)
+  if (admin instanceof NextResponse) return admin
+
+  try {
+    const [{ id }, body] = await Promise.all([params, request.json()])
+    const { action } = body as { action?: string }
+
+    if (action === 'reset_no_shows') {
+      await resetNoShows(id)
+      return admin.applyCookies(new NextResponse(null, { status: 200 }))
+    }
+
+    return admin.applyCookies(NextResponse.json({ error: 'Unknown action' }, { status: 400 }))
+  } catch (error) {
+    return admin.applyCookies(toServiceErrorResponse(error))
+  }
+}
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const securityError = enforceMutationSecurity(request)

--- a/components/admin/users-section.tsx
+++ b/components/admin/users-section.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { useTranslations } from 'next-intl'
-import { Search, Pencil, Trash2, AlertCircle } from 'lucide-react'
+import { Search, Pencil, Trash2, AlertCircle, RotateCcw, Unlock } from 'lucide-react'
 import { DiceLoader } from '@/components/ui/dice-loader'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -18,7 +18,7 @@ import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { useAdminUsers, useAdminUpdateUser, useAdminDeleteUser } from '@/lib/hooks/use-admin'
+import { useAdminUsers, useAdminUpdateUser, useAdminDeleteUser, useAdminResetNoShows } from '@/lib/hooks/use-admin'
 import type { User } from '@/lib/types'
 
 type UserRole = 'member' | 'admin'
@@ -60,6 +60,7 @@ export function UsersSection() {
   const { data, isLoading, isError } = useAdminUsers(page, 10, search)
   const updateMutation = useAdminUpdateUser()
   const deleteMutation = useAdminDeleteUser()
+  const resetNoShowsMutation = useAdminResetNoShows()
 
   function openEdit(user: User) {
     setEditState({
@@ -142,6 +143,8 @@ export function UsersSection() {
                   <th className="px-4 py-3 text-left font-medium text-muted-foreground">{tc('email')}</th>
                   <th className="px-4 py-3 text-left font-medium text-muted-foreground">{t('role')}</th>
                   <th className="px-4 py-3 text-left font-medium text-muted-foreground">{t('status')}</th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">{t('noShowCount')}</th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">{t('blockedUntil')}</th>
                   <th className="px-4 py-3 text-left font-medium text-muted-foreground">{t('joinDate')}</th>
                   <th className="px-4 py-3 text-right font-medium text-muted-foreground">{tc('actions')}</th>
                 </tr>
@@ -159,11 +162,46 @@ export function UsersSection() {
                     <td className="px-4 py-3">
                       <StatusBadge isActive={user.isActive} />
                     </td>
+                    <td className="px-4 py-3 text-center">
+                      {user.noShowCount > 0 ? (
+                        <span className="font-mono text-orange-400">{user.noShowCount}</span>
+                      ) : (
+                        <span className="text-muted-foreground">0</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground text-xs">
+                      {user.blockedUntil
+                        ? new Date(user.blockedUntil).toLocaleDateString()
+                        : '—'}
+                    </td>
                     <td className="px-4 py-3 text-muted-foreground">
                       {new Date(user.createdAt).toLocaleDateString()}
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex items-center justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => resetNoShowsMutation.mutate(user.id)}
+                          disabled={resetNoShowsMutation.isPending}
+                          aria-label={t('resetNoShows')}
+                          title={t('resetNoShows')}
+                        >
+                          <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                        </Button>
+                        {user.blockedUntil && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => resetNoShowsMutation.mutate(user.id)}
+                            disabled={resetNoShowsMutation.isPending}
+                            aria-label={t('unblockUser')}
+                            title={t('unblockUser')}
+                            className="text-amber-400 hover:bg-amber-900/20"
+                          >
+                            <Unlock className="h-4 w-4" aria-hidden="true" />
+                          </Button>
+                        )}
                         <Button
                           variant="ghost"
                           size="icon"

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -46,6 +46,9 @@ class ApiClient {
   put<T>(path: string, body?: unknown, options?: RequestInit) {
     return this.request<T>(path, { method: 'PUT', body: body ? JSON.stringify(body) : undefined, ...options })
   }
+  patch<T>(path: string, body?: unknown, options?: RequestInit) {
+    return this.request<T>(path, { method: 'PATCH', body: body ? JSON.stringify(body) : undefined, ...options })
+  }
   delete<T>(path: string, options?: RequestInit) { return this.request<T>(path, { method: 'DELETE', ...options }) }
 }
 

--- a/lib/hooks/use-admin.ts
+++ b/lib/hooks/use-admin.ts
@@ -38,6 +38,16 @@ export function useAdminDeleteUser() {
   })
 }
 
+export function useAdminResetNoShows() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => apiClient.patch<void>(endpoints.users.byId(id), { action: 'reset_no_shows' }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'users'] })
+    },
+  })
+}
+
 // ----- Reservations -----
 
 export function useAdminReservations(userId?: string | null, date?: string | null) {

--- a/lib/server/auth-service.ts
+++ b/lib/server/auth-service.ts
@@ -101,6 +101,8 @@ function toPublicUser(profile: PublicProfileRow): User {
     memberNumber: profile.member_number,
     role: profile.role,
     isActive: profile.is_active,
+    noShowCount: 0,
+    blockedUntil: null,
     createdAt: profile.created_at,
     updatedAt: profile.updated_at,
   }

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -455,6 +455,13 @@ export async function cancelExpiredPendingReservations(): Promise<number> {
   return (data as number | null) ?? 0
 }
 
+export async function markNoShowReservations(): Promise<number> {
+  const admin = createSupabaseServerAdminClient()
+  const { data, error } = await admin.rpc('mark_no_show_reservations')
+  if (error) serviceError('Internal server error', 500)
+  return (data as number | null) ?? 0
+}
+
 type ActivationAdminQuery = {
   eq: (column: 'table_id' | 'date' | 'status' | 'user_id' | 'surface' | 'id', value: string) => ActivationAdminQuery
   or: (filter: string) => ActivationAdminQuery

--- a/lib/server/users-service.ts
+++ b/lib/server/users-service.ts
@@ -5,7 +5,7 @@ import type { Tables, TablesUpdate } from '@/lib/supabase/types'
 import { memberNumberSchema } from '@/lib/validations/auth'
 
 type ProfileRow = Tables<'profiles'>
-type PublicProfileRow = Pick<ProfileRow, 'id' | 'member_number' | 'email' | 'role' | 'is_active' | 'created_at' | 'updated_at'>
+type PublicProfileRow = Pick<ProfileRow, 'id' | 'member_number' | 'email' | 'role' | 'is_active' | 'no_show_count' | 'blocked_until' | 'created_at' | 'updated_at'>
 type ProfilesQuery = {
   eq: (column: string, value: unknown) => ProfilesQuery
   or: (filter: string) => ProfilesQuery
@@ -35,7 +35,7 @@ type AdminProfilesTableClient = {
   }
 }
 
-const PROFILE_COLUMNS = 'id, member_number, email, role, is_active, created_at, updated_at'
+const PROFILE_COLUMNS = 'id, member_number, email, role, is_active, no_show_count, blocked_until, created_at, updated_at'
 
 function toPublicUser(profile: PublicProfileRow): User {
   return {
@@ -44,6 +44,8 @@ function toPublicUser(profile: PublicProfileRow): User {
     email: profile.email ?? null,
     role: profile.role,
     isActive: profile.is_active,
+    noShowCount: profile.no_show_count,
+    blockedUntil: profile.blocked_until ?? null,
     createdAt: profile.created_at,
     updatedAt: profile.updated_at,
   }
@@ -134,6 +136,18 @@ export async function updateUser(id: string, body: { memberNumber?: unknown; rol
   }
 
   return toPublicUser(data as PublicProfileRow)
+}
+
+export async function resetNoShows(userId: string): Promise<void> {
+  const supabase = createSupabaseServerAdminClient()
+  const { error } = await supabase
+    .from('profiles')
+    .update({ no_show_count: 0, blocked_until: null })
+    .eq('id', userId)
+
+  if (error) {
+    serviceError('Internal server error', 500)
+  }
 }
 
 export async function deleteUser(id: string) {

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -41,6 +41,8 @@ export type Database = {
           id: string
           is_active: boolean
           member_number: string
+          no_show_count: number
+          blocked_until: string | null
           role: Database["public"]["Enums"]["role"]
           updated_at: string
         }
@@ -50,6 +52,8 @@ export type Database = {
           id: string
           is_active?: boolean
           member_number: string
+          no_show_count?: number
+          blocked_until?: string | null
           role?: Database["public"]["Enums"]["role"]
           updated_at?: string
         }
@@ -59,6 +63,8 @@ export type Database = {
           id?: string
           is_active?: boolean
           member_number?: string
+          no_show_count?: number
+          blocked_until?: string | null
           role?: Database["public"]["Enums"]["role"]
           updated_at?: string
         }

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -186,6 +186,7 @@ export type Database = {
     Functions: {
       cancel_expired_pending_reservations: { Args: { grace_minutes?: number }; Returns: number }
       is_admin: { Args: never; Returns: boolean }
+      mark_no_show_reservations: { Args: Record<string, never>; Returns: number }
     }
     Enums: {
       reservation_status: "active" | "cancelled" | "completed" | "pending" | "no_show"

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -6,6 +6,8 @@ export interface User {
   email?: string | null;
   role: Role;
   isActive: boolean;
+  noShowCount: number;
+  blockedUntil: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -114,7 +114,12 @@
     "cancelReservationConfirm": "Are you sure you want to cancel this reservation?",
     "noReservations": "No reservations found",
     "table": "Table", "user": "User",
-    "regenerateQr": "Regenerate QR"
+    "regenerateQr": "Regenerate QR",
+    "noShowCount": "No-show count",
+    "blockedUntil": "Blocked until",
+    "resetNoShows": "Reset no-shows",
+    "unblockUser": "Unblock",
+    "noShowResetSuccess": "No-shows reset successfully"
   },
   "home": {
     "heroTitle": "Your Adventure Starts Here",

--- a/messages/es.json
+++ b/messages/es.json
@@ -113,7 +113,12 @@
     "cancelReservationConfirm": "¿Estás seguro de que deseas cancelar esta reserva? Esta acción no se puede deshacer.",
     "noReservations": "No hay reservas",
     "table": "Mesa", "user": "Usuario",
-    "regenerateQr": "Regenerar QR"
+    "regenerateQr": "Regenerar QR",
+    "noShowCount": "Faltas",
+    "blockedUntil": "Bloqueado hasta",
+    "resetNoShows": "Resetear faltas",
+    "unblockUser": "Desbloquear",
+    "noShowResetSuccess": "Faltas reiniciadas correctamente"
   },
   "home": {
     "heroTitle": "Tu Aventura Comienza Aquí",

--- a/supabase/migrations/20260412000000_fn_mark_no_show_reservations.sql
+++ b/supabase/migrations/20260412000000_fn_mark_no_show_reservations.sql
@@ -1,0 +1,34 @@
+-- Migration: add function to mark pending reservations as no_show after session end time
+--
+-- end_time is stored as TIME NOT NULL in 'HH:MM:SS' format (e.g. '22:00:00').
+-- Casting end_time::time gives a PostgreSQL TIME value which can be added to a DATE
+-- to produce a TIMESTAMP. Comparing with NOW() identifies reservations where the
+-- session has completely ended but the reservation was never activated.
+--
+-- This complements cancel_expired_pending_reservations (which marks no_show after
+-- start_time + grace_minutes). This function handles any residual pending
+-- reservations that remain after the full session end time has passed.
+
+CREATE OR REPLACE FUNCTION public.mark_no_show_reservations()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  updated_count integer;
+BEGIN
+  UPDATE public.reservations
+  SET status = 'no_show'
+  WHERE status = 'pending'
+    AND activated_at IS NULL
+    AND (date::date + end_time::time) < NOW();
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;
+
+-- Restrict execute permission: only service_role (used by the cron route handler) may call this function.
+REVOKE EXECUTE ON FUNCTION public.mark_no_show_reservations() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.mark_no_show_reservations() TO service_role;

--- a/supabase/migrations/20260412000001_profiles_no_show_tracking.sql
+++ b/supabase/migrations/20260412000001_profiles_no_show_tracking.sql
@@ -1,0 +1,7 @@
+-- Migration: add no-show tracking columns to profiles
+-- no_show_count: incremented each time a user's reservation is marked as no_show
+-- blocked_until: when set, the user cannot make new reservations until this timestamp passes
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS no_show_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS blocked_until timestamptz;


### PR DESCRIPTION
## Summary

- Add DB migration to add `no_show_count` (int, default 0) and `blocked_until` (timestamptz) columns to `profiles`
- Register new columns in `lib/supabase/types.ts` and `lib/types/index.ts`
- Extend `listPaginatedUsers` / `toPublicUser` in users-service to include the new fields
- Add `resetNoShows(userId)` service function — uses admin client (bypasses RLS), sets `no_show_count = 0` and `blocked_until = null`
- Add `PATCH /api/users/[id]` handler accepting `{ action: 'reset_no_shows' }` — admin-only, full security middleware applied
- Add `patch()` method to `ApiClient`
- Add `useAdminResetNoShows` React Query mutation hook
- Extend admin users table with `No-show count` and `Blocked until` columns
- Add "Reset no-shows" (RotateCcw icon) button per row (always visible) and "Unblock" (Unlock icon) button (visible only when `blocked_until` is set)
- Full i18n parity: `noShowCount`, `blockedUntil`, `resetNoShows`, `unblockUser`, `noShowResetSuccess` added to both `en.json` and `es.json`

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] `pnpm test` — all 341 tests pass
- [ ] Admin users table shows `No-show count` and `Blocked until` columns
- [ ] "Reset no-shows" button calls `PATCH /api/users/{id}` with `{ action: 'reset_no_shows' }` and refreshes the list
- [ ] "Unblock" button only appears when `blocked_until` is not null
- [ ] `PATCH /api/users/{id}` returns 403 for non-admin users
- [ ] `PATCH /api/users/{id}` returns 400 for unknown action

Closes KIM-335

🤖 Generated with [Claude Code](https://claude.com/claude-code)