### PR TITLE
fix(auth+i18n): prevent user enumeration and fix navbar on locale switch

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import { Suspense } from 'react'
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages } from 'next-intl/server'
 import { notFound } from 'next/navigation'
@@ -44,9 +43,7 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
           <Providers>
             <AuthProvider initialUser={initialUser}>
               <NavigationProgress />
-              <Suspense fallback={null}>
-                <Header locale={locale} />
-              </Suspense>
+              <Header locale={locale} />
               <main id="main-content" className="flex-1">
                 {children}
               </main>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -19,6 +19,7 @@ function LocaleSwitcherLink({ locale }: { locale: string }) {
   const otherLocale = locale === 'es' ? 'en' : 'es'
   const pathname = usePathname()
   const searchParams = useSearchParams()
+  const t = useTranslations()
   const pathWithoutLocale = pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '')
   const qs = searchParams.toString()
   const switchHref = `/${otherLocale}${pathWithoutLocale}${qs ? `?${qs}` : ''}`
@@ -27,7 +28,7 @@ function LocaleSwitcherLink({ locale }: { locale: string }) {
     <Link
       href={switchHref}
       className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      aria-label={`Switch to ${otherLocale}`}
+      aria-label={t('nav.switchLocale', { locale: otherLocale })}
     >
       <Globe className="h-3.5 w-3.5" aria-hidden="true" />
       <span className="uppercase font-medium">{otherLocale}</span>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -6,20 +6,50 @@ import { useTranslations } from 'next-intl'
 import { Sword, Menu, Globe, LogOut, LayoutDashboard } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useAuth } from '@/lib/auth/auth-context'
-import { useState } from 'react'
+import { useState, Suspense } from 'react'
 
 interface HeaderProps { locale: string }
 
-export function Header({ locale }: HeaderProps) {
-  const t = useTranslations()
-  const { user, logout, isAuthenticated } = useAuth()
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+/**
+ * Isolated sub-component that calls useSearchParams().
+ * Must be wrapped in its own Suspense boundary so that suspension caused by
+ * useSearchParams during streaming SSR does not hide the entire Header.
+ */
+function LocaleSwitcherLink({ locale }: { locale: string }) {
   const otherLocale = locale === 'es' ? 'en' : 'es'
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const pathWithoutLocale = pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '')
   const qs = searchParams.toString()
   const switchHref = `/${otherLocale}${pathWithoutLocale}${qs ? `?${qs}` : ''}`
+
+  return (
+    <Link
+      href={switchHref}
+      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      aria-label={`Switch to ${otherLocale}`}
+    >
+      <Globe className="h-3.5 w-3.5" aria-hidden="true" />
+      <span className="uppercase font-medium">{otherLocale}</span>
+    </Link>
+  )
+}
+
+/** Fallback shown while LocaleSwitcherLink is suspending (no layout shift). */
+function LocaleSwitcherFallback({ locale }: { locale: string }) {
+  const otherLocale = locale === 'es' ? 'en' : 'es'
+  return (
+    <span className="flex items-center gap-1 text-xs text-muted-foreground px-2 py-1 rounded" aria-hidden="true">
+      <Globe className="h-3.5 w-3.5" aria-hidden="true" />
+      <span className="uppercase font-medium">{otherLocale}</span>
+    </span>
+  )
+}
+
+export function Header({ locale }: HeaderProps) {
+  const t = useTranslations()
+  const { user, logout, isAuthenticated } = useAuth()
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
 
   return (
     <header className="sticky top-0 z-40 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -51,10 +81,9 @@ export function Header({ locale }: HeaderProps) {
         </nav>
 
         <div className="flex items-center gap-2">
-          <Link href={switchHref} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label={`Switch to ${otherLocale}`}>
-            <Globe className="h-3.5 w-3.5" aria-hidden="true" />
-            <span className="uppercase font-medium">{otherLocale}</span>
-          </Link>
+          <Suspense fallback={<LocaleSwitcherFallback locale={locale} />}>
+            <LocaleSwitcherLink locale={locale} />
+          </Suspense>
 
           {isAuthenticated ? (
             <div className="flex items-center gap-2">

--- a/lib/server/auth-service.ts
+++ b/lib/server/auth-service.ts
@@ -138,7 +138,7 @@ export async function login(
 
   if (credentialProfile.is_active === false) {
     // Suspended users cannot sign in.
-    serviceError('Your account is suspended. Contact an administrator to reactivate it.', 403)
+    serviceError('Invalid credentials', 401)
   }
 
   const supabase = client ?? await createSupabaseServerClient()
@@ -179,7 +179,7 @@ export async function register(
   // Generic message to avoid user enumeration (do not confirm whether the number exists).
   const existing = await getAuthCredentialProfileBy(adminClient, 'member_number', memberNumber)
   if (existing) {
-    serviceError('Invalid credentials or member number already in use', 409)
+    serviceError('Invalid registration details', 400)
   }
 
   // Derive a deterministic internal email from the member number so Supabase Auth
@@ -215,7 +215,7 @@ export async function register(
     // same member number; clean up the orphaned auth user.
     if ((profileError as { code?: string }).code === '23505') {
       await adminClient.auth.admin.deleteUser(userId)
-      serviceError('Invalid credentials or member number already in use', 409)
+      serviceError('Invalid registration details', 400)
     }
     await adminClient.auth.admin.deleteUser(userId)
     serviceError('Failed to create user profile', 500)

--- a/lib/server/auth-service.ts
+++ b/lib/server/auth-service.ts
@@ -176,9 +176,10 @@ export async function register(
   const adminClient = createSupabaseServerAdminClient()
 
   // Check whether the member number is already taken by an existing profile.
+  // Generic message to avoid user enumeration (do not confirm whether the number exists).
   const existing = await getAuthCredentialProfileBy(adminClient, 'member_number', memberNumber)
   if (existing) {
-    serviceError('This member number is already registered', 409)
+    serviceError('Invalid credentials or member number already in use', 409)
   }
 
   // Derive a deterministic internal email from the member number so Supabase Auth
@@ -214,7 +215,7 @@ export async function register(
     // same member number; clean up the orphaned auth user.
     if ((profileError as { code?: string }).code === '23505') {
       await adminClient.auth.admin.deleteUser(userId)
-      serviceError('This member number is already registered', 409)
+      serviceError('Invalid credentials or member number already in use', 409)
     }
     await adminClient.auth.admin.deleteUser(userId)
     serviceError('Failed to create user profile', 500)

--- a/messages/en.json
+++ b/messages/en.json
@@ -52,7 +52,7 @@
       "memberNumberRequired": "Member number is required",
       "memberNumberTooLong": "Member number must not exceed 10 digits",
       "memberNumberNumeric": "Member number must contain only digits",
-      "memberNumberExists": "This member number is already registered"
+      "memberNumberExists": "Invalid credentials or member number already in use"
     }
   },
   "rooms": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -52,7 +52,7 @@
       "memberNumberRequired": "Member number is required",
       "memberNumberTooLong": "Member number must not exceed 10 digits",
       "memberNumberNumeric": "Member number must contain only digits",
-      "memberNumberExists": "Invalid credentials or member number already in use"
+      "memberNumberExists": "Invalid registration details"
     }
   },
   "rooms": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -17,7 +17,8 @@
     "mobileNavAriaLabel": "Mobile navigation",
     "skipToContent": "Skip to main content",
     "logoAriaLabel": "Alea - Home",
-    "menuAriaLabel": "Menu"
+    "menuAriaLabel": "Menu",
+    "switchLocale": "Switch to {locale}"
   },
   "auth": {
     "login": "Sign In", "register": "Register", "logout": "Sign out",
@@ -52,7 +53,7 @@
       "memberNumberRequired": "Member number is required",
       "memberNumberTooLong": "Member number must not exceed 10 digits",
       "memberNumberNumeric": "Member number must contain only digits",
-      "memberNumberExists": "Invalid registration details"
+      "invalidRegistrationDetails": "Invalid registration details"
     }
   },
   "rooms": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -17,7 +17,8 @@
     "mobileNavAriaLabel": "Navegación móvil",
     "skipToContent": "Ir al contenido principal",
     "logoAriaLabel": "Alea - Inicio",
-    "menuAriaLabel": "Menú"
+    "menuAriaLabel": "Menú",
+    "switchLocale": "Cambiar a {locale}"
   },
   "auth": {
     "login": "Iniciar Sesión", "register": "Registrarse", "logout": "Cerrar sesión",
@@ -52,7 +53,7 @@
       "memberNumberRequired": "El número de socio es obligatorio",
       "memberNumberTooLong": "El número de socio no puede superar los 10 dígitos",
       "memberNumberNumeric": "El número de socio solo puede contener dígitos",
-      "memberNumberExists": "Datos de registro inválidos"
+      "invalidRegistrationDetails": "Datos de registro inválidos"
     }
   },
   "rooms": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -52,7 +52,7 @@
       "memberNumberRequired": "El número de socio es obligatorio",
       "memberNumberTooLong": "El número de socio no puede superar los 10 dígitos",
       "memberNumberNumeric": "El número de socio solo puede contener dígitos",
-      "memberNumberExists": "Este número de socio ya está registrado"
+      "memberNumberExists": "Credenciales inválidas o número de socio ya en uso"
     }
   },
   "rooms": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -52,7 +52,7 @@
       "memberNumberRequired": "El número de socio es obligatorio",
       "memberNumberTooLong": "El número de socio no puede superar los 10 dígitos",
       "memberNumberNumeric": "El número de socio solo puede contener dígitos",
-      "memberNumberExists": "Credenciales inválidas o número de socio ya en uso"
+      "memberNumberExists": "Datos de registro inválidos"
     }
   },
   "rooms": {


### PR DESCRIPTION
## Summary

- **BUG-1**: Replace specific registration error messages with generic ones to prevent user enumeration. HTTP status changed from 409 → 400 for duplicate member number. Suspended account login changed from 403 → 401.
- **BUG-2**: Fix navbar disappearing and Mis Reservas breaking when switching locale back to ES. Root cause: outer `<Suspense fallback={null}>` around `<Header>` caused the entire header to suspend. Fixed by isolating `useSearchParams()` in a `LocaleSwitcherLink` sub-component with its own `<Suspense>` boundary.

## Changes

- `lib/server/auth-service.ts` — Generic error messages for duplicate member number (400) and suspended accounts (401)
- `messages/en.json` / `messages/es.json` — Updated `auth.errors.memberNumberExists` key
- `components/layout/header.tsx` — `LocaleSwitcherLink` sub-component with isolated Suspense boundary
- `app/[locale]/layout.tsx` — Removed outer Suspense wrapper around Header

## Test plan

- [ ] Register with a duplicate member number → generic error shown (no confirmation of existence)
- [ ] Switch locale ES → EN → ES → navbar links remain visible at every step
- [ ] Mis Reservas page loads correctly after switching back to ES
- [ ] Login with a suspended account → generic 401 (no suspended account disclosure)

Closes KIM-365 (BUG-1, BUG-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)