### PR TITLE
fix(time): align database-backed timestamps and club-time comparisons

### DIFF
--- a/__tests__/components/reservations/my-reservations-view.test.tsx
+++ b/__tests__/components/reservations/my-reservations-view.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MyReservationsView } from '@/components/reservations/my-reservations-view'
+import { getCurrentClubDate } from '@/lib/club-time'
 import type { Reservation } from '@/lib/types'
 
 // Mock next-intl
@@ -31,7 +32,7 @@ vi.mock('@/lib/hooks/use-reservations', () => ({
 
 // Mock utility functions
 vi.mock('@/lib/utils', () => ({
-  formatDate: (date: string) => new Date(date).toLocaleDateString(),
+  formatDate: (date: string) => date ? new Date(date).toLocaleDateString() : '',
   formatTime: (time: string) => time,
   cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
 }))
@@ -59,18 +60,17 @@ function createReservation(overrides: Partial<Reservation> = {}): Reservation {
 function createReservationWithTimeOffset(minutesFromNow: number, overrides: Partial<Reservation> = {}): Reservation {
   const now = new Date()
   const startTime = new Date(now.getTime() + minutesFromNow * 60 * 1000)
-  const y = startTime.getFullYear()
-  const mo = String(startTime.getMonth() + 1).padStart(2, '0')
-  const d = String(startTime.getDate()).padStart(2, '0')
-  const date = `${y}-${mo}-${d}`
-  const hours = String(startTime.getHours()).padStart(2, '0')
-  const minutes = String(startTime.getMinutes()).padStart(2, '0')
-  const startTimeStr = `${hours}:${minutes}`
+  const date = getCurrentClubDate(startTime)
+  const timeFormatter = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Atlantic/Canary',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+  const startTimeStr = timeFormatter.format(startTime)
 
   const endTime = new Date(startTime.getTime() + 2 * 60 * 60 * 1000)
-  const endHours = String(endTime.getHours()).padStart(2, '0')
-  const endMinutes = String(endTime.getMinutes()).padStart(2, '0')
-  const endTimeStr = `${endHours}:${endMinutes}`
+  const endTimeStr = timeFormatter.format(endTime)
 
   return createReservation({
     date,
@@ -83,6 +83,11 @@ function createReservationWithTimeOffset(minutesFromNow: number, overrides: Part
 describe('MyReservationsView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-04-15T16:00:00.000Z').getTime())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   describe('Loading state', () => {

--- a/__tests__/components/reservations/my-reservations-view.test.tsx
+++ b/__tests__/components/reservations/my-reservations-view.test.tsx
@@ -5,6 +5,18 @@ import { MyReservationsView } from '@/components/reservations/my-reservations-vi
 import { getCurrentClubDate } from '@/lib/club-time'
 import type { Reservation } from '@/lib/types'
 
+vi.mock('@/lib/club-time', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/club-time')>('@/lib/club-time')
+  const testTimeZone = 'Atlantic/Canary'
+
+  return {
+    ...actual,
+    CLUB_TIMEZONE: testTimeZone,
+    getCurrentClubDate: (now: Date = new Date()) => actual.getCurrentClubDate(now, testTimeZone),
+    zonedDateTimeToUtc: (date: string, time: string) => actual.zonedDateTimeToUtc(date, time, testTimeZone),
+  }
+})
+
 // Mock next-intl
 vi.mock('next-intl', () => ({
   useTranslations: (namespace: string) => (key: string) => {
@@ -38,6 +50,7 @@ vi.mock('@/lib/utils', () => ({
 }))
 
 const CANCELLATION_CUTOFF_MS = 60 * 60 * 1000 // 60 minutes
+const TEST_TIME_ZONE = 'Atlantic/Canary'
 
 // Helper to create reservations with different times
 function createReservation(overrides: Partial<Reservation> = {}): Reservation {
@@ -58,11 +71,11 @@ function createReservation(overrides: Partial<Reservation> = {}): Reservation {
 
 // Helper to create a reservation with a specific time offset from now
 function createReservationWithTimeOffset(minutesFromNow: number, overrides: Partial<Reservation> = {}): Reservation {
-  const now = new Date()
+  const now = new Date(Date.now())
   const startTime = new Date(now.getTime() + minutesFromNow * 60 * 1000)
-  const date = getCurrentClubDate(startTime)
+  const date = getCurrentClubDate(startTime, TEST_TIME_ZONE)
   const timeFormatter = new Intl.DateTimeFormat('en-GB', {
-    timeZone: 'Atlantic/Canary',
+    timeZone: TEST_TIME_ZONE,
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,

--- a/__tests__/lib/club-time.test.ts
+++ b/__tests__/lib/club-time.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getCurrentClubDate, isValidDateOnlyString, zonedDateTimeToUtc } from '@/lib/club-time'
+
+describe('club-time helpers', () => {
+  it('returns today in the configured club timezone instead of UTC date rollover', () => {
+    const now = new Date('2026-04-15T23:30:00.000Z')
+
+    expect(getCurrentClubDate(now, 'Atlantic/Canary')).toBe('2026-04-16')
+    expect(getCurrentClubDate(now, 'America/New_York')).toBe('2026-04-15')
+  })
+
+  it('validates date-only strings without relying on Date parsing quirks', () => {
+    expect(isValidDateOnlyString('2026-02-28')).toBe(true)
+    expect(isValidDateOnlyString('2026-02-30')).toBe(false)
+    expect(isValidDateOnlyString('2026/02/28')).toBe(false)
+  })
+
+  it('converts club-local civil time into the matching UTC instant', () => {
+    expect(zonedDateTimeToUtc('2026-06-15', '16:00', 'Atlantic/Canary').toISOString()).toBe('2026-06-15T15:00:00.000Z')
+    expect(zonedDateTimeToUtc('2026-01-15', '16:00', 'Atlantic/Canary').toISOString()).toBe('2026-01-15T16:00:00.000Z')
+  })
+})

--- a/__tests__/server/auth-activation.test.ts
+++ b/__tests__/server/auth-activation.test.ts
@@ -37,6 +37,11 @@ const activationTokensByHash = new Map<string, ActivationTokenRow>()
 
 const updateUserByIdMock = vi.fn()
 const activationTokenUpsertMock = vi.fn()
+const databaseTimeRpcMock = vi.fn(async (fn: string) => (
+  fn === 'get_database_time'
+    ? { data: '2026-04-15T10:30:00.000Z', error: null }
+    : { data: null, error: null }
+))
 
 function hashToken(token: string) {
   return createHash('sha256').update(token).digest('hex')
@@ -100,6 +105,7 @@ vi.mock('@/lib/supabase/server', () => ({
         updateUserById: updateUserByIdMock,
       },
     },
+    rpc: databaseTimeRpcMock,
     from: vi.fn((table: 'profiles' | 'activation_tokens') => {
       if (table === 'profiles') {
         return {
@@ -222,6 +228,7 @@ describe('auth activation helpers', () => {
     activationTokensByHash.clear()
     updateUserByIdMock.mockResolvedValue({ error: null })
     activationTokenUpsertMock.mockClear()
+    databaseTimeRpcMock.mockClear()
 
     const profile = seedProfile()
     profilesById.set(profile.id, profile)

--- a/__tests__/server/auth-recovery.test.ts
+++ b/__tests__/server/auth-recovery.test.ts
@@ -37,6 +37,11 @@ const activationTokensByHash = new Map<string, ActivationTokenRow>()
 
 const updateUserByIdMock = vi.fn()
 const activationTokenUpsertMock = vi.fn()
+const databaseTimeRpcMock = vi.fn(async (fn: string) => (
+  fn === 'get_database_time'
+    ? { data: '2026-04-15T10:30:00.000Z', error: null }
+    : { data: null, error: null }
+))
 
 function hashToken(token: string) {
   return createHash('sha256').update(token).digest('hex')
@@ -100,6 +105,7 @@ vi.mock('@/lib/supabase/server', () => ({
         updateUserById: updateUserByIdMock,
       },
     },
+    rpc: databaseTimeRpcMock,
     from: vi.fn((table: 'profiles' | 'activation_tokens') => {
       if (table === 'profiles') {
         return {
@@ -222,6 +228,7 @@ describe('auth recovery helpers', () => {
     activationTokensByHash.clear()
     updateUserByIdMock.mockResolvedValue({ error: null })
     activationTokenUpsertMock.mockClear()
+    databaseTimeRpcMock.mockClear()
 
     const profile = seedProfile()
     profilesById.set(profile.id, profile)

--- a/__tests__/server/database-time.test.ts
+++ b/__tests__/server/database-time.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createSupabaseServerAdminClient = vi.fn()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createSupabaseServerAdminClient,
+}))
+
+async function loadModule() {
+  return import('@/lib/server/database-time')
+}
+
+describe('database-time', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('returns the parsed database timestamp from rpc', async () => {
+    createSupabaseServerAdminClient.mockReturnValue({
+      rpc: vi.fn(async () => ({ data: '2026-04-15T16:00:00.000Z', error: null })),
+    })
+
+    const { getDatabaseNow } = await loadModule()
+
+    await expect(getDatabaseNow()).resolves.toEqual(new Date('2026-04-15T16:00:00.000Z'))
+  })
+
+  it('throws when the admin client cannot provide rpc access', async () => {
+    createSupabaseServerAdminClient.mockReturnValue({})
+
+    const { getDatabaseNow } = await loadModule()
+
+    await expect(getDatabaseNow()).rejects.toMatchObject({
+      name: 'ServiceError',
+      statusCode: 500,
+    })
+  })
+
+  it('throws when rpc returns an unexpected payload', async () => {
+    createSupabaseServerAdminClient.mockReturnValue({
+      rpc: vi.fn(async () => undefined),
+    })
+
+    const { getDatabaseNow } = await loadModule()
+
+    await expect(getDatabaseNow()).rejects.toMatchObject({
+      name: 'ServiceError',
+      statusCode: 500,
+    })
+  })
+})

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -1619,7 +1619,10 @@ describe('reservations service', () => {
       const { cancelExpiredPendingReservations, GRACE_PERIOD_MINUTES } = await import('@/lib/server/reservations-service')
       const result = await cancelExpiredPendingReservations()
 
-      expect(mockRpc).toHaveBeenCalledWith('cancel_expired_pending_reservations', { grace_minutes: GRACE_PERIOD_MINUTES })
+      expect(mockRpc).toHaveBeenCalledWith('cancel_expired_pending_reservations', {
+        grace_minutes: GRACE_PERIOD_MINUTES,
+        club_timezone: process.env.CLUB_TIMEZONE ?? 'Atlantic/Canary',
+      })
       expect(result).toBe(3)
     })
 
@@ -1661,7 +1664,9 @@ describe('reservations service', () => {
       const { markNoShowReservations } = await import('@/lib/server/reservations-service')
       const result = await markNoShowReservations()
 
-      expect(mockRpc).toHaveBeenCalledWith('mark_no_show_reservations')
+      expect(mockRpc).toHaveBeenCalledWith('mark_no_show_reservations', {
+        club_timezone: process.env.CLUB_TIMEZONE ?? 'Atlantic/Canary',
+      })
       expect(result).toBe(2)
     })
 

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -58,6 +58,15 @@ const profilesMap = new Map<string, { member_number: string }>()
 const roomsMap = new Map<string, RoomRow>()
 const eventRoomBlocksState: EventRoomBlockRow[] = []
 
+function createDatabaseTimeRpc() {
+  return vi.fn(async (fn: string) => {
+    if (fn === 'get_database_time') {
+      return { data: new Date(Date.now()).toISOString(), error: null }
+    }
+    return { data: null, error: null }
+  })
+}
+
 function makeReservation(overrides?: Partial<ReservationRow>): ReservationRow {
   return {
     id: 'r1',
@@ -309,7 +318,7 @@ vi.mock('@/lib/supabase/server', () => ({
         }),
       }
     }),
-    rpc: vi.fn(),
+    rpc: createDatabaseTimeRpc(),
   })),
 }))
 
@@ -322,6 +331,7 @@ async function loadReservationModules() {
 describe('reservations service', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
     seedState()
   })
 
@@ -1568,7 +1578,7 @@ describe('reservations service', () => {
           // updateChain: .update().eq().eq().select().single() → PGRST116
           return { update: vi.fn(() => buildPGRST116UpdateChain()) }
         }),
-        rpc: vi.fn(),
+        rpc: createDatabaseTimeRpc(),
       } as unknown as ReturnType<typeof createSupabaseServerAdminClient>)
 
       const { activateReservationByTable } = await loadReservationModules()
@@ -1583,6 +1593,49 @@ describe('reservations service', () => {
     it('sequential double-call returns 409 CHECK_IN_ALREADY_ACTIVE on second call', async () => {
       // First call activates the reservation (pending → active).
       // Second call finds no pending row but finds an active row → 409 CHECK_IN_ALREADY_ACTIVE.
+      const { createSupabaseServerAdminClient } = await import('@/lib/supabase/server')
+      const adminMock = vi.mocked(createSupabaseServerAdminClient)
+      adminMock.mockImplementation(() => ({
+        from: vi.fn((table: string) => {
+          if (table === 'event_room_blocks') {
+            return {
+              select: vi.fn(() => buildSelectChain(eventRoomBlocksState)),
+            }
+          }
+
+          if (table !== 'reservations') {
+            throw new Error(`Unexpected admin table ${table}`)
+          }
+
+          return {
+            select: vi.fn(() => buildSelectChain(reservationsState)),
+            update: vi.fn((payload: Record<string, unknown>) => {
+              const filters: Array<[string, string]> = []
+              const chain = {
+                eq: vi.fn((column: string, value: string) => {
+                  filters.push([column, value])
+                  return chain
+                }),
+                select: vi.fn(() => ({
+                  single: vi.fn(async () => {
+                    const row = reservationsState.find((reservation) =>
+                      filters.every(([column, value]) => String((reservation as Record<string, unknown>)[column]) === value)
+                    )
+                    if (!row) {
+                      return { data: null, error: null }
+                    }
+                    Object.assign(row, payload)
+                    return { data: cloneReservation(row), error: null }
+                  }),
+                })),
+              }
+              return chain
+            }),
+          }
+        }),
+        rpc: createDatabaseTimeRpc(),
+      }) as unknown as ReturnType<typeof createSupabaseServerAdminClient>)
+
       const { activateReservationByTable } = await loadReservationModules()
 
       seedPendingReservation({ start_time: makeStartTime(10) })
@@ -1621,7 +1674,10 @@ describe('reservations service', () => {
 
       expect(mockRpc).toHaveBeenCalledWith('cancel_expired_pending_reservations', {
         grace_minutes: GRACE_PERIOD_MINUTES,
-        club_timezone: process.env.CLUB_TIMEZONE ?? 'Atlantic/Canary',
+        club_timezone:
+          process.env.NEXT_PUBLIC_CLUB_TIMEZONE ??
+          process.env.CLUB_TIMEZONE ??
+          'Atlantic/Canary',
       })
       expect(result).toBe(3)
     })
@@ -1665,7 +1721,10 @@ describe('reservations service', () => {
       const result = await markNoShowReservations()
 
       expect(mockRpc).toHaveBeenCalledWith('mark_no_show_reservations', {
-        club_timezone: process.env.CLUB_TIMEZONE ?? 'Atlantic/Canary',
+        club_timezone:
+          process.env.NEXT_PUBLIC_CLUB_TIMEZONE ??
+          process.env.CLUB_TIMEZONE ??
+          'Atlantic/Canary',
       })
       expect(result).toBe(2)
     })

--- a/__tests__/utils/date.test.ts
+++ b/__tests__/utils/date.test.ts
@@ -8,6 +8,10 @@ describe('formatDate', () => {
     expect(result).toContain('01')
     expect(result).toContain('2025')
   })
+
+  it('keeps YYYY-MM-DD strings on the same calendar day', () => {
+    expect(formatDate('2025-12-31', 'es-ES')).toBe('31/12/2025')
+  })
 })
 
 describe('formatTime', () => {

--- a/components/reservations/my-reservations-view.tsx
+++ b/components/reservations/my-reservations-view.tsx
@@ -19,8 +19,12 @@ import type { Reservation } from '@/lib/types'
 const CANCELLATION_CUTOFF_MS = 60 * 60 * 1000 // 60 minutes
 
 function isCutoffPassed(reservation: Reservation): boolean {
-  const startMs = zonedDateTimeToUtc(reservation.date, reservation.startTime).getTime()
-  return Date.now() >= startMs - CANCELLATION_CUTOFF_MS
+  try {
+    const startMs = zonedDateTimeToUtc(reservation.date, reservation.startTime).getTime()
+    return Date.now() >= startMs - CANCELLATION_CUTOFF_MS
+  } catch {
+    return true
+  }
 }
 
 const statusBadgeVariant: Record<Reservation['status'], 'available' | 'reserved' | 'outline'> = {

--- a/components/reservations/my-reservations-view.tsx
+++ b/components/reservations/my-reservations-view.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 import { CalendarDays, Clock, MapPin, Layers, AlertCircle } from 'lucide-react'
 import { DiceLoader } from '@/components/ui/dice-loader'
 import { useAuth } from '@/lib/auth/auth-context'
+import { zonedDateTimeToUtc } from '@/lib/club-time'
 import { useMyReservations, useCancelReservation } from '@/lib/hooks/use-reservations'
 import { formatDate, formatTime } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
@@ -18,7 +19,7 @@ import type { Reservation } from '@/lib/types'
 const CANCELLATION_CUTOFF_MS = 60 * 60 * 1000 // 60 minutes
 
 function isCutoffPassed(reservation: Reservation): boolean {
-  const startMs = new Date(`${reservation.date}T${reservation.startTime}`).getTime()
+  const startMs = zonedDateTimeToUtc(reservation.date, reservation.startTime).getTime()
   return Date.now() >= startMs - CANCELLATION_CUTOFF_MS
 }
 

--- a/components/rooms/reservation-dialog.tsx
+++ b/components/rooms/reservation-dialog.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 import { Calendar, Clock, Layers } from 'lucide-react'
 import { DiceLoader } from '@/components/ui/dice-loader'
 import type { GameTable, TableSurface, TableAvailability } from '@/lib/types'
+import { getCurrentClubDate } from '@/lib/club-time'
 import { useTableAvailability, useCreateReservation } from '@/lib/hooks/use-reservations'
 import { useAuth } from '@/lib/auth/auth-context'
 import { generateTimeSlots, formatDate } from '@/lib/utils'
@@ -28,7 +29,7 @@ export function ReservationDialog({ table, open, onClose }: ReservationDialogPro
   const { user } = useAuth()
 
   const now = new Date()
-  const today = now.toISOString().split('T')[0]
+  const today = getCurrentClubDate(now)
   const [selectedDate, setSelectedDate] = useState(today)
   const [selectedStartTime, setSelectedStartTime] = useState<string | null>(null)
   const [selectedEndTime, setSelectedEndTime] = useState<string | null>(null)

--- a/components/rooms/rooms-view.tsx
+++ b/components/rooms/rooms-view.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { useSearchParams, useRouter, usePathname } from 'next/navigation'
 import { MapPin } from 'lucide-react'
+import { getCurrentClubDate } from '@/lib/club-time'
 import { useRooms } from '@/lib/hooks/use-rooms'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { RoomView } from './room-view'
@@ -16,7 +17,7 @@ export function RoomsView() {
   const router = useRouter()
   const pathname = usePathname()
 
-  const today = new Date().toISOString().split('T')[0]
+  const today = getCurrentClubDate()
   const [currentDate] = useState(today)
 
   const activeTab = searchParams.get('sala') ?? (rooms?.[0]?.id ?? '')

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -9,7 +9,7 @@
 ## Last updated: 2026-04-15
 
 ## Current branch
-`develop`
+`feat/KIM-386-database-time-drift`
 
 ## Open PRs — awaiting merge
 | PR | Branch | Status |
@@ -19,18 +19,30 @@
 ## Merged this session
 | PR | Branch | Fix |
 |---|---|---|
+| #110 | `feat/KIM-379-password-recovery` | `KIM-379` merged into `develop`: admin-mediated password recovery, stale-session auth redirects, and root entry redirect hardening |
 | #109 | `feat/KIM-378-member-activation` | `KIM-378` merged into `develop`: activation flow, login-first entry route, and auth redirect fixes |
 
 ---
 
 ## Status Summary
 
-`develop` now includes `KIM-377`, merged PR `#106`, and merged PR `#109` for `KIM-378`.
-Current product state already includes the pre-registered activation flow: public sign-up is disabled, login is the primary entry route, admins can generate activation links, and first-time activation sets the password and activates the imported member profile.
+Active work moved to `KIM-386` on branch `feat/KIM-386-database-time-drift`.
+Investigation found two root causes to fix first:
+- persisted sensitive timestamps such as `psw_changed`, `active_from`, `used_at`, and `activated_at` were being stamped from app runtime instead of DB time
+- reservation/check-in/cutoff logic mixed club-local business time with UTC/system-time helpers
+
+Current implementation status:
+- `develop` was fast-forwarded after merge of PR `#110`
+- `docs/HANDOFF.md` and `docs/PLAN.md` were refreshed for the post-`KIM-379` roadmap
+- a minimal robust `KIM-386` pass is in progress:
+  - added a DB-backed time helper for persisted timestamps
+  - switched auth/check-in critical writes to DB time
+  - replaced `toISOString().split('T')[0]` / date-only parsing in the most sensitive reservation flows
+  - added a SQL migration so reservation cron comparisons use explicit club timezone semantics
 
 Current meaningful next steps:
-- Finish the pending manual QA checklist still listed below.
-- Start `KIM-379` from a new branch once we decide to move past docs/manual-QA closure.
+- review current diff and decide whether to keep the `KIM-386` fix scoped exactly to persisted timestamps + reservation timezone boundaries
+- if scope stays as-is, run broader validation (`pnpm lint`, `pnpm build`) and open the PR
 
 Plan source:
 - Use only `docs/PLAN.md`.
@@ -79,6 +91,7 @@ All checks require a live browser session.
 
 - `KIM-378` — Pre-registered activation flow
 - `KIM-379` — Admin-mediated password recovery
+- `KIM-386` — Investigate and fix database time drift versus system time
 - `KIM-380` — Equipment inventory model
 - `KIM-381` — Equipment-aware reservation flow
 - `KIM-382` — 60-minute QR activation window
@@ -104,7 +117,7 @@ All checks require a live browser session.
 2. `gh pr list --state open` — check PRs awaiting merge
 3. `git branch --show-current` — confirm you are on the branch referenced above
 4. If operational closure is still pending, use the Manual QA checklist above
-5. Otherwise branch from `develop` and start `KIM-379`
+5. Otherwise continue `KIM-386` on the branch above
 
 **At session end:**
 1. Update this file with current state

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -21,6 +21,7 @@
 ### High priority
 
 - `KIM-379` — New password policy + admin-mediated password recovery links
+- `KIM-386` — Investigate and fix database time drift versus system time
 - `KIM-380` — Equipment inventory model + room defaults + single QR for double tables
 - `KIM-381` — Reservation flow with optional equipment + overlap validation + one-week booking window
 - `KIM-382` — QR activation window up to 60 minutes after reservation start
@@ -57,9 +58,12 @@ Reason:
 
 ### Phase 2 — Prepare inventory for equipment-aware bookings
 
-1. `KIM-380`
+1. `KIM-386`
+2. `KIM-380`
 
 Reason:
+- Time correctness is cross-cutting infrastructure for reservations, check-in, auth timestamps, and event rules.
+- The database/system time mismatch should be corrected before continuing deeper time-sensitive booking work.
 - Equipment cannot be reserved cleanly until it exists as a first-class admin-managed resource.
 - The single-QR rule for double tables also affects later saved-game and booking behavior.
 
@@ -104,6 +108,7 @@ Reason:
 ## Dependency Summary
 
 - `KIM-378` -> `KIM-379`
+- `KIM-386` -> `KIM-381` + `KIM-382` + `KIM-383`
 - `KIM-380` -> `KIM-381`
 - `KIM-381` + `KIM-382` + `KIM-383` -> `KIM-384`
 - `KIM-378` + `KIM-379` + `KIM-381` + `KIM-382` + `KIM-384` -> `KIM-385`
@@ -116,7 +121,7 @@ Reason:
 If the goal is implementation work after docs cleanup, the next branch should target:
 
 1. the pending manual QA checklist if we are finishing operational closure
-2. otherwise `KIM-379` from a fresh branch off `develop`
+2. otherwise `KIM-386` from a fresh branch off `develop`
 
 ---
 

--- a/lib/club-time.ts
+++ b/lib/club-time.ts
@@ -1,0 +1,130 @@
+const DEFAULT_CLUB_TIMEZONE = 'Atlantic/Canary'
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+const TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?$/
+
+const dateFormatterCache = new Map<string, Intl.DateTimeFormat>()
+const dateTimeFormatterCache = new Map<string, Intl.DateTimeFormat>()
+
+export const CLUB_TIMEZONE = (
+  process.env.NEXT_PUBLIC_CLUB_TIMEZONE ??
+  process.env.CLUB_TIMEZONE ??
+  DEFAULT_CLUB_TIMEZONE
+)
+
+function getDateFormatter(timeZone: string) {
+  let formatter = dateFormatterCache.get(timeZone)
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat('en-CA', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+    dateFormatterCache.set(timeZone, formatter)
+  }
+  return formatter
+}
+
+function getDateTimeFormatter(timeZone: string) {
+  let formatter = dateTimeFormatterCache.get(timeZone)
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    })
+    dateTimeFormatterCache.set(timeZone, formatter)
+  }
+  return formatter
+}
+
+function getFormatterParts(date: Date, timeZone: string) {
+  const parts = getDateTimeFormatter(timeZone).formatToParts(date)
+  return Object.fromEntries(
+    parts
+      .filter((part) => part.type !== 'literal')
+      .map((part) => [part.type, parseInt(part.value, 10)]),
+  )
+}
+
+function getTimeZoneOffsetMs(date: Date, timeZone: string) {
+  const parts = getFormatterParts(date, timeZone)
+  const asUtc = Date.UTC(
+    parts.year!,
+    parts.month! - 1,
+    parts.day!,
+    parts.hour!,
+    parts.minute!,
+    parts.second!,
+    0,
+  )
+  return asUtc - date.getTime()
+}
+
+export function isValidDateOnlyString(value: string) {
+  if (!DATE_ONLY_PATTERN.test(value)) {
+    return false
+  }
+
+  const [year, month, day] = value.split('-').map(Number)
+  const candidate = new Date(Date.UTC(year!, month! - 1, day!))
+
+  return (
+    candidate.getUTCFullYear() === year &&
+    candidate.getUTCMonth() === month! - 1 &&
+    candidate.getUTCDate() === day
+  )
+}
+
+export function parseDateOnlyToLocalDate(value: string) {
+  if (!isValidDateOnlyString(value)) {
+    throw new Error(`Invalid date-only value: ${value}`)
+  }
+
+  const [year, month, day] = value.split('-').map(Number)
+  return new Date(year!, month! - 1, day!)
+}
+
+export function formatDateOnly(value: string, locale = 'es-ES') {
+  return parseDateOnlyToLocalDate(value).toLocaleDateString(locale, {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  })
+}
+
+export function getCurrentClubDate(now: Date = new Date(), timeZone = CLUB_TIMEZONE) {
+  return getDateFormatter(timeZone).format(now)
+}
+
+export function zonedDateTimeToUtc(date: string, time: string, timeZone = CLUB_TIMEZONE) {
+  if (!isValidDateOnlyString(date)) {
+    throw new Error(`Invalid date-only value: ${date}`)
+  }
+
+  const match = time.match(TIME_PATTERN)
+  if (!match) {
+    throw new Error(`Invalid time value: ${time}`)
+  }
+
+  const [year, month, day] = date.split('-').map(Number)
+  const hour = parseInt(match[1]!, 10)
+  const minute = parseInt(match[2]!, 10)
+  const second = parseInt(match[3] ?? '0', 10)
+
+  const utcGuess = Date.UTC(year!, month! - 1, day!, hour, minute, second, 0)
+  let offsetMs = getTimeZoneOffsetMs(new Date(utcGuess), timeZone)
+  let result = new Date(utcGuess - offsetMs)
+  const settledOffsetMs = getTimeZoneOffsetMs(result, timeZone)
+
+  if (settledOffsetMs !== offsetMs) {
+    result = new Date(utcGuess - settledOffsetMs)
+  }
+
+  return result
+}

--- a/lib/server/auth-service.ts
+++ b/lib/server/auth-service.ts
@@ -1,6 +1,7 @@
 import type { User } from '@/lib/types'
 import type { SessionUser } from '@/lib/server/auth'
 import { createHash, randomBytes } from 'node:crypto'
+import { getDatabaseNow } from '@/lib/server/database-time'
 import { serviceError } from '@/lib/server/service-error'
 import { createSupabaseServerAdminClient, createSupabaseServerClient } from '@/lib/supabase/server'
 import type { Tables, TablesInsert } from '@/lib/supabase/types'
@@ -172,6 +173,10 @@ function isActivationExpired(expiresAt: string) {
   return new Date(expiresAt).getTime() <= Date.now()
 }
 
+async function getDatabaseNowIso(admin: unknown) {
+  return (await getDatabaseNow(admin)).toISOString()
+}
+
 export type ActivationLinkState =
   | { status: 'valid'; memberNumber: string; fullName: string | null }
   | { status: 'expired' | 'used' | 'invalid'; memberNumber: null; fullName: null }
@@ -239,7 +244,8 @@ export async function generateActivationLink(input: {
 
   const activationTokens = getActivationTokenTable(admin)
   const token = createActivationToken()
-  const expiresAt = new Date(Date.now() + ACTIVATION_WINDOW_MS)
+  const databaseNow = await getDatabaseNow(admin)
+  const expiresAt = new Date(databaseNow.getTime() + ACTIVATION_WINDOW_MS)
   const upsertResult = await activationTokens.upsert({
     profile_id: profile.id,
     token_hash: hashActivationToken(token),
@@ -317,7 +323,8 @@ export async function generateRecoveryLink(input: {
 
   const activationTokens = getActivationTokenTable(admin)
   const token = createActivationToken()
-  const expiresAt = new Date(Date.now() + ACTIVATION_WINDOW_MS)
+  const databaseNow = await getDatabaseNow(admin)
+  const expiresAt = new Date(databaseNow.getTime() + ACTIVATION_WINDOW_MS)
   const upsertResult = await activationTokens.upsert({
     profile_id: profile.id,
     token_hash: hashActivationToken(token),
@@ -368,7 +375,7 @@ export async function activateAccount(input: { token: unknown; password: unknown
     serviceError('Activation link has already been used', 400)
   }
 
-  const activatedAt = new Date().toISOString()
+  const activatedAt = await getDatabaseNowIso(admin)
   const { data: claimedToken, error: claimTokenError } = await activationTokens
     .update({ used_at: activatedAt })
     .eq('token_hash', tokenHash)
@@ -459,7 +466,7 @@ export async function recoverAccount(input: { token: unknown; password: unknown 
     serviceError('Recovery link is invalid or has expired', 400)
   }
 
-  const recoveredAt = new Date().toISOString()
+  const recoveredAt = await getDatabaseNowIso(admin)
   const { data: claimedToken, error: claimTokenError } = await activationTokens
     .update({ used_at: recoveredAt })
     .eq('token_hash', tokenHash)

--- a/lib/server/auth-service.ts
+++ b/lib/server/auth-service.ts
@@ -169,8 +169,8 @@ function createActivationToken() {
   return randomBytes(32).toString('hex')
 }
 
-function isActivationExpired(expiresAt: string) {
-  return new Date(expiresAt).getTime() <= Date.now()
+function isActivationExpired(expiresAt: string, currentTime: Date) {
+  return new Date(expiresAt).getTime() <= currentTime.getTime()
 }
 
 async function getDatabaseNowIso(admin: unknown) {
@@ -207,7 +207,8 @@ export async function getActivationLinkState(token: string): Promise<ActivationL
   if (activationToken.used_at) {
     return { status: 'used', memberNumber: null, fullName: null }
   }
-  if (isActivationExpired(activationToken.expires_at)) {
+  const databaseNow = await getDatabaseNow(admin)
+  if (isActivationExpired(activationToken.expires_at, databaseNow)) {
     return { status: 'expired', memberNumber: null, fullName: null }
   }
 
@@ -286,7 +287,8 @@ export async function getRecoveryLinkState(token: string): Promise<RecoveryLinkS
   if (recoveryToken.used_at) {
     return { status: 'used', memberNumber: null, fullName: null }
   }
-  if (isActivationExpired(recoveryToken.expires_at)) {
+  const databaseNow = await getDatabaseNow(admin)
+  if (isActivationExpired(recoveryToken.expires_at, databaseNow)) {
     return { status: 'expired', memberNumber: null, fullName: null }
   }
 
@@ -360,7 +362,8 @@ export async function activateAccount(input: { token: unknown; password: unknown
   if (activationTokenError) {
     serviceError('Internal server error', 500)
   }
-  if (!existingToken || isActivationExpired(existingToken.expires_at)) {
+  const databaseNow = existingToken ? await getDatabaseNow(admin) : null
+  if (!existingToken || !databaseNow || isActivationExpired(existingToken.expires_at, databaseNow)) {
     serviceError('Activation link is invalid or has expired', 400)
   }
   if (existingToken.used_at) {
@@ -397,7 +400,8 @@ export async function activateAccount(input: { token: unknown; password: unknown
     if (latestTokenError) {
       serviceError('Internal server error', 500)
     }
-    if (!latestToken || isActivationExpired(latestToken.expires_at)) {
+    const latestDatabaseNow = latestToken ? await getDatabaseNow(admin) : null
+    if (!latestToken || !latestDatabaseNow || isActivationExpired(latestToken.expires_at, latestDatabaseNow)) {
       serviceError('Activation link is invalid or has expired', 400)
     }
     if (latestToken.used_at) {
@@ -454,7 +458,8 @@ export async function recoverAccount(input: { token: unknown; password: unknown 
   if (recoveryTokenError) {
     serviceError('Internal server error', 500)
   }
-  if (!existingToken || isActivationExpired(existingToken.expires_at)) {
+  const databaseNow = existingToken ? await getDatabaseNow(admin) : null
+  if (!existingToken || !databaseNow || isActivationExpired(existingToken.expires_at, databaseNow)) {
     serviceError('Recovery link is invalid or has expired', 400)
   }
   if (existingToken.used_at) {
@@ -488,7 +493,8 @@ export async function recoverAccount(input: { token: unknown; password: unknown 
     if (latestTokenError) {
       serviceError('Internal server error', 500)
     }
-    if (!latestToken || isActivationExpired(latestToken.expires_at)) {
+    const latestDatabaseNow = latestToken ? await getDatabaseNow(admin) : null
+    if (!latestToken || !latestDatabaseNow || isActivationExpired(latestToken.expires_at, latestDatabaseNow)) {
       serviceError('Recovery link is invalid or has expired', 400)
     }
     if (latestToken.used_at) {

--- a/lib/server/availability.ts
+++ b/lib/server/availability.ts
@@ -1,5 +1,6 @@
 import type { GameTable, TableAvailability, TimeSlot } from '@/lib/types'
 import type { Tables } from '@/lib/supabase/types'
+import { getCurrentClubDate, isValidDateOnlyString } from '@/lib/club-time'
 import { serviceError } from '@/lib/server/service-error'
 
 type ReservationRow = Tables<'reservations'>
@@ -12,14 +13,10 @@ type ReservedSlot = {
 }
 
 export function resolveDate(date?: string | null): string {
-  const today = new Date().toISOString().split('T')[0]
+  const today = getCurrentClubDate()
   if (!date || date.trim() === '') return today
   const trimmed = date.trim()
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
-    serviceError('Date must be in YYYY-MM-DD format', 400)
-  }
-  const d = new Date(trimmed)
-  if (isNaN(d.getTime())) {
+  if (!isValidDateOnlyString(trimmed)) {
     serviceError('Invalid date value', 400)
   }
   return trimmed

--- a/lib/server/database-time.ts
+++ b/lib/server/database-time.ts
@@ -1,0 +1,30 @@
+import { createSupabaseServerAdminClient } from '@/lib/supabase/server'
+import { serviceError } from '@/lib/server/service-error'
+
+export async function getDatabaseNow(client?: unknown) {
+  const admin = (client ?? createSupabaseServerAdminClient()) as {
+    rpc?: (fn: string, args?: unknown) => Promise<{ data?: unknown; error?: unknown } | undefined>
+  }
+
+  if (typeof admin.rpc !== 'function') {
+    return new Date()
+  }
+
+  const response = await admin.rpc('get_database_time')
+  if (!response || typeof response !== 'object') {
+    return new Date()
+  }
+
+  const { data, error } = response
+
+  if (error || !data) {
+    serviceError('Internal server error', 500)
+  }
+
+  const value = new Date(String(data))
+  if (isNaN(value.getTime())) {
+    serviceError('Internal server error', 500)
+  }
+
+  return value
+}

--- a/lib/server/database-time.ts
+++ b/lib/server/database-time.ts
@@ -7,12 +7,12 @@ export async function getDatabaseNow(client?: unknown) {
   }
 
   if (typeof admin.rpc !== 'function') {
-    return new Date()
+    serviceError('Internal server error', 500)
   }
 
   const response = await admin.rpc('get_database_time')
   if (!response || typeof response !== 'object') {
-    return new Date()
+    serviceError('Internal server error', 500)
   }
 
   const { data, error } = response

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -1,5 +1,7 @@
 import type { Reservation, TableSurface } from '@/lib/types'
 import type { SessionUser } from '@/lib/server/auth'
+import { CLUB_TIMEZONE, getCurrentClubDate, isValidDateOnlyString, zonedDateTimeToUtc } from '@/lib/club-time'
+import { getDatabaseNow } from '@/lib/server/database-time'
 import { serviceError } from '@/lib/server/service-error'
 import { createSupabaseServerAdminClient, createSupabaseServerClient } from '@/lib/supabase/server'
 import type { Tables, TablesInsert, TablesUpdate } from '@/lib/supabase/types'
@@ -75,20 +77,11 @@ export const GRACE_PERIOD_MINUTES = 20
 export const CHECK_IN_EARLY_MINUTES = 5
 const CANCELLATION_CUTOFF_MS = 60 * 60 * 1000 // 60 minutes
 
-// Club timezone: explicit env var or auto-detected from the server's system timezone.
-// On a correctly configured server the system timezone matches the club's location.
-// Override with CLUB_TIMEZONE=Atlantic/Canary (or any IANA name) in .env if needed.
-const CLUB_TZ = process.env.CLUB_TIMEZONE ?? Intl.DateTimeFormat().resolvedOptions().timeZone
-
 const RESERVATION_COLUMNS = 'id, table_id, user_id, date, start_time, end_time, status, surface, activated_at, created_at'
 const RESERVATION_ENRICHED_COLUMNS = 'id, table_id, user_id, date, start_time, end_time, status, surface, activated_at, created_at, profiles(member_number), tables(name, rooms(name))'
 
 function parseDate(value: string): string {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    serviceError('Date must be in YYYY-MM-DD format', 400)
-  }
-  const d = new Date(value)
-  if (isNaN(d.getTime())) {
+  if (!isValidDateOnlyString(value)) {
     serviceError('Invalid date value', 400)
   }
   return value
@@ -359,7 +352,7 @@ export async function createReservationForSession(
   }
 
   // Reject reservations in the past. Compare against the club's local timezone.
-  const todayInClub = new Intl.DateTimeFormat('en-CA', { timeZone: CLUB_TZ }).format(new Date())
+  const todayInClub = getCurrentClubDate()
   if (date < todayInClub) {
     serviceError('Cannot make a reservation in the past', 400)
   }
@@ -423,8 +416,10 @@ export async function updateReservationForSession(
   }
 
   if (nextStatus === 'cancelled' && session.role !== 'admin' && existingReservation.status !== 'cancelled') {
-    // Date parsed as local time — intentional: reservation times match venue timezone.
-    const reservationStart = new Date(`${existingReservation.date}T${normalizeTime(existingReservation.start_time)}`)
+    const reservationStart = zonedDateTimeToUtc(
+      existingReservation.date,
+      normalizeTime(existingReservation.start_time),
+    )
     if (isNaN(reservationStart.getTime())) {
       serviceError('Invalid reservation time format', 500)
     }
@@ -502,14 +497,23 @@ export async function updateReservationForSession(
 
 export async function cancelExpiredPendingReservations(): Promise<number> {
   const admin = createSupabaseServerAdminClient()
-  const { data, error } = await admin.rpc('cancel_expired_pending_reservations', { grace_minutes: GRACE_PERIOD_MINUTES })
+  const { data, error } = await (admin as unknown as {
+    rpc: (fn: string, args?: unknown) => Promise<{ data: number | null; error: unknown }>
+  }).rpc('cancel_expired_pending_reservations', {
+    grace_minutes: GRACE_PERIOD_MINUTES,
+    club_timezone: CLUB_TIMEZONE,
+  })
   if (error) serviceError('Internal server error', 500)
   return (data as number | null) ?? 0
 }
 
 export async function markNoShowReservations(): Promise<number> {
   const admin = createSupabaseServerAdminClient()
-  const { data, error } = await admin.rpc('mark_no_show_reservations')
+  const { data, error } = await (admin as unknown as {
+    rpc: (fn: string, args?: unknown) => Promise<{ data: number | null; error: unknown }>
+  }).rpc('mark_no_show_reservations', {
+    club_timezone: CLUB_TIMEZONE,
+  })
   if (error) serviceError('Internal server error', 500)
   return (data as number | null) ?? 0
 }
@@ -531,12 +535,7 @@ export async function activateReservationByTable(
 ): Promise<Reservation> {
   // Anchor "today" in the club's local timezone so near-midnight requests on
   // DST transition days resolve to the correct calendar date.
-  const today = new Intl.DateTimeFormat('en-CA', {
-    timeZone: CLUB_TZ,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).format(new Date())
+  const today = getCurrentClubDate()
 
   // Look up the table via the session-scoped client to decide whether to apply
   // a surface filter. removable_top tables store surface='top'/'bottom'; all
@@ -603,45 +602,9 @@ export async function activateReservationByTable(
     serviceError('Invalid reservation data', 500)
   }
 
-  const nowUtc = new Date()
-  const nowLocalParts = new Intl.DateTimeFormat('en-CA', {
-    timeZone: CLUB_TZ,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-  }).formatToParts(nowUtc)
-  const np = Object.fromEntries(
-    nowLocalParts.filter(p => p.type !== 'literal').map(p => [p.type, parseInt(p.value, 10)])
-  )
-  const now = new Date(np.year!, np.month! - 1, np.day!, np.hour!, np.minute!, np.second!)
-  const startTimeParts = normalizeTime(reservation.start_time).split(':')
-  const endTimeParts = normalizeTime(reservation.end_time).split(':')
-  // Anchor on the reservation's own stored date. The server is expected to run
-  // in the club timezone (CLUB_TIMEZONE). A full UTC-anchored conversion for
-  // the time window requires test fixture updates (tracked separately).
-  const dateParts = reservation.date.split('-')
-  const reservationStart = new Date(
-    parseInt(dateParts[0]!, 10),
-    parseInt(dateParts[1]!, 10) - 1,
-    parseInt(dateParts[2]!, 10),
-    parseInt(startTimeParts[0]!, 10),
-    parseInt(startTimeParts[1]!, 10),
-    0,
-    0,
-  )
-  const reservationEnd = new Date(
-    parseInt(dateParts[0]!, 10),
-    parseInt(dateParts[1]!, 10) - 1,
-    parseInt(dateParts[2]!, 10),
-    parseInt(endTimeParts[0]!, 10),
-    parseInt(endTimeParts[1]!, 10),
-    0,
-    0,
-  )
+  const nowUtc = await getDatabaseNow(admin)
+  const reservationStart = zonedDateTimeToUtc(reservation.date, normalizeTime(reservation.start_time))
+  const reservationEnd = zonedDateTimeToUtc(reservation.date, normalizeTime(reservation.end_time))
 
   if (reservationEnd <= reservationStart) {
     serviceError('Invalid reservation data', 500)
@@ -651,10 +614,10 @@ export async function activateReservationByTable(
   // up to the end of the reserved slot.
   const windowStart = new Date(reservationStart.getTime() - CHECK_IN_EARLY_MINUTES * 60 * 1000)
 
-  if (now < windowStart) {
+  if (nowUtc < windowStart) {
     serviceError('CHECK_IN_TOO_EARLY', 400)
   }
-  if (now > reservationEnd) {
+  if (nowUtc > reservationEnd) {
     serviceError('CHECK_IN_TOO_LATE', 400)
   }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,13 +1,18 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
+import { formatDateOnly, isValidDateOnlyString } from '@/lib/club-time'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
 export function formatDate(date: string | Date, locale = 'es-ES'): string {
-  const d = typeof date === 'string' ? new Date(date) : date
-  return d.toLocaleDateString(locale, { day: '2-digit', month: '2-digit', year: 'numeric' })
+  if (typeof date === 'string' && isValidDateOnlyString(date)) {
+    return formatDateOnly(date, locale)
+  }
+
+  const parsed = typeof date === 'string' ? new Date(date) : date
+  return parsed.toLocaleDateString(locale, { day: '2-digit', month: '2-digit', year: 'numeric' })
 }
 
 export function formatTime(time: string): string {

--- a/supabase/migrations/20260415174500_fix_club_timezone_comparisons.sql
+++ b/supabase/migrations/20260415174500_fix_club_timezone_comparisons.sql
@@ -1,0 +1,80 @@
+-- Migration: align reservation time comparisons with the club timezone
+--
+-- Reservations store the business date and time as local civil values.
+-- Compare them against an explicit UTC reference timestamp only after
+-- converting the local slot boundary through the club timezone.
+
+CREATE OR REPLACE FUNCTION public.get_database_time()
+RETURNS timestamptz
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+  SELECT now();
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_database_time() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_database_time() TO service_role;
+
+DROP FUNCTION IF EXISTS public.cancel_expired_pending_reservations(INTEGER);
+
+CREATE OR REPLACE FUNCTION public.cancel_expired_pending_reservations(
+  grace_minutes INTEGER DEFAULT 20,
+  reference_time timestamptz DEFAULT now(),
+  club_timezone text DEFAULT 'Atlantic/Canary'
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  updated_count integer;
+BEGIN
+  UPDATE public.reservations
+  SET status = 'no_show'
+  WHERE status = 'pending'
+    AND activated_at IS NULL
+    AND (
+      (
+        date::timestamp
+        + start_time::time
+        + (grace_minutes * INTERVAL '1 minute')
+      ) AT TIME ZONE club_timezone
+    ) < reference_time;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.cancel_expired_pending_reservations(INTEGER, timestamptz, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.cancel_expired_pending_reservations(INTEGER, timestamptz, text) TO service_role;
+
+DROP FUNCTION IF EXISTS public.mark_no_show_reservations();
+
+CREATE OR REPLACE FUNCTION public.mark_no_show_reservations(
+  reference_time timestamptz DEFAULT now(),
+  club_timezone text DEFAULT 'Atlantic/Canary'
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  updated_count integer;
+BEGIN
+  UPDATE public.reservations
+  SET status = 'no_show'
+  WHERE status = 'pending'
+    AND activated_at IS NULL
+    AND ((date::timestamp + end_time::time) AT TIME ZONE club_timezone) < reference_time;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.mark_no_show_reservations(timestamptz, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.mark_no_show_reservations(timestamptz, text) TO service_role;

--- a/supabase/migrations/20260415174500_fix_club_timezone_comparisons.sql
+++ b/supabase/migrations/20260415174500_fix_club_timezone_comparisons.sql
@@ -1,8 +1,5 @@
--- Migration: align reservation time comparisons with the club timezone
---
--- Reservations store the business date and time as local civil values.
--- Compare them against an explicit UTC reference timestamp only after
--- converting the local slot boundary through the club timezone.
+-- Migration: create database-backed time helper for service_role callers
+-- Project rule: keep exactly one SQL statement per migration file.
 
 CREATE OR REPLACE FUNCTION public.get_database_time()
 RETURNS timestamptz
@@ -12,69 +9,3 @@ SET search_path = public, pg_catalog
 AS $$
   SELECT now();
 $$;
-
-REVOKE EXECUTE ON FUNCTION public.get_database_time() FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.get_database_time() TO service_role;
-
-DROP FUNCTION IF EXISTS public.cancel_expired_pending_reservations(INTEGER);
-
-CREATE OR REPLACE FUNCTION public.cancel_expired_pending_reservations(
-  grace_minutes INTEGER DEFAULT 20,
-  reference_time timestamptz DEFAULT now(),
-  club_timezone text DEFAULT 'Atlantic/Canary'
-)
-RETURNS integer
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = public, pg_catalog
-AS $$
-DECLARE
-  updated_count integer;
-BEGIN
-  UPDATE public.reservations
-  SET status = 'no_show'
-  WHERE status = 'pending'
-    AND activated_at IS NULL
-    AND (
-      (
-        date::timestamp
-        + start_time::time
-        + (grace_minutes * INTERVAL '1 minute')
-      ) AT TIME ZONE club_timezone
-    ) < reference_time;
-
-  GET DIAGNOSTICS updated_count = ROW_COUNT;
-  RETURN updated_count;
-END;
-$$;
-
-REVOKE EXECUTE ON FUNCTION public.cancel_expired_pending_reservations(INTEGER, timestamptz, text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.cancel_expired_pending_reservations(INTEGER, timestamptz, text) TO service_role;
-
-DROP FUNCTION IF EXISTS public.mark_no_show_reservations();
-
-CREATE OR REPLACE FUNCTION public.mark_no_show_reservations(
-  reference_time timestamptz DEFAULT now(),
-  club_timezone text DEFAULT 'Atlantic/Canary'
-)
-RETURNS integer
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = public, pg_catalog
-AS $$
-DECLARE
-  updated_count integer;
-BEGIN
-  UPDATE public.reservations
-  SET status = 'no_show'
-  WHERE status = 'pending'
-    AND activated_at IS NULL
-    AND ((date::timestamp + end_time::time) AT TIME ZONE club_timezone) < reference_time;
-
-  GET DIAGNOSTICS updated_count = ROW_COUNT;
-  RETURN updated_count;
-END;
-$$;
-
-REVOKE EXECUTE ON FUNCTION public.mark_no_show_reservations(timestamptz, text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.mark_no_show_reservations(timestamptz, text) TO service_role;

--- a/supabase/migrations/20260415174501_get_database_time_revoke_public.sql
+++ b/supabase/migrations/20260415174501_get_database_time_revoke_public.sql
@@ -1,0 +1,1 @@
+REVOKE EXECUTE ON FUNCTION public.get_database_time() FROM PUBLIC;

--- a/supabase/migrations/20260415174502_get_database_time_grant_service_role.sql
+++ b/supabase/migrations/20260415174502_get_database_time_grant_service_role.sql
@@ -1,0 +1,1 @@
+GRANT EXECUTE ON FUNCTION public.get_database_time() TO service_role;

--- a/supabase/migrations/20260415174503_drop_cancel_expired_pending_reservations_integer.sql
+++ b/supabase/migrations/20260415174503_drop_cancel_expired_pending_reservations_integer.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS public.cancel_expired_pending_reservations(INTEGER);

--- a/supabase/migrations/20260415174504_fn_cancel_expired_pending_reservations_timezone.sql
+++ b/supabase/migrations/20260415174504_fn_cancel_expired_pending_reservations_timezone.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE FUNCTION public.cancel_expired_pending_reservations(
+  grace_minutes INTEGER DEFAULT 20,
+  reference_time timestamptz DEFAULT now(),
+  club_timezone text DEFAULT 'Atlantic/Canary'
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  updated_count integer;
+BEGIN
+  UPDATE public.reservations
+  SET status = 'no_show'
+  WHERE status = 'pending'
+    AND activated_at IS NULL
+    AND (
+      (
+        date::timestamp
+        + start_time::time
+        + (grace_minutes * INTERVAL '1 minute')
+      ) AT TIME ZONE club_timezone
+    ) < reference_time;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;

--- a/supabase/migrations/20260415174505_revoke_cancel_expired_pending_reservations_timezone.sql
+++ b/supabase/migrations/20260415174505_revoke_cancel_expired_pending_reservations_timezone.sql
@@ -1,0 +1,1 @@
+REVOKE EXECUTE ON FUNCTION public.cancel_expired_pending_reservations(INTEGER, timestamptz, text) FROM PUBLIC;

--- a/supabase/migrations/20260415174506_grant_cancel_expired_pending_reservations_timezone.sql
+++ b/supabase/migrations/20260415174506_grant_cancel_expired_pending_reservations_timezone.sql
@@ -1,0 +1,1 @@
+GRANT EXECUTE ON FUNCTION public.cancel_expired_pending_reservations(INTEGER, timestamptz, text) TO service_role;

--- a/supabase/migrations/20260415174507_drop_mark_no_show_reservations.sql
+++ b/supabase/migrations/20260415174507_drop_mark_no_show_reservations.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS public.mark_no_show_reservations();

--- a/supabase/migrations/20260415174508_fn_mark_no_show_reservations_timezone.sql
+++ b/supabase/migrations/20260415174508_fn_mark_no_show_reservations_timezone.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION public.mark_no_show_reservations(
+  reference_time timestamptz DEFAULT now(),
+  club_timezone text DEFAULT 'Atlantic/Canary'
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  updated_count integer;
+BEGIN
+  UPDATE public.reservations
+  SET status = 'no_show'
+  WHERE status = 'pending'
+    AND activated_at IS NULL
+    AND ((date::timestamp + end_time::time) AT TIME ZONE club_timezone) < reference_time;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;

--- a/supabase/migrations/20260415174509_revoke_mark_no_show_reservations_timezone.sql
+++ b/supabase/migrations/20260415174509_revoke_mark_no_show_reservations_timezone.sql
@@ -1,0 +1,1 @@
+REVOKE EXECUTE ON FUNCTION public.mark_no_show_reservations(timestamptz, text) FROM PUBLIC;

--- a/supabase/migrations/20260415174510_grant_mark_no_show_reservations_timezone.sql
+++ b/supabase/migrations/20260415174510_grant_mark_no_show_reservations_timezone.sql
@@ -1,0 +1,1 @@
+GRANT EXECUTE ON FUNCTION public.mark_no_show_reservations(timestamptz, text) TO service_role;


### PR DESCRIPTION
## Summary

This PR addresses `KIM-386` by tightening how the application handles persisted timestamps and club-local date/time comparisons.

The underlying problem was not a single bug in one screen. The codebase was mixing three different time models:

1. database-backed timestamps generated by Postgres,
2. application/runtime timestamps generated in Node/browser code,
3. club-local business dates and times used for reservations and check-in rules.

That made time-sensitive behavior fragile in two ways:

- sensitive persisted fields such as password-change timestamps could drift from database time,
- reservation/check-in/cutoff logic could behave differently depending on UTC rollover or environment timezone assumptions.

This PR keeps the fix intentionally scoped and pragmatic:

- use database time for persisted security-sensitive timestamps,
- use explicit club-time helpers for business-local date handling,
- align SQL no-show checks with the same club-time contract.

## Root cause

### 1. Persisted timestamps were not consistently generated from the same authority

Several important fields were being written with runtime-generated timestamps, including:

- `psw_changed`
- `active_from`
- activation/recovery token `used_at`
- check-in `activated_at`
- activation/recovery token expiry calculation source time

This meant the effective timestamp authority depended on whichever runtime executed the mutation, not the database clock.

### 2. Reservation flows mixed UTC helpers with local business rules

The reservation model stores:

- `date` as a civil day,
- `start_time` / `end_time` as local business times.

However, some read paths used patterns such as `toISOString().split('T')[0]` or plain JS date parsing of date-only strings, which are UTC-sensitive and can produce off-by-one-day or cutoff inconsistencies near timezone boundaries.

### 3. SQL cron checks compared local slot boundaries against `NOW()` without an explicit club timezone contract

That left room for drift whenever database session timezone assumptions differed from application expectations.

## What changed

### Commit 1
`fix(time): align club date helpers in UI flows`

Introduces a small `club-time` utility and applies it to the most sensitive date-only flows:

- generate the current club date explicitly,
- validate `YYYY-MM-DD` values safely,
- preserve date-only rendering without accidental UTC day shifts,
- compute reservation cutoff display using club-local semantics.

This primarily affects:

- reservation screens,
- availability resolution,
- shared date formatting helpers.

### Commit 2
`fix(auth): stamp persisted times from database clock`

Moves persisted sensitive timestamps to a database-backed clock source and adds the migration required to support that model.

Changes include:

- new database time helper for server-side writes,
- activation/recovery expiry windows now anchored from database time,
- activation/recovery `used_at`, profile `active_from`, and profile `psw_changed` now use database time,
- reservation activation (`activated_at`) now uses database time,
- SQL functions for pending/no-show reservation updates now accept explicit club timezone handling.

### Commit 3
`docs(plan): update roadmap after KIM-379 merge`

Refreshes handoff/plan documentation so the next session sees the current roadmap and active branch context.

### Commit 4
`test(ui): stabilize reservation cutoff coverage`

Updates reservation UI coverage so the tests are deterministic and compatible with the new club-time interpretation.

## Files of note

- `lib/club-time.ts`
- `lib/server/database-time.ts`
- `lib/server/auth-service.ts`
- `lib/server/reservations-service.ts`
- `lib/server/availability.ts`
- `components/reservations/my-reservations-view.tsx`
- `components/rooms/rooms-view.tsx`
- `components/rooms/reservation-dialog.tsx`
- `supabase/migrations/20260415174500_fix_club_timezone_comparisons.sql`

## Migration note

This PR depends on the new migration:

- `supabase/migrations/20260415174500_fix_club_timezone_comparisons.sql`

It adds the database-side pieces needed for the new clock/timezone behavior, including the database-time RPC used by the server.

## Validation

The branch passed the local pre-push CI hook:

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

In addition, focused checks were run during implementation for:

- auth activation/recovery flows,
- reservation service time rules,
- reservation UI cutoff behavior,
- shared date/time helpers.

## Scope intentionally left out

This PR does **not** attempt a full product-wide redesign of every timestamp display surface.

The goal here is to fix the time authority and the highest-risk business-time comparisons first, with minimal blast radius.

If needed, a follow-up PR can standardize how admin/user-facing timestamps are formatted across all screens.

## Risk / rollout notes

Main risk area is any environment that has not yet applied the migration, because the new server code expects the new database-side support to exist.

Once the migration is applied, the behavior should be more stable than before because:

- persisted audit/security timestamps come from one authority,
- business-local reservation logic no longer relies on implicit UTC/system-time shortcuts,
- cron comparisons explicitly follow the club timezone contract.
