### PR TITLE
fix(admin+checkin): admin cancel for pending reservations and check-in timing window

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"2afda68f-ea13-43f4-9807-1b45d90e6f52","pid":1590,"acquiredAt":1776075884243}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"2afda68f-ea13-43f4-9807-1b45d90e6f52","pid":1590,"acquiredAt":1776075884243}

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ pnpm-debug.log
 *.bak
 
 .aia/
+
+# Claude tooling lockfiles (ephemeral, not for commit)
+.claude/*.lock

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -985,11 +985,10 @@ describe('reservations service', () => {
     }
 
     function makeEndTime(startTimeStr: string, durationMinutes: number): string {
-      // Parse the start time and add duration minutes
       const [hh, mm] = startTimeStr.split(':')
       const date = new Date()
-      date.setHours(parseInt(hh!, 10))
-      date.setMinutes(parseInt(mm!, 10) + durationMinutes)
+      date.setHours(parseInt(hh!, 10), parseInt(mm!, 10), 0, 0)
+      date.setTime(date.getTime() + durationMinutes * 60 * 1000)
       const endHh = String(date.getHours()).padStart(2, '0')
       const endMm = String(date.getMinutes()).padStart(2, '0')
       return `${endHh}:${endMm}:00`

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -984,6 +984,17 @@ describe('reservations service', () => {
       return `${hh}:${mm}:00`
     }
 
+    function makeEndTime(startTimeStr: string, durationMinutes: number): string {
+      // Parse the start time and add duration minutes
+      const [hh, mm] = startTimeStr.split(':')
+      const date = new Date()
+      date.setHours(parseInt(hh!, 10))
+      date.setMinutes(parseInt(mm!, 10) + durationMinutes)
+      const endHh = String(date.getHours()).padStart(2, '0')
+      const endMm = String(date.getMinutes()).padStart(2, '0')
+      return `${endHh}:${endMm}:00`
+    }
+
     it('succeeds within the grace period activation window', async () => {
       const { activateReservationByTable } = await loadReservationModules()
 
@@ -1009,7 +1020,8 @@ describe('reservations service', () => {
     it('throws CHECK_IN_TOO_LATE when called more than 20 minutes after start_time', async () => {
       const { activateReservationByTable } = await loadReservationModules()
 
-      seedPendingReservation({ start_time: makeStartTime(25) })
+      const startTime = makeStartTime(25)
+      seedPendingReservation({ start_time: startTime, end_time: makeEndTime(startTime, 20) })
 
       await expect(activateReservationByTable('t3', '2', undefined)).rejects.toMatchObject({
         name: 'ServiceError',
@@ -1101,7 +1113,8 @@ describe('reservations service', () => {
     it('boundary: called at start_time + (21) min throws CHECK_IN_TOO_LATE', async () => {
       const { activateReservationByTable } = await loadReservationModules()
 
-      seedPendingReservation({ start_time: makeStartTime(21) })
+      const startTime = makeStartTime(21)
+      seedPendingReservation({ start_time: startTime, end_time: makeEndTime(startTime, 20) })
 
       await expect(activateReservationByTable('t3', '2', undefined)).rejects.toMatchObject({
         name: 'ServiceError',

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -1017,7 +1017,34 @@ describe('reservations service', () => {
       })
     })
 
-    it('throws CHECK_IN_TOO_LATE when called more than 20 minutes after start_time', async () => {
+    it('boundary: called exactly 15 minutes before start_time (early window opens) succeeds', async () => {
+      const { activateReservationByTable } = await loadReservationModules()
+
+      // now is 14:00:00, start_time is 14:15:00 (15 min in future)
+      // This is exactly at [start - 15min, end_time], so check-in should succeed
+      const startTime = makeStartTime(-15)
+      seedPendingReservation({ start_time: startTime })
+
+      const result = await activateReservationByTable('t3', '2', undefined)
+
+      expect(result.status).toBe('active')
+    })
+
+    it('boundary: called 16 minutes before start_time throws CHECK_IN_TOO_EARLY', async () => {
+      const { activateReservationByTable } = await loadReservationModules()
+
+      // now is 14:00:00, start_time is 14:16:00 (16 min in future)
+      // This is before the early window [start - 15min], so check-in should fail
+      seedPendingReservation({ start_time: makeStartTime(-16) })
+
+      await expect(activateReservationByTable('t3', '2', undefined)).rejects.toMatchObject({
+        name: 'ServiceError',
+        statusCode: 400,
+        message: expect.stringContaining('CHECK_IN_TOO_EARLY'),
+      })
+    })
+
+    it('throws CHECK_IN_TOO_LATE when called after end_time', async () => {
       const { activateReservationByTable } = await loadReservationModules()
 
       const startTime = makeStartTime(25)
@@ -1110,11 +1137,28 @@ describe('reservations service', () => {
       expect(result.status).toBe('active')
     })
 
-    it('boundary: called at start_time + (21) min throws CHECK_IN_TOO_LATE', async () => {
+    it('boundary: called exactly at end_time succeeds', async () => {
       const { activateReservationByTable } = await loadReservationModules()
 
+      // now is 14:00:00, set start_time so end_time is also 14:00:00
+      // At end_time boundary, check-in should succeed (now === reservationEnd, not strictly greater)
+      const startTime = makeStartTime(20)
+      const endTime = makeEndTime(startTime, 20)
+      seedPendingReservation({ start_time: startTime, end_time: endTime })
+
+      const result = await activateReservationByTable('t3', '2', undefined)
+
+      expect(result.status).toBe('active')
+    })
+
+    it('boundary: called just after end_time throws CHECK_IN_TOO_LATE', async () => {
+      const { activateReservationByTable } = await loadReservationModules()
+
+      // now is 14:00:00, set end_time to 13:59:00 (1 minute before now)
+      // This is after end_time, so check-in should fail
       const startTime = makeStartTime(21)
-      seedPendingReservation({ start_time: startTime, end_time: makeEndTime(startTime, 20) })
+      const endTime = makeEndTime(startTime, 19)
+      seedPendingReservation({ start_time: startTime, end_time: endTime })
 
       await expect(activateReservationByTable('t3', '2', undefined)).rejects.toMatchObject({
         name: 'ServiceError',

--- a/components/admin/reservations-section.tsx
+++ b/components/admin/reservations-section.tsx
@@ -140,7 +140,7 @@ export function ReservationsSection() {
                     </Badge>
                   </td>
                   <td className="px-4 py-3.5 text-right">
-                    {r.status === 'active' ? (
+                    {(r.status === 'active' || r.status === 'pending') ? (
                       <Button
                         variant="outline"
                         size="sm"

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -5,15 +5,19 @@
 
 ---
 
-## Last updated: 2026-04-13
-
-## ⚠️ PRESENTACIÓN HOY — 2026-04-14
+## Last updated: 2026-04-14
 
 ## Current branch
 `develop`
 
-## Open PRs
-None — all merged.
+## Open PRs — awaiting merge
+| PR | Branch | Bugs | Status |
+|---|---|---|---|
+| #98 | `fix/i18n-navbar-auth-enumeration` | BUG-1 + BUG-2 | APPROVED ✅ |
+| #99 | `fix/admin-reservations-checkin-timing` | BUG-5 + BUG-6 | APPROVED ✅ |
+| #100 | `fix/ui-qr-icon-responsive-cards` | BUG-3 + BUG-4 | APPROVED ✅ |
+
+All 3 PRs passed 2× Security + 2× QA cycles. All Copilot review comments responded to in English. Merge order: #98 → #99 → #100 (independent, any order is fine).
 
 ## Merged this session
 | PR | Branch | Issues |
@@ -52,24 +56,22 @@ None — all merged.
 - **KIM-357, KIM-359** — checkin hardening — merged PR #86 ✅
 - **KIM-328** — Docker docs cleanup — merged PR #87 ✅
 
-**Smoke test completado 2026-04-13. 6 bugs encontrados — deben estar resueltos antes de la presentación de hoy.**
+**Smoke test completado 2026-04-13. 6 bugs encontrados — todos corregidos en PRs #98–#100.**
 
 ---
 
-## 🔴 Siguiente paso: Fix bugs pre-presentación (KIM-365)
+## ✅ Bugs pre-presentación (KIM-365) — todos en PRs aprobados
 
-Bugs documentados en KIM-365 (comentario 2026-04-13). Orden de prioridad:
+| # | Bug | PR | Estado |
+|---|---|---|---|
+| BUG-1 | Auth: user enumeration en registro | #98 | APPROVED ✅ |
+| BUG-2 | i18n: navbar desaparece al volver a ES | #98 | APPROVED ✅ |
+| BUG-5 | Admin dashboard: acciones en reservas no cargan | #99 | APPROVED ✅ |
+| BUG-6 | Check-in: error "demasiado pronto" dentro de ventana válida | #99 | APPROVED ✅ |
+| BUG-4 | Responsive: cards de mesa mal a 1440px y mobile | #100 | APPROVED ✅ |
+| BUG-3 | UI: icono QR visible a usuarios no-admin | #100 | APPROVED ✅ |
 
-| # | Bug | Prioridad |
-|---|---|---|
-| BUG-1 | Auth: mensaje de registro revela si el número existe (user enumeration) | Urgent |
-| BUG-2 | i18n: navbar desaparece + Mis Reservas rota al volver a ES desde EN | Urgent |
-| BUG-5 | Admin dashboard: acciones en sección reservas no cargan | Urgent |
-| BUG-6 | Check-in: error "demasiado pronto" dentro del horario válido | Urgent |
-| BUG-4 | Responsive: cards de mesa mal a 1440px y mobile | High |
-| BUG-3 | UI: icono QR visible en hover sobre mesa (solo admin debería verlo) | Normal |
-
-**Arrancar con BUG-2 primero** — es el más visible y afecta navegación completa en ES.
+**Siguiente paso: merge de #98, #99, #100 y smoke test final.**
 
 ---
 

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -568,6 +568,10 @@ export async function activateReservationByTable(
 
   const reservation = pendingData as ReservationRow
 
+  if (!reservation.end_time) {
+    serviceError('Invalid reservation data', 500)
+  }
+
   const now = new Date()
   const startTimeParts = normalizeTime(reservation.start_time).split(':')
   const endTimeParts = normalizeTime(reservation.end_time).split(':')
@@ -584,7 +588,7 @@ export async function activateReservationByTable(
     0,
     0,
   )
-  const reservationEnd = new Date(
+  let reservationEnd = new Date(
     parseInt(dateParts[0]!, 10),
     parseInt(dateParts[1]!, 10) - 1,
     parseInt(dateParts[2]!, 10),
@@ -593,6 +597,11 @@ export async function activateReservationByTable(
     0,
     0,
   )
+
+  // If end is at or before start, the reservation spans midnight — advance end by one day.
+  if (reservationEnd <= reservationStart) {
+    reservationEnd.setDate(reservationEnd.getDate() + 1)
+  }
 
   // Allow check-in starting CHECK_IN_EARLY_MINUTES before the slot begins,
   // up to the end of the reserved slot.

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -588,7 +588,7 @@ export async function activateReservationByTable(
     0,
     0,
   )
-  let reservationEnd = new Date(
+  const reservationEnd = new Date(
     parseInt(dateParts[0]!, 10),
     parseInt(dateParts[1]!, 10) - 1,
     parseInt(dateParts[2]!, 10),
@@ -598,9 +598,8 @@ export async function activateReservationByTable(
     0,
   )
 
-  // If end is at or before start, the reservation spans midnight — advance end by one day.
   if (reservationEnd <= reservationStart) {
-    reservationEnd.setDate(reservationEnd.getDate() + 1)
+    serviceError('Invalid reservation data', 500)
   }
 
   // Allow check-in starting CHECK_IN_EARLY_MINUTES before the slot begins,

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -71,6 +71,8 @@ type EnrichedReservationsTableClient = {
 }
 
 export const GRACE_PERIOD_MINUTES = 20
+// How many minutes before the reservation start time check-in is allowed.
+export const CHECK_IN_EARLY_MINUTES = 15
 const CANCELLATION_CUTOFF_MS = 60 * 60 * 1000 // 60 minutes
 
 const RESERVATION_COLUMNS = 'id, table_id, user_id, date, start_time, end_time, status, surface, activated_at, created_at'
@@ -568,6 +570,7 @@ export async function activateReservationByTable(
 
   const now = new Date()
   const startTimeParts = normalizeTime(reservation.start_time).split(':')
+  const endTimeParts = normalizeTime(reservation.end_time).split(':')
   // Anchor on the reservation's own stored date. The server is expected to run
   // in the club timezone (CLUB_TIMEZONE). A full UTC-anchored conversion for
   // the time window requires test fixture updates (tracked separately).
@@ -581,13 +584,24 @@ export async function activateReservationByTable(
     0,
     0,
   )
+  const reservationEnd = new Date(
+    parseInt(dateParts[0]!, 10),
+    parseInt(dateParts[1]!, 10) - 1,
+    parseInt(dateParts[2]!, 10),
+    parseInt(endTimeParts[0]!, 10),
+    parseInt(endTimeParts[1]!, 10),
+    0,
+    0,
+  )
 
-  const windowEnd = new Date(reservationStart.getTime() + GRACE_PERIOD_MINUTES * 60 * 1000)
+  // Allow check-in starting CHECK_IN_EARLY_MINUTES before the slot begins,
+  // up to the end of the reserved slot.
+  const windowStart = new Date(reservationStart.getTime() - CHECK_IN_EARLY_MINUTES * 60 * 1000)
 
-  if (now < reservationStart) {
+  if (now < windowStart) {
     serviceError('CHECK_IN_TOO_EARLY', 400)
   }
-  if (now > windowEnd) {
+  if (now > reservationEnd) {
     serviceError('CHECK_IN_TOO_LATE', 400)
   }
 


### PR DESCRIPTION
## Summary

- **BUG-5**: Admin dashboard reservations tab — cancel button now shows for both \`active\` and \`pending\` reservations (was only \`active\`).
- **BUG-6**: Check-in window now opens 15 minutes before reservation start and closes at \`end_time\`, instead of the narrow \`[start, start+20min]\` window that was rejecting valid activations. Added defensive fast-fail guard for corrupted rows where \`end_time <= start_time\` (which the schema and validation layer prevent from occurring in practice).

## Changes

- \`components/admin/reservations-section.tsx\` — Expanded cancel button condition to include \`pending\` status
- \`lib/server/reservations-service.ts\` — New \`CHECK_IN_EARLY_MINUTES = 15\` constant; window is now \`[start - 15min, end_time]\`; null guard for \`end_time\`; fast-fail on invalid \`end_time <= start_time\` data
- \`__tests__/server/reservations-service.test.ts\` — Updated TOO_LATE tests; added early-window boundary tests; updated boundary tests to use \`end_time\` semantics
- \`.gitignore\` — Added \`.claude/scheduled_tasks.lock\`

## Test plan

- [ ] Admin dashboard → Reservations tab → cancel button visible on pending and active reservations
- [ ] Scan QR 15 min before reservation start → check-in accepted
- [ ] Scan QR at exact start time → check-in accepted
- [ ] Scan QR after \`end_time\` has passed → CHECK_IN_TOO_LATE error

Closes KIM-365 (BUG-5, BUG-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)