### PR TITLE
[KIM-376] Support all-day event room blocking

### DIFF
--- a/__tests__/components/rooms/reservation-dialog.test.tsx
+++ b/__tests__/components/rooms/reservation-dialog.test.tsx
@@ -81,6 +81,18 @@ describe('ReservationDialog', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 
+  it('uses translated availability labels in slot aria-labels', () => {
+    render(
+      <ReservationDialog
+        table={mockTable}
+        open={true}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByRole('button', { name: /\d{2}:\d{2} — available/ }).length).toBeGreaterThan(0)
+  })
+
   it('does not render when table is null', () => {
     render(
       <ReservationDialog

--- a/__tests__/server/availability.test.ts
+++ b/__tests__/server/availability.test.ts
@@ -102,8 +102,8 @@ describe('generateDaySlots', () => {
 
   it('first slot starts at 00:00 and last slot ends at 24:00', () => {
     const slots = generateDaySlots([])
-    expect(slots[0]).toEqual({ startTime: '00:00', endTime: '01:00', available: true })
-    expect(slots[23]).toEqual({ startTime: '23:00', endTime: '24:00', available: true })
+    expect(slots[0]).toMatchObject({ startTime: '00:00', endTime: '01:00', available: true })
+    expect(slots[23]).toMatchObject({ startTime: '23:00', endTime: '24:00', available: true })
   })
 
   it('each slot has startTime, endTime and available fields', () => {

--- a/__tests__/server/events-service.test.ts
+++ b/__tests__/server/events-service.test.ts
@@ -607,6 +607,53 @@ describe('events-service — updateEvent with cancellation', () => {
     )
   })
 
+  it('keeps existing room when allDay is updated without roomId', async () => {
+    const mock = buildSupabaseMock()
+    mock.rpc.mockResolvedValueOnce({
+      data: {
+        id: 'evt-1',
+        title: 'Updated Event',
+        description: null,
+        date: '2026-04-20',
+        start_time: '00:00',
+        end_time: '23:59',
+        created_by: null,
+        created_at: '2026-04-13T00:00:00Z',
+        room_blocks: [
+          {
+            id: 'block-1',
+            event_id: 'evt-1',
+            room_id: 'room-1',
+            date: '2026-04-20',
+            start_time: '00:00',
+            end_time: '23:59',
+            all_day: true,
+          },
+        ],
+      },
+      error: null,
+    })
+
+    const { createSupabaseServerAdminClient } = await import('@/lib/supabase/server')
+    vi.mocked(createSupabaseServerAdminClient).mockReturnValue(mock as any)
+
+    const { updateEvent } = await import('@/lib/server/events-service')
+
+    const result = await updateEvent('evt-update-1', {
+      allDay: true,
+    })
+
+    expect(result.allDay).toBe(true)
+    expect(mock.rpc).toHaveBeenCalledWith(
+      'update_event_atomic',
+      expect.objectContaining({
+        p_id: 'evt-update-1',
+        p_room_id: 'room-1',
+        p_all_day: true,
+      })
+    )
+  })
+
   it('updates room when roomId is provided', async () => {
     const mock = buildSupabaseMock()
     mock.rpc.mockResolvedValueOnce({
@@ -754,5 +801,32 @@ describe('events-service — updateEvent with cancellation', () => {
 
     expect(caught).toBeDefined()
     expect(caught?.statusCode).toBe(500)
+  })
+
+  it('rejects non-hour event start times', async () => {
+    const mock = buildSupabaseMock()
+
+    const { createSupabaseServerAdminClient } = await import('@/lib/supabase/server')
+    vi.mocked(createSupabaseServerAdminClient).mockReturnValue(mock as any)
+
+    const { createEvent } = await import('@/lib/server/events-service')
+
+    let caught: ServiceError | undefined
+    try {
+      await createEvent({
+        title: 'Test Event',
+        date: '2026-04-20',
+        startTime: '18:30',
+        endTime: '20:00',
+        roomId: 'room-1',
+      })
+    } catch (err) {
+      caught = err as ServiceError
+    }
+
+    expect(caught).toBeDefined()
+    expect(caught?.message).toBe('startTime must be on a whole-hour boundary')
+    expect(caught?.statusCode).toBe(400)
+    expect(mock.rpc).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -544,6 +544,34 @@ describe('reservations service', () => {
       })
     })
 
+    it('rejects create when an overlapping event room block exists', async () => {
+      const { createReservationForSession } = await loadReservationModules()
+      reservationsState.forEach((reservation) => {
+        reservation.user_id = 'other-user'
+      })
+
+      eventRoomBlocksState.push({
+        id: 'block-1',
+        event_id: 'event-1',
+        room_id: 'room-1',
+        date: '2026-12-31',
+        start_time: '17:00:00',
+        end_time: '19:00:00',
+        all_day: false,
+      })
+
+      await expect(createReservationForSession(memberSession, {
+        tableId: 't2',
+        date: '2026-12-31',
+        startTime: '17:30',
+        endTime: '18:30',
+      })).rejects.toMatchObject({
+        name: 'ServiceError',
+        message: 'ROOM_BLOCKED_BY_EVENT',
+        statusCode: 409,
+      })
+    })
+
     it('rejects a reservation that overlaps an existing slot for the same user', async () => {
       const { createReservationForSession } = await loadReservationModules()
       await expect(
@@ -756,6 +784,29 @@ describe('reservations service', () => {
 
       expect(updated.startTime).toBe('00:00')
       expect(updated.endTime).toBe('01:00')
+    })
+
+    it('rejects updates that move into an event-blocked range', async () => {
+      const { updateReservationForSession } = await loadReservationModules()
+
+      eventRoomBlocksState.push({
+        id: 'block-2',
+        event_id: 'event-2',
+        room_id: 'room-1',
+        date: '2026-12-31',
+        start_time: '18:00:00',
+        end_time: '20:00:00',
+        all_day: false,
+      })
+
+      await expect(updateReservationForSession(memberSession, 'r1', {
+        startTime: '18:30',
+        endTime: '19:30',
+      })).rejects.toMatchObject({
+        name: 'ServiceError',
+        message: 'ROOM_BLOCKED_BY_EVENT',
+        statusCode: 409,
+      })
     })
 
     it('ignores the current reservation when checking conflicts during updates', async () => {

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -32,6 +32,16 @@ type RoomRow = {
   name: string
 }
 
+type EventRoomBlockRow = {
+  id: string
+  event_id: string
+  room_id: string
+  date: string
+  start_time: string
+  end_time: string
+  all_day: boolean
+}
+
 const adminSession: SessionUser = {
   id: '1',
   role: 'admin',
@@ -46,6 +56,7 @@ const reservationsState: ReservationRow[] = []
 const tablesState = new Map<string, TableRow>()
 const profilesMap = new Map<string, { member_number: string }>()
 const roomsMap = new Map<string, RoomRow>()
+const eventRoomBlocksState: EventRoomBlockRow[] = []
 
 function makeReservation(overrides?: Partial<ReservationRow>): ReservationRow {
   return {
@@ -104,6 +115,7 @@ function seedState() {
   })
 
   reservationsState.length = 0
+  eventRoomBlocksState.length = 0
 
   const r1base = makeReservation()
   const t1 = tablesState.get(r1base.table_id)!
@@ -258,6 +270,12 @@ vi.mock('@/lib/supabase/server', () => ({
   })),
   createSupabaseServerAdminClient: vi.fn(() => ({
     from: vi.fn((table: string) => {
+      if (table === 'event_room_blocks') {
+        return {
+          select: vi.fn(() => buildSelectChain(eventRoomBlocksState)),
+        }
+      }
+
       if (table !== 'reservations') {
         throw new Error(`Unexpected admin table ${table}`)
       }

--- a/__tests__/server/rooms-service.test.ts
+++ b/__tests__/server/rooms-service.test.ts
@@ -36,6 +36,30 @@ vi.mock('@/lib/supabase/server', () => ({
         }
       }
 
+      if (table === 'event_room_blocks') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(async () => ({
+                data: [],
+                error: null,
+              })),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'events') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn(async () => ({
+              data: [],
+              error: null,
+            })),
+          })),
+        }
+      }
+
       return {
         select: vi.fn(() => ({
           eq: vi.fn(() => ({
@@ -74,6 +98,30 @@ vi.mock('@/lib/supabase/server', () => ({
           insert: vi.fn(() => ({
             select: vi.fn(() => ({
               maybeSingle: maybeSingleMock,
+            })),
+          })),
+        }
+      }
+
+      if (table === 'event_room_blocks') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(async () => ({
+                data: [],
+                error: null,
+              })),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'events') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn(async () => ({
+              data: [],
+              error: null,
             })),
           })),
         }

--- a/components/admin/events-section.tsx
+++ b/components/admin/events-section.tsx
@@ -7,6 +7,7 @@ import { DiceLoader } from '@/components/ui/dice-loader'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Badge } from '@/components/ui/badge'
 import {
@@ -33,10 +34,11 @@ interface EventFormState {
   startTime: string
   endTime: string
   roomId: string
+  allDay: boolean
 }
 
 function emptyForm(): EventFormState {
-  return { title: '', description: '', date: '', startTime: '', endTime: '', roomId: NONE_ROOM }
+  return { title: '', description: '', date: '', startTime: '', endTime: '', roomId: NONE_ROOM, allDay: false }
 }
 
 function formFromEvent(event: AdminEvent): EventFormState {
@@ -47,6 +49,7 @@ function formFromEvent(event: AdminEvent): EventFormState {
     startTime: event.startTime,
     endTime: event.endTime,
     roomId: event.roomBlocks[0]?.roomId ?? NONE_ROOM,
+    allDay: event.allDay,
   }
 }
 
@@ -134,6 +137,25 @@ function EventFormDialog({
               </SelectContent>
             </Select>
           </div>
+          <div className="flex items-start gap-3 rounded-lg border border-border bg-background-secondary/60 px-3 py-3">
+            <Checkbox
+              id={id('all-day')}
+              checked={form.allDay}
+              onCheckedChange={(checked) => setForm({
+                ...form,
+                allDay: checked === true,
+                startTime: checked === true ? '' : form.startTime,
+                endTime: checked === true ? '' : form.endTime,
+              })}
+              className="mt-0.5"
+            />
+            <div className="space-y-1">
+              <Label htmlFor={id('all-day')} className="text-sm text-foreground font-medium">
+                {t('events.allDay')}
+              </Label>
+              <p className="text-xs text-muted-foreground">{t('events.allDayHelp')}</p>
+            </div>
+          </div>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <div className="space-y-2">
               <Label htmlFor={id('date')} className="text-sm text-muted-foreground font-medium">
@@ -148,32 +170,36 @@ function EventFormDialog({
                 className="bg-background-secondary border-border focus:border-primary/50"
               />
             </div>
-            <div className="space-y-2">
-              <Label htmlFor={id('start')} className="text-sm text-muted-foreground font-medium">
-                {t('events.startTime')}
-              </Label>
-              <Input
-                id={id('start')}
-                type="time"
-                value={form.startTime}
-                onChange={field('startTime')}
-                required
-                className="bg-background-secondary border-border focus:border-primary/50"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor={id('end')} className="text-sm text-muted-foreground font-medium">
-                {t('events.endTime')}
-              </Label>
-              <Input
-                id={id('end')}
-                type="time"
-                value={form.endTime}
-                onChange={field('endTime')}
-                required
-                className="bg-background-secondary border-border focus:border-primary/50"
-              />
-            </div>
+            {!form.allDay && (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor={id('start')} className="text-sm text-muted-foreground font-medium">
+                    {t('events.startTime')}
+                  </Label>
+                  <Input
+                    id={id('start')}
+                    type="time"
+                    value={form.startTime}
+                    onChange={field('startTime')}
+                    required={!form.allDay}
+                    className="bg-background-secondary border-border focus:border-primary/50"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={id('end')} className="text-sm text-muted-foreground font-medium">
+                    {t('events.endTime')}
+                  </Label>
+                  <Input
+                    id={id('end')}
+                    type="time"
+                    value={form.endTime}
+                    onChange={field('endTime')}
+                    required={!form.allDay}
+                    className="bg-background-secondary border-border focus:border-primary/50"
+                  />
+                </div>
+              </>
+            )}
           </div>
           {error && (
             <div role="alert" className="rounded-md bg-destructive/15 border border-destructive/30 px-3 py-2 text-sm text-destructive">
@@ -271,6 +297,7 @@ function EventRow({
   onEdit: (event: AdminEvent) => void
   onDelete: (event: AdminEvent) => void
 }) {
+  const t = useTranslations('admin')
   const tc = useTranslations('common')
   const { data: rooms } = useAdminRooms()
   const hasRoom = event.roomBlocks.length > 0
@@ -291,11 +318,16 @@ function EventRow({
               {event.date}
             </Badge>
             <span className="text-xs text-muted-foreground">
-              {event.startTime.slice(0, 5)} – {event.endTime.slice(0, 5)}
+              {event.allDay ? t('events.allDay') : `${event.startTime.slice(0, 5)} – ${event.endTime.slice(0, 5)}`}
             </span>
             {hasRoom && roomName && (
               <Badge variant="partial" className="text-xs">
                 {roomName}
+              </Badge>
+            )}
+            {event.allDay && (
+              <Badge variant="outline" className="text-xs">
+                {t('events.allDay')}
               </Badge>
             )}
           </div>
@@ -362,9 +394,10 @@ export function EventsSection() {
         title: createForm.title.trim(),
         description: createForm.description.trim() || null,
         date: createForm.date,
-        startTime: createForm.startTime,
-        endTime: createForm.endTime,
+        startTime: createForm.allDay ? undefined : createForm.startTime,
+        endTime: createForm.allDay ? undefined : createForm.endTime,
         roomId: createForm.roomId === NONE_ROOM ? null : createForm.roomId,
+        allDay: createForm.allDay,
       })
       setCreateForm(emptyForm())
       setShowCreate(false)
@@ -387,9 +420,10 @@ export function EventsSection() {
           title: editForm.title.trim(),
           description: editForm.description.trim() || null,
           date: editForm.date,
-          startTime: editForm.startTime,
-          endTime: editForm.endTime,
+          startTime: editForm.allDay ? undefined : editForm.startTime,
+          endTime: editForm.allDay ? undefined : editForm.endTime,
           roomId: editForm.roomId === NONE_ROOM ? null : editForm.roomId,
+          allDay: editForm.allDay,
         },
       })
       setEditingEvent(null)

--- a/components/admin/events-section.tsx
+++ b/components/admin/events-section.tsx
@@ -179,6 +179,7 @@ function EventFormDialog({
                   <Input
                     id={id('start')}
                     type="time"
+                    step={3600}
                     value={form.startTime}
                     onChange={field('startTime')}
                     required={!form.allDay}
@@ -192,6 +193,7 @@ function EventFormDialog({
                   <Input
                     id={id('end')}
                     type="time"
+                    step={3600}
                     value={form.endTime}
                     onChange={field('endTime')}
                     required={!form.allDay}

--- a/components/rooms/reservation-dialog.tsx
+++ b/components/rooms/reservation-dialog.tsx
@@ -261,7 +261,7 @@ export function ReservationDialog({ table, open, onClose }: ReservationDialogPro
                           : undefined}
                         aria-label={!available && slotDetails?.source === 'event'
                           ? `${time} — ${t('eventBlocked')}: ${slotDetails.label ?? t('eventBlockLabel')}`
-                          : `${time} — ${available ? 'disponible' : 'ocupado'}`}
+                          : `${time} — ${available ? t('available') : t('occupied')}`}
                         aria-pressed={isStart || isEnd || !!isInRange}
                         aria-disabled={!available}
                       >

--- a/components/rooms/reservation-dialog.tsx
+++ b/components/rooms/reservation-dialog.tsx
@@ -63,6 +63,15 @@ export function ReservationDialog({ table, open, onClose }: ReservationDialogPro
     return slot?.available ?? true
   }
 
+  function getSlotDetails(time: string, surface?: TableSurface) {
+    if (!availability) return undefined
+    if (table?.type === 'removable_top' && surface) {
+      const surfaceSlots = surface === 'top' ? availability.top : availability.bottom
+      return surfaceSlots?.find((slot) => slot.startTime === time)
+    }
+    return availability.slots.find((slot) => slot.startTime === time)
+  }
+
   function handleSurfaceSelect(surface: TableSurface) {
     setSelectedSurface(surface)
     setSelectedStartTime(null)
@@ -99,6 +108,8 @@ export function ReservationDialog({ table, open, onClose }: ReservationDialogPro
         setError(t('errors.userSlotConflict'))
       } else if (errorCode === 'Cannot make a reservation in the past') {
         setError(t('errors.pastDate'))
+      } else if (errorCode === 'ROOM_BLOCKED_BY_EVENT') {
+        setError(t('errors.eventBlocked'))
       } else {
         setError(t('errors.generic'))
       }
@@ -212,6 +223,7 @@ export function ReservationDialog({ table, open, onClose }: ReservationDialogPro
                 >
                   {timeSlots.map((time) => {
                     const available = isSlotAvailable(time, selectedSurface ?? undefined)
+                    const slotDetails = getSlotDetails(time, selectedSurface ?? undefined)
                     const isStart = selectedStartTime === time
                     const isEnd = selectedEndTime === time
                     const isInRange =
@@ -244,15 +256,34 @@ export function ReservationDialog({ table, open, onClose }: ReservationDialogPro
                               )
                             : 'border border-crimson/40 bg-crimson-dark/30 text-destructive/70 cursor-not-allowed line-through'
                         )}
-                        aria-label={`${time} — ${available ? 'disponible' : 'ocupado'}`}
+                        title={!available && slotDetails?.source === 'event'
+                          ? `${t('eventBlocked')}: ${slotDetails.label ?? t('eventBlockLabel')}`
+                          : undefined}
+                        aria-label={!available && slotDetails?.source === 'event'
+                          ? `${time} — ${t('eventBlocked')}: ${slotDetails.label ?? t('eventBlockLabel')}`
+                          : `${time} — ${available ? 'disponible' : 'ocupado'}`}
                         aria-pressed={isStart || isEnd || !!isInRange}
                         aria-disabled={!available}
                       >
-                        {time}
+                        {!available && slotDetails?.source === 'event' ? `E ${time}` : time}
                       </button>
                     )
                   })}
                 </div>
+              )}
+
+              {availability?.slots.some((slot) => !slot.available && slot.source === 'event') && (
+                <p className="text-xs text-muted-foreground">
+                  {t('eventBlocked')}
+                  {': '}
+                  {[
+                    ...new Set(
+                      availability.slots
+                        .filter((slot) => !slot.available && slot.source === 'event')
+                        .map((slot) => slot.label ?? t('eventBlockLabel')),
+                    ),
+                  ].join(', ')}
+                </p>
               )}
 
               {selectedStartTime && !selectedEndTime && (

--- a/lib/hooks/use-admin.ts
+++ b/lib/hooks/use-admin.ts
@@ -142,7 +142,7 @@ export function useAdminEvents() {
 export function useAdminCreateEvent() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (data: { title: string; description?: string | null; date: string; startTime: string; endTime: string; roomId?: string | null }) =>
+    mutationFn: (data: { title: string; description?: string | null; date: string; startTime?: string; endTime?: string; roomId?: string | null; allDay?: boolean }) =>
       apiClient.post<AdminEvent>(endpoints.events.list, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'events'] })
@@ -153,7 +153,7 @@ export function useAdminCreateEvent() {
 export function useAdminUpdateEvent() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: { title?: string; description?: string | null; date?: string; startTime?: string; endTime?: string; roomId?: string | null } }) =>
+    mutationFn: ({ id, data }: { id: string; data: { title?: string; description?: string | null; date?: string; startTime?: string; endTime?: string; roomId?: string | null; allDay?: boolean } }) =>
       apiClient.put<AdminEvent>(endpoints.events.byId(id), data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'events'] })

--- a/lib/server/availability.ts
+++ b/lib/server/availability.ts
@@ -3,6 +3,13 @@ import type { Tables } from '@/lib/supabase/types'
 import { serviceError } from '@/lib/server/service-error'
 
 type ReservationRow = Tables<'reservations'>
+type ReservedSlot = {
+  start: string
+  end: string
+  surface?: 'top' | 'bottom'
+  source?: 'reservation' | 'event'
+  label?: string | null
+}
 
 export function resolveDate(date?: string | null): string {
   const today = new Date().toISOString().split('T')[0]
@@ -22,35 +29,61 @@ export function normalizeTime(time: string) {
   return time.slice(0, 5)
 }
 
-export function generateDaySlots(reservedSlots: Array<{ start: string; end: string }>): TimeSlot[] {
+export function generateDaySlots(reservedSlots: ReservedSlot[]): TimeSlot[] {
   return Array.from({ length: 24 }, (_, i) => {
     const time = `${String(i).padStart(2, '0')}:00`
     const nextHour = i + 1
     const nextTime = nextHour < 24 ? `${String(nextHour).padStart(2, '0')}:00` : '24:00'
-    const isReserved = reservedSlots.some((reservation) => reservation.start <= time && reservation.end >= time)
-    return { startTime: time, endTime: nextTime, available: !isReserved }
+    const reservation = reservedSlots.find((item) => item.start <= time && item.end >= time)
+    return {
+      startTime: time,
+      endTime: nextTime,
+      available: !reservation,
+      source: reservation?.source,
+      label: reservation?.label ?? null,
+    }
   })
 }
 
-export function buildAvailability(table: GameTable, date: string, reservations: ReservationRow[]): TableAvailability {
+export function buildAvailability(
+  table: GameTable,
+  date: string,
+  reservations: ReservationRow[],
+  eventBlocks: Array<{ start: string; end: string; label?: string | null }> = [],
+): TableAvailability {
   const reserved = reservations.map((reservation) => ({
     start: normalizeTime(reservation.start_time),
     end: normalizeTime(reservation.end_time),
     surface: reservation.surface ?? undefined,
+    source: 'reservation' as const,
+    label: null,
   }))
+  const blockedByEvents = eventBlocks.map((block) => ({
+    start: block.start,
+    end: block.end,
+    source: 'event' as const,
+    label: block.label ?? null,
+  }))
+  const combinedReserved = [...reserved, ...blockedByEvents]
 
   const availability: TableAvailability = {
     tableId: table.id,
     date,
-    slots: generateDaySlots(reserved),
+    slots: generateDaySlots(combinedReserved),
   }
 
   if (table.type === 'removable_top') {
-    const topReserved = reserved.filter((reservation) => reservation.surface == null || reservation.surface === 'top')
-    const bottomReserved = reserved.filter((reservation) => reservation.surface == null || reservation.surface === 'bottom')
+    const topReserved = [
+      ...reserved.filter((reservation) => reservation.surface == null || reservation.surface === 'top'),
+      ...blockedByEvents,
+    ]
+    const bottomReserved = [
+      ...reserved.filter((reservation) => reservation.surface == null || reservation.surface === 'bottom'),
+      ...blockedByEvents,
+    ]
     availability.top = generateDaySlots(topReserved)
     availability.bottom = generateDaySlots(bottomReserved)
-    availability.conflicts = generateDaySlots(reserved)
+    availability.conflicts = generateDaySlots(combinedReserved)
   }
 
   return availability

--- a/lib/server/events-service.ts
+++ b/lib/server/events-service.ts
@@ -8,11 +8,14 @@ export type { AdminEvent, AdminEventRoomBlock }
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 const TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/
+const WHOLE_HOUR_TIME_RE = /^([01]\d|2[0-3]):00$/
 
 function validateDateTimeFields(date: string, startTime: string, endTime: string): void {
   if (!DATE_RE.test(date)) serviceError('date must be in YYYY-MM-DD format', 400)
   if (!TIME_RE.test(startTime)) serviceError('startTime must be in HH:MM format', 400)
   if (!TIME_RE.test(endTime)) serviceError('endTime must be in HH:MM format', 400)
+  if (!WHOLE_HOUR_TIME_RE.test(startTime)) serviceError('startTime must be on a whole-hour boundary', 400)
+  if (!WHOLE_HOUR_TIME_RE.test(endTime)) serviceError('endTime must be on a whole-hour boundary', 400)
   if (endTime <= startTime) serviceError('endTime must be after startTime', 400)
 }
 
@@ -213,7 +216,7 @@ export async function updateEvent(
   // Resolve room: if body.roomId is present use it (null means remove), otherwise load existing block
   let roomId: string | null
   let currentAllDay = false
-  if (body.roomId !== undefined || body.allDay === undefined) {
+  if (body.roomId === undefined || body.allDay === undefined) {
     const { data: existingBlocks } = await admin
       .from('event_room_blocks')
       .select('room_id, all_day')

--- a/lib/server/events-service.ts
+++ b/lib/server/events-service.ts
@@ -16,7 +16,22 @@ function validateDateTimeFields(date: string, startTime: string, endTime: string
   if (endTime <= startTime) serviceError('endTime must be after startTime', 400)
 }
 
+function parseAllDay(value: unknown): boolean {
+  return value === true || value === 'true'
+}
+
+function resolveEventTimes(date: string, startTime: string, endTime: string, allDay: boolean) {
+  if (!DATE_RE.test(date)) serviceError('date must be in YYYY-MM-DD format', 400)
+  if (allDay) {
+    return { startTime: '00:00', endTime: '23:59' }
+  }
+
+  validateDateTimeFields(date, startTime, endTime)
+  return { startTime, endTime }
+}
+
 function toAdminEvent(row: EventRow, blocks: EventRoomBlockRow[]): AdminEvent {
+  const inferredAllDay = row.start_time.slice(0, 5) === '00:00' && row.end_time.slice(0, 5) === '23:59'
   return {
     id: row.id,
     title: row.title,
@@ -32,12 +47,15 @@ function toAdminEvent(row: EventRow, blocks: EventRoomBlockRow[]): AdminEvent {
       date: b.date,
       startTime: b.start_time,
       endTime: b.end_time,
+      allDay: b.all_day,
     })),
+    allDay: blocks.some((b) => b.all_day) || inferredAllDay,
   }
 }
 
 function jsonToAdminEvent(obj: Record<string, unknown>): AdminEvent {
   const rawBlocks = Array.isArray(obj.room_blocks) ? obj.room_blocks : []
+  const inferredAllDay = String(obj.start_time).slice(0, 5) === '00:00' && String(obj.end_time).slice(0, 5) === '23:59'
   return {
     id: String(obj.id),
     title: String(obj.title),
@@ -55,8 +73,10 @@ function jsonToAdminEvent(obj: Record<string, unknown>): AdminEvent {
         date: String(block.date),
         startTime: String(block.start_time),
         endTime: String(block.end_time),
+        allDay: Boolean(block.all_day),
       }
     }),
+    allDay: rawBlocks.some((b: unknown) => Boolean((b as Record<string, unknown>).all_day)) || inferredAllDay,
   }
 }
 
@@ -121,15 +141,14 @@ export async function createEvent(body: {
   endTime?: unknown
   roomId?: unknown
   createdBy?: unknown
+  allDay?: unknown
 }): Promise<AdminEvent> {
   const title = String(body.title).trim()
   if (!title) serviceError('Title is required', 400)
 
   const date = String(body.date).trim()
-  const startTime = String(body.startTime).trim()
-  const endTime = String(body.endTime).trim()
-
-  validateDateTimeFields(date, startTime, endTime)
+  const allDay = parseAllDay(body.allDay)
+  const resolvedTimes = resolveEventTimes(date, String(body.startTime ?? '').trim(), String(body.endTime ?? '').trim(), allDay)
 
   const description = body.description ? String(body.description).trim() : null
   const roomId = body.roomId ? String(body.roomId).trim() : null
@@ -140,9 +159,10 @@ export async function createEvent(body: {
     p_title: title,
     p_description: description,
     p_date: date,
-    p_start_time: startTime,
-    p_end_time: endTime,
+    p_start_time: resolvedTimes.startTime,
+    p_end_time: resolvedTimes.endTime,
     p_room_id: roomId,
+    p_all_day: allDay,
   })
 
   if (rpcError) serviceError('Internal server error', 500)
@@ -159,6 +179,7 @@ export async function updateEvent(
     startTime?: unknown
     endTime?: unknown
     roomId?: unknown
+    allDay?: unknown
   },
 ): Promise<AdminEvent> {
   const admin = createSupabaseServerAdminClient()
@@ -184,35 +205,40 @@ export async function updateEvent(
         : String(body.description).trim() || null
       : currentRow.description
   const date = body.date !== undefined ? String(body.date).trim() || currentRow.date : currentRow.date
-  const startTime =
+  const inputStartTime =
     body.startTime !== undefined ? String(body.startTime).trim() || currentRow.start_time : currentRow.start_time
-  const endTime =
+  const inputEndTime =
     body.endTime !== undefined ? String(body.endTime).trim() || currentRow.end_time : currentRow.end_time
-
-  validateDateTimeFields(date, startTime, endTime)
 
   // Resolve room: if body.roomId is present use it (null means remove), otherwise load existing block
   let roomId: string | null
-  if (body.roomId !== undefined) {
-    roomId = body.roomId ? String(body.roomId).trim() : null
-  } else {
+  let currentAllDay = false
+  if (body.roomId !== undefined || body.allDay === undefined) {
     const { data: existingBlocks } = await admin
       .from('event_room_blocks')
-      .select('room_id')
+      .select('room_id, all_day')
       .eq('event_id', id)
       .limit(1)
-    const firstBlock = (existingBlocks ?? [])[0] as { room_id: string } | undefined
-    roomId = firstBlock ? firstBlock.room_id : null
+    const firstBlock = (existingBlocks ?? [])[0] as { room_id: string; all_day: boolean } | undefined
+    currentAllDay = firstBlock?.all_day ?? false
+    roomId = body.roomId !== undefined
+      ? (body.roomId ? String(body.roomId).trim() : null)
+      : (firstBlock ? firstBlock.room_id : null)
+  } else {
+    roomId = body.roomId ? String(body.roomId).trim() : null
   }
+  const allDay = body.allDay !== undefined ? parseAllDay(body.allDay) : currentAllDay
+  const resolvedTimes = resolveEventTimes(date, inputStartTime, inputEndTime, allDay)
 
   const { data: result, error: rpcError } = await admin.rpc('update_event_atomic', {
     p_id: id,
     p_title: title,
     p_description: description,
     p_date: date,
-    p_start_time: startTime,
-    p_end_time: endTime,
+    p_start_time: resolvedTimes.startTime,
+    p_end_time: resolvedTimes.endTime,
     p_room_id: roomId,
+    p_all_day: allDay,
   })
 
   if (rpcError) serviceError('Internal server error', 500)

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -175,6 +175,7 @@ async function hasEventBlockConflict(input: {
     .eq('date', input.date)
     .lt('start_time', input.endTime)
     .gt('end_time', input.startTime)
+    .limit(1)
 
   if (error) {
     serviceError('Internal server error', 500)

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -150,7 +150,7 @@ async function getTable(tableId: string) {
   const supabase = await createSupabaseServerClient()
   const tables = supabase.from('tables') as unknown as TablesLookupClient
   const { data, error } = await tables
-    .select('id, type')
+    .select('id, type, room_id')
     .eq('id', tableId)
     .maybeSingle()
 
@@ -159,6 +159,28 @@ async function getTable(tableId: string) {
   }
 
   return data as TableRow | null
+}
+
+async function hasEventBlockConflict(input: {
+  roomId: string
+  date: string
+  startTime: string
+  endTime: string
+}) {
+  const admin = createSupabaseServerAdminClient()
+  const { data, error } = await admin
+    .from('event_room_blocks')
+    .select('id')
+    .eq('room_id', input.roomId)
+    .eq('date', input.date)
+    .lt('start_time', input.endTime)
+    .gt('end_time', input.startTime)
+
+  if (error) {
+    serviceError('Internal server error', 500)
+  }
+
+  return Boolean(data && data.length > 0)
 }
 
 async function getReservationForAccess(reservationId: string) {
@@ -349,6 +371,9 @@ export async function createReservationForSession(
   if (hasReservationConflict(conflictingReservations, { startTime, endTime, surface })) {
     serviceError('Time slot is already reserved', 409)
   }
+  if (await hasEventBlockConflict({ roomId: table.room_id, date, startTime, endTime })) {
+    serviceError('ROOM_BLOCKED_BY_EVENT', 409)
+  }
   const insertPayload: TablesInsert<'reservations'> = {
     table_id: tableId,
     user_id: session.id,
@@ -418,6 +443,11 @@ export async function updateReservationForSession(
   const nextSurface = body.surface === undefined || body.surface === null
     ? (existingReservation.surface ?? null)
     : (parseSurface(body.surface) ?? (existingReservation.surface ?? null))
+  const table = await getTable(existingReservation.table_id)
+
+  if (!table) {
+    serviceError('Table not found', 404)
+  }
 
   if (nextStartTime >= nextEndTime) {
     serviceError('Invalid reservation time range', 400)
@@ -434,6 +464,14 @@ export async function updateReservationForSession(
     surface: nextSurface ?? undefined,
   })) {
     serviceError('Time slot is already reserved', 409)
+  }
+  if (await hasEventBlockConflict({
+    roomId: table.room_id,
+    date: nextDate,
+    startTime: nextStartTime,
+    endTime: nextEndTime,
+  })) {
+    serviceError('ROOM_BLOCKED_BY_EVENT', 409)
   }
 
   const supabase = await createSupabaseServerClient()

--- a/lib/server/rooms-service.ts
+++ b/lib/server/rooms-service.ts
@@ -233,16 +233,18 @@ export async function getRoomTablesAvailability(roomId: string, date?: string | 
     reservationsByTable.set(reservation.table_id, items)
   }
 
+  const eventSlots = eventBlocks.map((block) => ({
+    start: block.start_time.slice(0, 5),
+    end: block.end_time.slice(0, 5),
+    label: eventTitleById.get(block.event_id) ?? null,
+  }))
+
   return tables.reduce<Record<string, TableAvailability>>((acc, table) => {
     acc[table.id] = buildAvailability(
       table,
       effectiveDate,
       reservationsByTable.get(table.id) ?? [],
-      eventBlocks.map((block) => ({
-        start: block.start_time.slice(0, 5),
-        end: block.end_time.slice(0, 5),
-        label: eventTitleById.get(block.event_id) ?? null,
-      })),
+      eventSlots,
     )
     return acc
   }, {})

--- a/lib/server/rooms-service.ts
+++ b/lib/server/rooms-service.ts
@@ -8,6 +8,7 @@ import { regenerateQrCodes } from '@/lib/server/tables-service'
 type RoomRow = Tables<'rooms'>
 type TableRow = Tables<'tables'>
 type ReservationRow = Tables<'reservations'>
+type EventBlockRow = Tables<'event_room_blocks'>
 type RoomsTableClient = {
   select: (columns: string) => {
     order: (column: string, options: { ascending: boolean }) => Promise<{ data: RoomRow[] | null; error: unknown }>
@@ -197,6 +198,34 @@ export async function getRoomTablesAvailability(roomId: string, date?: string | 
     serviceError('Internal server error', 500)
   }
 
+  const eventBlocksResult = await admin
+    .from('event_room_blocks')
+    .select('id, event_id, room_id, date, start_time, end_time, all_day')
+    .eq('room_id', roomId)
+    .eq('date', effectiveDate)
+  const eventBlocks = (eventBlocksResult.data ?? []) as EventBlockRow[]
+
+  if (eventBlocksResult.error) {
+    serviceError('Internal server error', 500)
+  }
+
+  let eventTitleById = new Map<string, string>()
+  const eventIds = [...new Set(eventBlocks.map((block) => block.event_id))]
+  if (eventIds.length > 0) {
+    const eventsResult = await admin
+      .from('events')
+      .select('id, title')
+      .in('id', eventIds)
+
+    if (eventsResult.error) {
+      serviceError('Internal server error', 500)
+    }
+
+    eventTitleById = new Map(
+      ((eventsResult.data ?? []) as Array<{ id: string; title: string }>).map((event) => [event.id, event.title]),
+    )
+  }
+
   const reservationsByTable = new Map<string, ReservationRow[]>()
   for (const reservation of (data ?? []) as ReservationRow[]) {
     const items = reservationsByTable.get(reservation.table_id) ?? []
@@ -205,7 +234,16 @@ export async function getRoomTablesAvailability(roomId: string, date?: string | 
   }
 
   return tables.reduce<Record<string, TableAvailability>>((acc, table) => {
-    acc[table.id] = buildAvailability(table, effectiveDate, reservationsByTable.get(table.id) ?? [])
+    acc[table.id] = buildAvailability(
+      table,
+      effectiveDate,
+      reservationsByTable.get(table.id) ?? [],
+      eventBlocks.map((block) => ({
+        start: block.start_time.slice(0, 5),
+        end: block.end_time.slice(0, 5),
+        label: eventTitleById.get(block.event_id) ?? null,
+      })),
+    )
     return acc
   }, {})
 }

--- a/lib/server/tables-service.ts
+++ b/lib/server/tables-service.ts
@@ -7,6 +7,7 @@ import type { Tables } from '@/lib/supabase/types'
 
 type TableRow = Tables<'tables'>
 type ReservationRow = Tables<'reservations'>
+type EventBlockRow = Tables<'event_room_blocks'>
 
 const TABLE_COLUMNS = 'id, room_id, name, type, qr_code, qr_code_inf, pos_x, pos_y'
 
@@ -132,5 +133,42 @@ export async function getTableAvailability(tableId: string, date?: string | null
     serviceError('Internal server error', 500)
   }
 
-  return buildAvailability(toGameTable(table!), effectiveDate, reservations)
+  const eventBlocksResult = await admin
+    .from('event_room_blocks')
+    .select('id, event_id, room_id, date, start_time, end_time, all_day')
+    .eq('room_id', table.room_id)
+    .eq('date', effectiveDate)
+  const eventBlocks = (eventBlocksResult.data ?? []) as EventBlockRow[]
+
+  if (eventBlocksResult.error) {
+    serviceError('Internal server error', 500)
+  }
+
+  let eventTitleById = new Map<string, string>()
+  const eventIds = [...new Set(eventBlocks.map((block) => block.event_id))]
+  if (eventIds.length > 0) {
+    const eventsResult = await admin
+      .from('events')
+      .select('id, title')
+      .in('id', eventIds)
+
+    if (eventsResult.error) {
+      serviceError('Internal server error', 500)
+    }
+
+    eventTitleById = new Map(
+      ((eventsResult.data ?? []) as Array<{ id: string; title: string }>).map((event) => [event.id, event.title]),
+    )
+  }
+
+  return buildAvailability(
+    toGameTable(table),
+    effectiveDate,
+    reservations,
+    eventBlocks.map((block) => ({
+      start: block.start_time.slice(0, 5),
+      end: block.end_time.slice(0, 5),
+      label: eventTitleById.get(block.event_id) ?? null,
+    })),
+  )
 }

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -36,6 +36,7 @@ export type Database = {
     Tables: {
       event_room_blocks: {
         Row: {
+          all_day: boolean
           date: string
           end_time: string
           event_id: string
@@ -44,6 +45,7 @@ export type Database = {
           start_time: string
         }
         Insert: {
+          all_day?: boolean
           date: string
           end_time: string
           event_id: string
@@ -52,6 +54,7 @@ export type Database = {
           start_time: string
         }
         Update: {
+          all_day?: boolean
           date?: string
           end_time?: string
           event_id?: string

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -57,6 +57,8 @@ export interface TimeSlot {
   startTime: string; // HH:mm
   endTime: string;   // HH:mm
   available: boolean;
+  source?: 'reservation' | 'event';
+  label?: string | null;
 }
 
 export interface TableAvailability {
@@ -82,6 +84,7 @@ export interface AdminEventRoomBlock {
   date: string
   startTime: string
   endTime: string
+  allDay: boolean
 }
 
 export interface AdminEvent {
@@ -93,6 +96,7 @@ export interface AdminEvent {
   endTime: string
   createdBy: string | null
   createdAt: string
+  allDay: boolean
   roomBlocks: AdminEventRoomBlock[]
 }
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -83,11 +83,14 @@
     "occupied": "Occupied", "myReservation": "My reservation",
     "calendar": "Availability calendar",
     "canceling": "Canceling...", "confirmCancel": "Yes, cancel", "submitting": "Submitting...",
+    "eventBlocked": "Blocked by event",
+    "eventBlockLabel": "Reserved - Event",
     "errors": {
       "conflictTime": "A reservation already exists at that time",
       "pastDate": "You cannot book dates in the past",
       "invalidTime": "End time must be after start time",
       "userSlotConflict": "You already have a reservation in this time slot",
+      "eventBlocked": "This time slot is blocked by an event.",
       "cancellationCutoff": "This reservation cannot be cancelled — it starts in less than 60 minutes.",
       "generic": "Something went wrong. Please try again."
     }
@@ -128,6 +131,8 @@
       "title": "Events",
       "description": "Description",
       "room": "Room",
+      "allDay": "All day",
+      "allDayHelp": "Reserve selected room for the full day without setting start and end times.",
       "startTime": "Start time",
       "endTime": "End time",
       "createEvent": "Create event",

--- a/messages/es.json
+++ b/messages/es.json
@@ -83,11 +83,14 @@
     "occupied": "Ocupado", "myReservation": "Mi reserva",
     "calendar": "Calendario de disponibilidad",
     "canceling": "Cancelando...", "confirmCancel": "Sí, cancelar", "submitting": "Reservando...",
+    "eventBlocked": "Bloqueado por evento",
+    "eventBlockLabel": "Reservado - Evento",
     "errors": {
       "conflictTime": "Ya existe una reserva en ese horario",
       "pastDate": "No puedes reservar en fechas pasadas",
       "invalidTime": "La hora de fin debe ser posterior a la de inicio",
       "userSlotConflict": "Ya tienes una reserva en este horario",
+      "eventBlocked": "Este horario está bloqueado por un evento.",
       "cancellationCutoff": "Esta reserva no se puede cancelar: comienza en menos de 60 minutos.",
       "generic": "Algo salió mal. Por favor, inténtalo de nuevo."
     }
@@ -127,6 +130,8 @@
       "title": "Eventos",
       "description": "Descripción",
       "room": "Sala",
+      "allDay": "Todo el día",
+      "allDayHelp": "Reserva la sala seleccionada durante todo el día sin indicar hora de inicio ni fin.",
       "startTime": "Hora de inicio",
       "endTime": "Hora de fin",
       "createEvent": "Crear evento",

--- a/supabase/migrations/20260413000002_event_room_blocks_all_day.sql
+++ b/supabase/migrations/20260413000002_event_room_blocks_all_day.sql
@@ -7,6 +7,8 @@
 ALTER TABLE public.event_room_blocks
   ADD COLUMN IF NOT EXISTS all_day boolean NOT NULL DEFAULT false;
 
+DROP FUNCTION IF EXISTS public.create_event_atomic(text, text, date, time, time, uuid);
+
 CREATE OR REPLACE FUNCTION public.create_event_atomic(
   p_title       text,
   p_description text,
@@ -80,6 +82,8 @@ BEGIN
   );
 END;
 $$;
+
+DROP FUNCTION IF EXISTS public.update_event_atomic(uuid, text, text, date, time, time, uuid);
 
 CREATE OR REPLACE FUNCTION public.update_event_atomic(
   p_id          uuid,

--- a/supabase/migrations/20260413000002_event_room_blocks_all_day.sql
+++ b/supabase/migrations/20260413000002_event_room_blocks_all_day.sql
@@ -1,0 +1,169 @@
+-- ============================================================
+-- Alea Webapp — Event room blocks all-day support
+-- Migration: 20260413000002_event_room_blocks_all_day.sql
+-- KIM-376
+-- ============================================================
+
+ALTER TABLE public.event_room_blocks
+  ADD COLUMN IF NOT EXISTS all_day boolean NOT NULL DEFAULT false;
+
+CREATE OR REPLACE FUNCTION public.create_event_atomic(
+  p_title       text,
+  p_description text,
+  p_date        date,
+  p_start_time  time,
+  p_end_time    time,
+  p_room_id     uuid,
+  p_all_day     boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  v_event       public.events%ROWTYPE;
+  v_block       public.event_room_blocks%ROWTYPE;
+  v_table_ids   uuid[];
+  v_blocks_json jsonb;
+  v_start_time  time := CASE WHEN COALESCE(p_all_day, false) THEN '00:00'::time ELSE p_start_time END;
+  v_end_time    time := CASE WHEN COALESCE(p_all_day, false) THEN '23:59'::time ELSE p_end_time END;
+BEGIN
+  INSERT INTO public.events (title, description, date, start_time, end_time)
+  VALUES (p_title, p_description, p_date, v_start_time, v_end_time)
+  RETURNING * INTO v_event;
+
+  v_blocks_json := '[]'::jsonb;
+
+  IF p_room_id IS NOT NULL THEN
+    INSERT INTO public.event_room_blocks (event_id, room_id, date, start_time, end_time, all_day)
+    VALUES (v_event.id, p_room_id, p_date, v_start_time, v_end_time, COALESCE(p_all_day, false))
+    RETURNING * INTO v_block;
+
+    v_blocks_json := jsonb_build_array(
+      jsonb_build_object(
+        'id',         v_block.id,
+        'event_id',   v_block.event_id,
+        'room_id',    v_block.room_id,
+        'date',       v_block.date,
+        'start_time', v_block.start_time,
+        'end_time',   v_block.end_time,
+        'all_day',    v_block.all_day
+      )
+    );
+
+    SELECT ARRAY(
+      SELECT id FROM public.tables WHERE room_id = p_room_id
+    ) INTO v_table_ids;
+
+    IF array_length(v_table_ids, 1) > 0 THEN
+      UPDATE public.reservations
+      SET status = 'cancelled'
+      WHERE table_id = ANY(v_table_ids)
+        AND date = p_date
+        AND start_time < v_end_time
+        AND end_time > v_start_time
+        AND status IN ('active', 'pending');
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'id',          v_event.id,
+    'title',       v_event.title,
+    'description', v_event.description,
+    'date',        v_event.date,
+    'start_time',  v_event.start_time,
+    'end_time',    v_event.end_time,
+    'created_by',  v_event.created_by,
+    'created_at',  v_event.created_at,
+    'room_blocks', v_blocks_json
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_event_atomic(
+  p_id          uuid,
+  p_title       text,
+  p_description text,
+  p_date        date,
+  p_start_time  time,
+  p_end_time    time,
+  p_room_id     uuid,
+  p_all_day     boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  v_event       public.events%ROWTYPE;
+  v_block       public.event_room_blocks%ROWTYPE;
+  v_table_ids   uuid[];
+  v_blocks_json jsonb;
+  v_start_time  time := CASE WHEN COALESCE(p_all_day, false) THEN '00:00'::time ELSE p_start_time END;
+  v_end_time    time := CASE WHEN COALESCE(p_all_day, false) THEN '23:59'::time ELSE p_end_time END;
+BEGIN
+  UPDATE public.events
+  SET
+    title       = p_title,
+    description = p_description,
+    date        = p_date,
+    start_time  = v_start_time,
+    end_time    = v_end_time
+  WHERE id = p_id
+  RETURNING * INTO v_event;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Event not found: %', p_id;
+  END IF;
+
+  DELETE FROM public.event_room_blocks WHERE event_id = p_id;
+
+  v_blocks_json := '[]'::jsonb;
+
+  IF p_room_id IS NOT NULL THEN
+    INSERT INTO public.event_room_blocks (event_id, room_id, date, start_time, end_time, all_day)
+    VALUES (p_id, p_room_id, p_date, v_start_time, v_end_time, COALESCE(p_all_day, false))
+    RETURNING * INTO v_block;
+
+    v_blocks_json := jsonb_build_array(
+      jsonb_build_object(
+        'id',         v_block.id,
+        'event_id',   v_block.event_id,
+        'room_id',    v_block.room_id,
+        'date',       v_block.date,
+        'start_time', v_block.start_time,
+        'end_time',   v_block.end_time,
+        'all_day',    v_block.all_day
+      )
+    );
+
+    SELECT ARRAY(
+      SELECT id FROM public.tables WHERE room_id = p_room_id
+    ) INTO v_table_ids;
+
+    IF array_length(v_table_ids, 1) > 0 THEN
+      UPDATE public.reservations
+      SET status = 'cancelled'
+      WHERE table_id = ANY(v_table_ids)
+        AND date = p_date
+        AND start_time < v_end_time
+        AND end_time > v_start_time
+        AND status IN ('active', 'pending');
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'id',          v_event.id,
+    'title',       v_event.title,
+    'description', v_event.description,
+    'date',        v_event.date,
+    'start_time',  v_event.start_time,
+    'end_time',    v_event.end_time,
+    'created_by',  v_event.created_by,
+    'created_at',  v_event.created_at,
+    'room_blocks', v_blocks_json
+  );
+END;
+$$;


### PR DESCRIPTION
## Summary

This PR adds all-day event room blocking so admins can reserve an entire room for a full day and the reservation flow treats those blocks as unavailable time.

## What changed

- added `all_day` support to `event_room_blocks` and updated the atomic event RPCs to store all-day room blocks as `00:00` to `23:59`
- updated admin event create/edit UI to support an all-day toggle and hide time inputs when it is enabled
- merged event blocks into room and table availability responses, including event labels for blocked slots
- blocked reservation create/update requests when the selected table's room is covered by an event block
- improved reservation dialog feedback so event-blocked slots are labeled in the UI and return a specific error message
- extended server tests around availability, rooms, and reservations for event-blocked scenarios

## Why

Previously, room blocking was time-based only. Admins could not mark a room as unavailable for the whole day, and user reservation flows did not surface event-based room blocks clearly enough.

## Impact

- admins can create or edit events that block a room for the full day
- users can see which slots are blocked by events before submitting a reservation
- reservation mutations now reject conflicts caused by event room blocks instead of only reservation overlaps
- existing overlapping active or pending reservations are cancelled when an all-day room block is created or updated through the atomic event RPCs

## Validation

- `pnpm test -- --runTestsByPath __tests__/server/availability.test.ts __tests__/server/reservations-service.test.ts __tests__/server/rooms-service.test.ts`
- result: Vitest ran the full suite in this repo and passed: `29` test files, `416` tests

## Ticket

- KIM-376
