### PR TITLE
fix(availability): mark end_time slot as unavailable for existing reservations

### DIFF
--- a/__tests__/server/availability.test.ts
+++ b/__tests__/server/availability.test.ts
@@ -124,7 +124,7 @@ describe('generateDaySlots', () => {
   it('leaves slots outside the reserved range as available', () => {
     const slots = generateDaySlots([{ start: '10:00', end: '11:00' }])
     expect(slots.find((s) => s.startTime === '09:00')?.available).toBe(true)
-    expect(slots.find((s) => s.startTime === '11:00')?.available).toBe(true)
+    expect(slots.find((s) => s.startTime === '11:00')?.available).toBe(false)
   })
 
   it('marks multiple reserved slots correctly', () => {
@@ -134,7 +134,14 @@ describe('generateDaySlots', () => {
     ])
     expect(slots.find((s) => s.startTime === '09:00')?.available).toBe(false)
     expect(slots.find((s) => s.startTime === '14:00')?.available).toBe(false)
-    expect(slots.find((s) => s.startTime === '10:00')?.available).toBe(true)
+    expect(slots.find((s) => s.startTime === '10:00')?.available).toBe(false)
+  })
+
+  it('marks the end_time slot as unavailable (end is inclusive)', () => {
+    const slots = generateDaySlots([{ start: '17:00', end: '18:00' }])
+    expect(slots.find((s) => s.startTime === '17:00')?.available).toBe(false)
+    expect(slots.find((s) => s.startTime === '18:00')?.available).toBe(false)
+    expect(slots.find((s) => s.startTime === '19:00')?.available).toBe(true)
   })
 })
 
@@ -164,7 +171,7 @@ describe('buildAvailability', () => {
     const result = buildAvailability(table, '2025-06-15', [reservation])
 
     expect(result.slots.find((s) => s.startTime === '09:00')?.available).toBe(true)
-    expect(result.slots.find((s) => s.startTime === '11:00')?.available).toBe(true)
+    expect(result.slots.find((s) => s.startTime === '11:00')?.available).toBe(false)
   })
 
   it('does not add top/bottom/conflicts for non-removable-top tables', () => {

--- a/lib/server/availability.ts
+++ b/lib/server/availability.ts
@@ -27,7 +27,7 @@ export function generateDaySlots(reservedSlots: Array<{ start: string; end: stri
     const time = `${String(i).padStart(2, '0')}:00`
     const nextHour = i + 1
     const nextTime = nextHour < 24 ? `${String(nextHour).padStart(2, '0')}:00` : '24:00'
-    const isReserved = reservedSlots.some((reservation) => reservation.start <= time && reservation.end > time)
+    const isReserved = reservedSlots.some((reservation) => reservation.start <= time && reservation.end >= time)
     return { startTime: time, endTime: nextTime, available: !isReserved }
   })
 }


### PR DESCRIPTION
## Summary

- Fixes a display bug where the slot at `end_time` appeared available in the reservation dialog even when another user had a reservation ending at that hour.
- Example: reservation 17:00–18:00 now correctly marks **both 17:00 and 18:00 as unavailable**.

## Changes

- `lib/server/availability.ts` — `generateDaySlots`: changed `reservation.end > time` → `reservation.end >= time` (end_time slot is now inclusive/blocked)
- `__tests__/server/availability.test.ts` — updated 3 assertions and added 1 new test to document inclusive end-time semantics

## Root cause

The previous `>` comparison made end_time exclusive: a reservation from 17:00 to 18:00 blocked 17:00 but left 18:00 green. The fix uses `>=` so both the start and end slots are shown as unavailable.

## Test plan

- [ ] User A has a reservation 17:00–18:00 → User B opens reservation dialog → 17:00 appears red, **18:00 also appears red/unavailable**
- [ ] Slot immediately after end_time (19:00) remains green

🤖 Generated with [Claude Code](https://claude.com/claude-code)