### PR TITLE
fix(availability): poll for updates every 30s to reflect concurrent bookings

### DIFF
--- a/__tests__/hooks/use-reservations.test.ts
+++ b/__tests__/hooks/use-reservations.test.ts
@@ -1,4 +1,169 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the API client
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(() => Promise.resolve({})),
+  },
+}))
+
+// Mock the endpoints
+vi.mock('@/lib/api/endpoints', () => ({
+  endpoints: {
+    tables: {
+      availability: (tableId: string, date: string) => `/tables/${tableId}/availability?date=${date}`,
+    },
+    rooms: {
+      tablesAvailability: (roomId: string, date: string) => `/rooms/${roomId}/availability?date=${date}`,
+    },
+  },
+}))
+
+// Capture the options passed to useQuery by mocking @tanstack/react-query
+let capturedUseQueryCalls: Array<{ options: any; hook: string }> = []
+
+const createMockQueryResult = () => ({
+  data: undefined,
+  isLoading: false,
+  isError: false,
+  error: null,
+  isPending: false,
+  isSuccess: false,
+  status: 'pending' as const,
+  isFetching: false,
+  failureCount: 0,
+  failureReason: null,
+  dataUpdatedAt: 0,
+  errorUpdatedAt: 0,
+})
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query')
+  return {
+    ...actual,
+    useQuery: (options: any) => {
+      capturedUseQueryCalls.push({ options, hook: 'useQuery' })
+      return createMockQueryResult()
+    },
+    useMutation: vi.fn((config: any) => ({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+      isPending: false,
+      isError: false,
+      isSuccess: false,
+      error: null,
+      status: 'idle' as const,
+      reset: vi.fn(),
+    })),
+    useQueryClient: vi.fn(() => ({
+      invalidateQueries: vi.fn(),
+    })),
+  }
+})
+
+// Now import the hooks after mocking
+import { useTableAvailability, useRoomAvailability } from '@/lib/hooks/use-reservations'
+import { renderHook } from '@testing-library/react'
+
+describe('useTableAvailability polling configuration', () => {
+  beforeEach(() => {
+    capturedUseQueryCalls = []
+  })
+
+  it('should set staleTime: 0 and refetchInterval: 30_000', () => {
+    const tableId = 'table-1'
+    const date = '2025-06-15'
+
+    renderHook(() => useTableAvailability(tableId, date))
+
+    // Find the call for useTableAvailability
+    expect(capturedUseQueryCalls.length).toBeGreaterThan(0)
+
+    const lastCall = capturedUseQueryCalls[capturedUseQueryCalls.length - 1]
+    const options = lastCall.options
+
+    // Verify the polling configuration
+    expect(options.staleTime).toBe(0)
+    expect(options.refetchInterval).toBe(30_000)
+  })
+
+  it('should not be enabled when tableId is null', () => {
+    capturedUseQueryCalls = []
+    renderHook(() => useTableAvailability(null, '2025-06-15'))
+
+    expect(capturedUseQueryCalls.length).toBeGreaterThan(0)
+    const lastCall = capturedUseQueryCalls[capturedUseQueryCalls.length - 1]
+    expect(lastCall.options.enabled).toBe(false)
+  })
+
+  it('should not be enabled when date is null', () => {
+    capturedUseQueryCalls = []
+    renderHook(() => useTableAvailability('table-1', null))
+
+    expect(capturedUseQueryCalls.length).toBeGreaterThan(0)
+    const lastCall = capturedUseQueryCalls[capturedUseQueryCalls.length - 1]
+    expect(lastCall.options.enabled).toBe(false)
+  })
+
+  it('should be enabled when both tableId and date are provided', () => {
+    capturedUseQueryCalls = []
+    renderHook(() => useTableAvailability('table-1', '2025-06-15'))
+
+    expect(capturedUseQueryCalls.length).toBeGreaterThan(0)
+    const lastCall = capturedUseQueryCalls[capturedUseQueryCalls.length - 1]
+    expect(lastCall.options.enabled).toBe(true)
+  })
+})
+
+describe('useRoomAvailability polling configuration', () => {
+  beforeEach(() => {
+    capturedUseQueryCalls = []
+  })
+
+  it('should set staleTime: 0 and refetchInterval: 60_000', () => {
+    const roomId = 'room-1'
+    const date = '2025-06-15'
+
+    renderHook(() => useRoomAvailability(roomId, date))
+
+    // Find the call for useRoomAvailability
+    expect(capturedUseQueryCalls.length).toBeGreaterThan(0)
+
+    const lastCall = capturedUseQueryCalls[capturedUseQueryCalls.length - 1]
+    const options = lastCall.options
+
+    // Verify the polling configuration
+    expect(options.staleTime).toBe(0)
+    expect(options.refetchInterval).toBe(60_000)
+  })
+
+  it('should not be enabled when roomId is null', () => {
+    capturedUseQueryCalls = []
+    renderHook(() => useRoomAvailability(null, '2025-06-15'))
+
+    expect(capturedUseQueryCalls.length).toBeGreaterThan(0)
+    const lastCall = capturedUseQueryCalls[capturedUseQueryCalls.length - 1]
+    expect(lastCall.options.enabled).toBe(false)
+  })
+
+  it('should not be enabled when date is null', () => {
+    capturedUseQueryCalls = []
+    renderHook(() => useRoomAvailability('room-1', null))
+
+    expect(capturedUseQueryCalls.length).toBeGreaterThan(0)
+    const lastCall = capturedUseQueryCalls[capturedUseQueryCalls.length - 1]
+    expect(lastCall.options.enabled).toBe(false)
+  })
+
+  it('should be enabled when both roomId and date are provided', () => {
+    capturedUseQueryCalls = []
+    renderHook(() => useRoomAvailability('room-1', '2025-06-15'))
+
+    expect(capturedUseQueryCalls.length).toBeGreaterThan(0)
+    const lastCall = capturedUseQueryCalls[capturedUseQueryCalls.length - 1]
+    expect(lastCall.options.enabled).toBe(true)
+  })
+})
 
 // Business logic unit tests for removable_top tables
 describe('Removable top table availability logic', () => {

--- a/lib/hooks/use-reservations.ts
+++ b/lib/hooks/use-reservations.ts
@@ -24,6 +24,8 @@ export function useTableAvailability(tableId: string | null, date: string | null
     queryKey: ['availability', tableId, date],
     queryFn: () => apiClient.get<TableAvailability>(endpoints.tables.availability(tableId!, date!)),
     enabled: !!tableId && !!date,
+    staleTime: 0,
+    refetchInterval: 30_000,
   })
 }
 
@@ -32,6 +34,8 @@ export function useRoomAvailability(roomId: string | null, date: string | null) 
     queryKey: ['availability', 'room', roomId, date],
     queryFn: () => apiClient.get<Record<string, TableAvailability>>(endpoints.rooms.tablesAvailability(roomId!, date!)),
     enabled: !!roomId && !!date,
+    staleTime: 0,
+    refetchInterval: 60_000,
   })
 }
 


### PR DESCRIPTION
## Summary

- Fixes a stale-data bug where User A's reservation dialog showed incorrect (outdated) slot availability if User B booked a slot while User A had the dialog open.
- The dialog now automatically refreshes availability every 30 seconds, so concurrent reservations become visible without closing and reopening.

## Changes

- `lib/hooks/use-reservations.ts`:
  - `useTableAvailability`: added `staleTime: 0` + `refetchInterval: 30_000` (dialog polls every 30s)
  - `useRoomAvailability`: added `staleTime: 0` + `refetchInterval: 60_000` (rooms overview refreshes every 60s)

## Root cause

`useTableAvailability` only invalidated the cache when the **current user** created a reservation. Availability changes made by other users were invisible until the component unmounted and remounted.

## Test plan

- [ ] User A opens reservation dialog for a table → User B books a slot on the same table and date → within 30 seconds, the slot User B booked appears red in User A's open dialog (without closing/reopening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)