### PR TITLE
fix(events): admin force-delete and localize delete error message

### DIFF
--- a/__tests__/app/api/events.test.ts
+++ b/__tests__/app/api/events.test.ts
@@ -663,10 +663,8 @@ describe('Events API routes', () => {
       expect(response.status).toBe(404)
     })
 
-    it('returns 409 when active reservations conflict with event', async () => {
-      deleteEventMock.mockRejectedValue(
-        new ServiceError('Cannot delete event: active or pending reservations exist for this room during the event time', 409),
-      )
+    it('returns 204 on successful delete when event has overlapping reservations (auto-cancelled by service)', async () => {
+      deleteEventMock.mockResolvedValue(undefined)
 
       const { DELETE } = await import('@/app/api/events/[id]/route')
       const response = await DELETE(
@@ -674,22 +672,10 @@ describe('Events API routes', () => {
         { params: Promise.resolve({ id: 'event-1' }) },
       )
 
-      expect(response.status).toBe(409)
+      expect(response.status).toBe(204)
+      expect(deleteEventMock).toHaveBeenCalledWith('event-1')
     })
 
-    it('returns 409 when pending reservations conflict with event', async () => {
-      deleteEventMock.mockRejectedValue(
-        new ServiceError('Cannot delete event: active or pending reservations exist for this room during the event time', 409),
-      )
-
-      const { DELETE } = await import('@/app/api/events/[id]/route')
-      const response = await DELETE(
-        createJsonRequest('/api/events/event-1', undefined, 'DELETE'),
-        { params: Promise.resolve({ id: 'event-1' }) },
-      )
-
-      expect(response.status).toBe(409)
-    })
 
     it('returns 403 when non-admin user tries to delete event', async () => {
       requireAdminMock.mockResolvedValue(

--- a/components/admin/events-section.tsx
+++ b/components/admin/events-section.tsx
@@ -230,8 +230,7 @@ function DeleteEventDialog({
           </p>
           {conflictError && (
             <div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3">
-              <p className="text-sm text-destructive font-medium">{t('events.conflictWarning')}</p>
-              <p className="text-xs text-destructive/80 mt-1">{conflictError}</p>
+              <p className="text-sm text-destructive font-medium">{t('events.deleteError')}</p>
             </div>
           )}
         </div>
@@ -239,22 +238,20 @@ function DeleteEventDialog({
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)} className="border-border">
             {tc('cancel')}
           </Button>
-          {!conflictError && (
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={onConfirm}
-              disabled={isPending}
-              className="min-w-[80px]"
-            >
-              {isPending ? (
-                <span className="inline-flex items-center gap-2">
-                  <DiceLoader size="sm" hideRole />
-                  <span>{tc('loading')}</span>
-                </span>
-              ) : tc('delete')}
-            </Button>
-          )}
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={isPending}
+            className="min-w-[80px]"
+          >
+            {isPending ? (
+              <span className="inline-flex items-center gap-2">
+                <DiceLoader size="sm" hideRole />
+                <span>{tc('loading')}</span>
+              </span>
+            ) : tc('delete')}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/components/admin/events-section.tsx
+++ b/components/admin/events-section.tsx
@@ -199,21 +199,21 @@ function EventFormDialog({
   )
 }
 
-// Conflict warning delete dialog
+// Delete event dialog
 function DeleteEventDialog({
   open,
   onOpenChange,
   event,
   onConfirm,
   isPending,
-  conflictError,
+  deleteError,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   event: AdminEvent | null
   onConfirm: () => void
   isPending: boolean
-  conflictError: string | null
+  deleteError: string | null
 }) {
   const t = useTranslations('admin')
   const tc = useTranslations('common')
@@ -228,8 +228,11 @@ function DeleteEventDialog({
           <p className="text-sm text-muted-foreground">
             {t('deleteEventConfirm', { title: event?.title ?? '' })}
           </p>
-          {conflictError && (
-            <div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3">
+          <p className="text-sm text-muted-foreground">
+            {t('events.deleteWarning')}
+          </p>
+          {deleteError && (
+            <div role="alert" className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3">
               <p className="text-sm text-destructive font-medium">{t('events.deleteError')}</p>
             </div>
           )}
@@ -337,7 +340,7 @@ export function EventsSection() {
   const [editForm, setEditForm] = useState<EventFormState>(emptyForm())
 
   const [deletingEvent, setDeletingEvent] = useState<AdminEvent | null>(null)
-  const [deleteConflictError, setDeleteConflictError] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   const [createError, setCreateError] = useState<string | null>(null)
   const [updateError, setUpdateError] = useState<string | null>(null)
 
@@ -348,7 +351,7 @@ export function EventsSection() {
 
   function openDelete(event: AdminEvent) {
     setDeletingEvent(event)
-    setDeleteConflictError(null)
+    setDeleteError(null)
   }
 
   async function handleCreate(e: React.FormEvent) {
@@ -403,12 +406,12 @@ export function EventsSection() {
     try {
       await deleteEvent.mutateAsync(deletingEvent.id)
       setDeletingEvent(null)
-      setDeleteConflictError(null)
+      setDeleteError(null)
     } catch (err: unknown) {
       const msg = err instanceof Error
         ? err.message
         : (err as { message?: string })?.message ?? String(err)
-      setDeleteConflictError(msg)
+      setDeleteError(msg)
     }
   }
 
@@ -501,11 +504,11 @@ export function EventsSection() {
       {/* Delete Dialog */}
       <DeleteEventDialog
         open={!!deletingEvent}
-        onOpenChange={(open) => { if (!open) { setDeletingEvent(null); setDeleteConflictError(null) } }}
+        onOpenChange={(open) => { if (!open) { setDeletingEvent(null); setDeleteError(null) } }}
         event={deletingEvent}
         onConfirm={handleDelete}
         isPending={deleteEvent.isPending}
-        conflictError={deleteConflictError}
+        deleteError={deleteError}
       />
     </section>
   )

--- a/lib/server/events-service.ts
+++ b/lib/server/events-service.ts
@@ -1,12 +1,10 @@
 import 'server-only'
 import { createSupabaseServerAdminClient, createSupabaseServerClient } from '@/lib/supabase/server'
 import { serviceError } from '@/lib/server/service-error'
-import type { Tables, TablesInsert, TablesUpdate, EventRow, EventRoomBlockRow } from '@/lib/supabase/types'
+import type { TablesInsert, TablesUpdate, EventRow, EventRoomBlockRow } from '@/lib/supabase/types'
 import type { AdminEvent, AdminEventRoomBlock } from '@/lib/types'
 
 export type { AdminEvent, AdminEventRoomBlock }
-
-type ReservationRow = Tables<'reservations'>
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 const TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/
@@ -294,19 +292,16 @@ export async function deleteEvent(id: string): Promise<void> {
     const tableIds = ((tables ?? []) as { id: string }[]).map((t) => t.id)
 
     if (tableIds.length > 0) {
-      const { data: conflicting } = await admin
+      const { error: cancelError } = await admin
         .from('reservations')
-        .select('id')
+        .update({ status: 'cancelled' })
         .in('table_id', tableIds)
         .eq('date', event.date)
         .lt('start_time', event.end_time)
         .gt('end_time', event.start_time)
         .in('status', ['active', 'pending'])
-        .limit(1)
 
-      if (conflicting && (conflicting as ReservationRow[]).length > 0) {
-        serviceError('Cannot delete event: active or pending reservations exist for this room during the event time', 409)
-      }
+      if (cancelError) serviceError('Internal server error', 500)
     }
   }
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -135,7 +135,8 @@
       "deleteEvent": "Delete event",
       "noEvents": "No events found",
       "conflictWarning": "This event cannot be deleted because active or pending reservations exist for the affected room during this time.",
-      "deleteError": "An error occurred while deleting the event. Please try again."
+      "deleteError": "An error occurred while deleting the event. Please try again.",
+      "deleteWarning": "Deleting this event will also cancel any active or pending member reservations for this room during the event time."
     }
   },
   "home": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -134,7 +134,8 @@
       "editEvent": "Edit event",
       "deleteEvent": "Delete event",
       "noEvents": "No events found",
-      "conflictWarning": "This event cannot be deleted because active or pending reservations exist for the affected room during this time."
+      "conflictWarning": "This event cannot be deleted because active or pending reservations exist for the affected room during this time.",
+      "deleteError": "An error occurred while deleting the event. Please try again."
     }
   },
   "home": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -134,7 +134,8 @@
       "deleteEvent": "Eliminar evento",
       "noEvents": "No se encontraron eventos",
       "conflictWarning": "Este evento no se puede eliminar porque existen reservas activas o pendientes para la sala afectada en este horario.",
-      "deleteError": "Se produjo un error al eliminar el evento. Por favor, inténtalo de nuevo."
+      "deleteError": "Se produjo un error al eliminar el evento. Por favor, inténtalo de nuevo.",
+      "deleteWarning": "Eliminar este evento también cancelará las reservas activas o pendientes de los miembros para esta sala durante el horario del evento."
     }
   },
   "home": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -133,7 +133,8 @@
       "editEvent": "Editar evento",
       "deleteEvent": "Eliminar evento",
       "noEvents": "No se encontraron eventos",
-      "conflictWarning": "Este evento no se puede eliminar porque existen reservas activas o pendientes para la sala afectada en este horario."
+      "conflictWarning": "Este evento no se puede eliminar porque existen reservas activas o pendientes para la sala afectada en este horario.",
+      "deleteError": "Se produjo un error al eliminar el evento. Por favor, inténtalo de nuevo."
     }
   },
   "home": {


### PR DESCRIPTION
## Summary

- Admin can now delete events even when active/pending reservations exist — conflicting reservations are automatically cancelled before the event is removed.
- Delete error message in the confirmation dialog is now localized (uses i18n key instead of raw English server string).

## Changes

- \`lib/server/events-service.ts\` — \`deleteEvent\`: cancel conflicting reservations instead of throwing 409
- \`components/admin/events-section.tsx\` — use i18n key for delete error display; delete button is now always shown
- \`messages/en.json\` / \`messages/es.json\` — added \`events.deleteError\` key

## Test plan

- [ ] Admin creates an event that overlaps with an existing active/pending reservation → delete the event → reservation is cancelled, event is removed
- [ ] Delete error (if any) displays in the active locale (ES or EN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)