### PR TITLE
feat(KIM-317): support 30-minute reservation slots

### DIFF
--- a/__tests__/components/rooms/reservation-dialog.test.tsx
+++ b/__tests__/components/rooms/reservation-dialog.test.tsx
@@ -32,10 +32,13 @@ vi.mock('@/lib/hooks/use-reservations', () => ({
       tableId: 't1',
       date: '2025-01-15',
       slots: [
-        { startTime: '09:00', available: true },
-        { startTime: '10:00', available: true },
-        { startTime: '11:00', available: true },
-        { startTime: '12:00', available: true },
+        { startTime: '09:00', endTime: '09:30', available: true },
+        { startTime: '09:30', endTime: '10:00', available: true },
+        { startTime: '10:00', endTime: '10:30', available: true },
+        { startTime: '10:30', endTime: '11:00', available: true },
+        { startTime: '11:00', endTime: '11:30', available: true },
+        { startTime: '11:30', endTime: '12:00', available: true },
+        { startTime: '12:00', endTime: '12:30', available: true },
       ],
       top: undefined,
       bottom: undefined,
@@ -98,6 +101,19 @@ describe('ReservationDialog', () => {
     )
 
     expect(screen.getAllByRole('button', { name: /\d{2}:\d{2} — available/ }).length).toBeGreaterThan(0)
+  })
+
+  it('renders half-hour slot options', () => {
+    render(
+      <ReservationDialog
+        table={mockTable}
+        open={true}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: '11:30 — available' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '12:30 — available' })).toBeInTheDocument()
   })
 
   it('does not render when table is null', () => {

--- a/__tests__/components/rooms/reservation-dialog.test.tsx
+++ b/__tests__/components/rooms/reservation-dialog.test.tsx
@@ -39,6 +39,7 @@ vi.mock('@/lib/hooks/use-reservations', () => ({
         { startTime: '11:00', endTime: '11:30', available: true },
         { startTime: '11:30', endTime: '12:00', available: true },
         { startTime: '12:00', endTime: '12:30', available: true },
+        { startTime: '23:30', endTime: '24:00', available: true },
       ],
       top: undefined,
       bottom: undefined,
@@ -114,6 +115,50 @@ describe('ReservationDialog', () => {
 
     expect(screen.getByRole('button', { name: '11:30 — available' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '12:30 — available' })).toBeInTheDocument()
+  })
+
+  it('allows selecting 24:00 as the end boundary after choosing the last slot', async () => {
+    const user = userEvent.setup()
+    mockMutateAsync.fn = vi.fn().mockResolvedValueOnce({
+      id: 'res-midnight',
+      tableId: 't1',
+      userId: 'user-123',
+      date: '2025-01-15',
+      startTime: '23:30',
+      endTime: '24:00',
+      status: 'pending',
+      surface: null,
+      createdAt: new Date().toISOString(),
+      activatedAt: null,
+    })
+
+    render(
+      <ReservationDialog
+        table={mockTable}
+        open={true}
+        onClose={vi.fn()}
+      />
+    )
+
+    const dateInput = screen.getByLabelText('selectDate') as HTMLInputElement
+    const today = new Date()
+    const tomorrow = new Date(today)
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    const dateString = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, '0')}-${String(tomorrow.getDate()).padStart(2, '0')}`
+
+    await user.clear(dateInput)
+    await user.type(dateInput, dateString)
+    await user.click(screen.getByRole('button', { name: '23:30 — available' }))
+    await user.click(screen.getByRole('button', { name: '24:00 — available' }))
+    await user.click(screen.getByRole('button', { name: 'makeReservation' }))
+
+    await waitFor(() => {
+      expect(mockMutateAsync.fn).toHaveBeenCalledWith(expect.objectContaining({
+        startTime: '23:30',
+        endTime: '24:00',
+        date: dateString,
+      }))
+    })
   })
 
   it('does not render when table is null', () => {

--- a/__tests__/lib/club-time.test.ts
+++ b/__tests__/lib/club-time.test.ts
@@ -1,23 +1,35 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from 'vitest'
-import { getCurrentClubDate, isValidDateOnlyString, zonedDateTimeToUtc } from '@/lib/club-time'
 
 describe('club-time helpers', () => {
-  it('returns today in the configured club timezone instead of UTC date rollover', () => {
+  it('returns today in the configured club timezone instead of UTC date rollover', async () => {
+    vi.resetModules()
+    const { getCurrentClubDate } = await import('@/lib/club-time')
     const now = new Date('2026-04-15T23:30:00.000Z')
 
     expect(getCurrentClubDate(now, 'Atlantic/Canary')).toBe('2026-04-16')
     expect(getCurrentClubDate(now, 'America/New_York')).toBe('2026-04-15')
   })
 
-  it('validates date-only strings without relying on Date parsing quirks', () => {
+  it('validates date-only strings without relying on Date parsing quirks', async () => {
+    vi.resetModules()
+    const { isValidDateOnlyString } = await import('@/lib/club-time')
     expect(isValidDateOnlyString('2026-02-28')).toBe(true)
     expect(isValidDateOnlyString('2026-02-30')).toBe(false)
     expect(isValidDateOnlyString('2026/02/28')).toBe(false)
   })
 
-  it('converts club-local civil time into the matching UTC instant', () => {
+  it('converts club-local civil time into the matching UTC instant', async () => {
+    vi.resetModules()
+    const { zonedDateTimeToUtc } = await import('@/lib/club-time')
     expect(zonedDateTimeToUtc('2026-06-15', '16:00', 'Atlantic/Canary').toISOString()).toBe('2026-06-15T15:00:00.000Z')
     expect(zonedDateTimeToUtc('2026-01-15', '16:00', 'Atlantic/Canary').toISOString()).toBe('2026-01-15T16:00:00.000Z')
+  })
+
+  it('treats 24:00 as next-day midnight', async () => {
+    vi.resetModules()
+    const { zonedDateTimeToUtc } = await import('@/lib/club-time')
+    expect(zonedDateTimeToUtc('2026-06-15', '24:00', 'Atlantic/Canary').toISOString()).toBe('2026-06-15T23:00:00.000Z')
+    expect(zonedDateTimeToUtc('2026-01-15', '24:00', 'Atlantic/Canary').toISOString()).toBe('2026-01-16T00:00:00.000Z')
   })
 })

--- a/__tests__/server/availability.test.ts
+++ b/__tests__/server/availability.test.ts
@@ -96,15 +96,15 @@ describe('normalizeTime', () => {
 })
 
 describe('generateDaySlots', () => {
-  it('generates 24 slots for an empty reserved list', () => {
+  it('generates 48 half-hour slots for an empty reserved list', () => {
     const slots = generateDaySlots([])
-    expect(slots).toHaveLength(24)
+    expect(slots).toHaveLength(48)
   })
 
-  it('first slot starts at 00:00 and last slot ends at 24:00', () => {
+  it('first slot starts at 00:00 and last half-hour slot ends at 24:00', () => {
     const slots = generateDaySlots([])
-    expect(slots[0]).toMatchObject({ startTime: '00:00', endTime: '01:00', available: true })
-    expect(slots[23]).toMatchObject({ startTime: '23:00', endTime: '24:00', available: true })
+    expect(slots[0]).toMatchObject({ startTime: '00:00', endTime: '00:30', available: true })
+    expect(slots[47]).toMatchObject({ startTime: '23:30', endTime: '24:00', available: true })
   })
 
   it('each slot has startTime, endTime and available fields', () => {
@@ -120,6 +120,7 @@ describe('generateDaySlots', () => {
     const slots = generateDaySlots([{ start: '10:00', end: '11:00' }])
     const slot = slots.find((s) => s.startTime === '10:00')
     expect(slot?.available).toBe(false)
+    expect(slots.find((s) => s.startTime === '10:30')?.available).toBe(false)
   })
 
   it('leaves slots outside the reserved range as available', () => {
@@ -134,7 +135,9 @@ describe('generateDaySlots', () => {
       { start: '14:00', end: '15:00' },
     ])
     expect(slots.find((s) => s.startTime === '09:00')?.available).toBe(false)
+    expect(slots.find((s) => s.startTime === '09:30')?.available).toBe(false)
     expect(slots.find((s) => s.startTime === '14:00')?.available).toBe(false)
+    expect(slots.find((s) => s.startTime === '14:30')?.available).toBe(false)
     expect(slots.find((s) => s.startTime === '10:00')?.available).toBe(true)
   })
 
@@ -146,10 +149,12 @@ describe('generateDaySlots', () => {
 
   it('marks partial overlaps on both touched slots', () => {
     const slots = generateDaySlots([{ start: '10:30', end: '12:30' }])
-    expect(slots.find((s) => s.startTime === '10:00')?.available).toBe(false)
+    expect(slots.find((s) => s.startTime === '10:00')?.available).toBe(true)
+    expect(slots.find((s) => s.startTime === '10:30')?.available).toBe(false)
     expect(slots.find((s) => s.startTime === '11:00')?.available).toBe(false)
+    expect(slots.find((s) => s.startTime === '11:30')?.available).toBe(false)
     expect(slots.find((s) => s.startTime === '12:00')?.available).toBe(false)
-    expect(slots.find((s) => s.startTime === '13:00')?.available).toBe(true)
+    expect(slots.find((s) => s.startTime === '12:30')?.available).toBe(true)
   })
 })
 
@@ -160,7 +165,7 @@ describe('buildAvailability', () => {
 
     expect(result.tableId).toBe('t1')
     expect(result.date).toBe('2025-06-15')
-    expect(result.slots).toHaveLength(24)
+    expect(result.slots).toHaveLength(48)
     expect(result.slots.every((s) => s.available)).toBe(true)
   })
 
@@ -198,8 +203,8 @@ describe('buildAvailability', () => {
     expect(result.top).toBeDefined()
     expect(result.bottom).toBeDefined()
     expect(result.conflicts).toBeDefined()
-    expect(result.top).toHaveLength(24)
-    expect(result.bottom).toHaveLength(24)
+    expect(result.top).toHaveLength(48)
+    expect(result.bottom).toHaveLength(48)
   })
 
   it('separates top and bottom surface reservations for removable_top tables', () => {

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -548,6 +548,17 @@ describe('reservations service', () => {
         expect.objectContaining({ id: 'eq-2', available: true }),
       ]))
     })
+
+    it('accepts 24:00 as an end-time boundary', async () => {
+      const { listAvailableEquipmentForReservation } = await loadReservationModules()
+
+      await expect(listAvailableEquipmentForReservation({
+        roomId: 'room-1',
+        date: '2026-12-31',
+        startTime: '23:30',
+        endTime: '24:00',
+      })).resolves.toEqual(expect.any(Array))
+    })
   })
 
   describe('createReservationForSession', () => {
@@ -671,6 +682,17 @@ describe('reservations service', () => {
         startTime: '00:00',
         endTime: '01:00',
       })).resolves.toEqual(expect.objectContaining({ startTime: '00:00', endTime: '01:00' }))
+    })
+
+    it('accepts 24:00 as a valid reservation end boundary', async () => {
+      const { createReservationForSession } = await loadReservationModules()
+
+      await expect(createReservationForSession(memberSession, {
+        tableId: 't1',
+        date: '2026-12-31',
+        startTime: '23:30',
+        endTime: '24:00',
+      })).resolves.toEqual(expect.objectContaining({ startTime: '23:30', endTime: '24:00' }))
     })
 
     it('ignores non-active reservations when checking conflicts', async () => {
@@ -1027,6 +1049,18 @@ describe('reservations service', () => {
 
       expect(updated.startTime).toBe('00:00')
       expect(updated.endTime).toBe('01:00')
+    })
+
+    it('accepts 24:00 as a valid reservation end boundary on update', async () => {
+      const { updateReservationForSession } = await loadReservationModules()
+
+      const updated = await updateReservationForSession(memberSession, 'r1', {
+        startTime: '23:30',
+        endTime: '24:00',
+      })
+
+      expect(updated.startTime).toBe('23:30')
+      expect(updated.endTime).toBe('24:00')
     })
 
     it('rejects updates that move into an event-blocked range', async () => {

--- a/components/rooms/reservation-dialog.tsx
+++ b/components/rooms/reservation-dialog.tsx
@@ -17,7 +17,7 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 
-const ALL_TIME_SLOTS = generateTimeSlots('00:00', '24:00', 60)
+const ALL_TIME_SLOTS = generateTimeSlots('00:00', '24:00', 30)
 
 function addDaysToDateOnly(date: string, days: number) {
   const [year, month, day] = date.split('-').map(Number)

--- a/components/rooms/reservation-dialog.tsx
+++ b/components/rooms/reservation-dialog.tsx
@@ -321,6 +321,45 @@ export function ReservationDialog({ table, open, onClose }: ReservationDialogPro
                       </button>
                     )
                   })}
+                  {(() => {
+                    const midnightSlot = getSlotDetails('23:30', selectedSurface ?? undefined)
+                    const canSelectMidnightBoundary = Boolean(
+                      selectedStartTime &&
+                      !selectedEndTime &&
+                      selectedStartTime < '24:00'
+                    )
+                    const midnightAvailable = midnightSlot?.available ?? false
+                    const isMidnightEnd = selectedEndTime === '24:00'
+
+                    return (
+                      <button
+                        key="24:00"
+                        disabled={!canSelectMidnightBoundary || !midnightAvailable}
+                        onClick={() => {
+                          if (canSelectMidnightBoundary && midnightAvailable) {
+                            setSelectedEndTime('24:00')
+                          }
+                        }}
+                        className={cn(
+                          'py-1 px-1.5 text-xs rounded transition-all font-medium',
+                          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                          canSelectMidnightBoundary && midnightAvailable
+                            ? cn(
+                                'border hover:border-primary/60',
+                                isMidnightEnd && 'bg-primary text-primary-foreground border-primary',
+                                !isMidnightEnd && 'border-emerald/40 bg-emerald-dark/20 text-emerald-light'
+                              )
+                            : 'border border-dashed border-border/60 text-muted-foreground cursor-not-allowed opacity-60'
+                        )}
+                        aria-label={`24:00 — ${canSelectMidnightBoundary && midnightAvailable ? t('available') : t('occupied')}`}
+                        aria-pressed={isMidnightEnd}
+                        aria-disabled={!canSelectMidnightBoundary || !midnightAvailable}
+                        title="24:00"
+                      >
+                        24:00
+                      </button>
+                    )
+                  })()}
                 </div>
               )}
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -9,78 +9,40 @@
 ## Last updated: 2026-04-24
 
 ## Current branch
-`feat/KIM-382-qr-activation-window` (active — do NOT switch to develop)
+`feat/KIM-317-30-minute-reservation-times` (active — do NOT switch to develop)
 
 ## Open PRs — awaiting merge
-| PR | Branch | Fix |
-|---|---|---|
-| #116 | `feat/KIM-382-qr-activation-window` | Extend QR activation window, stabilize auth/test coverage |
+(none)
 
 ## Most recently merged
 | PR | Branch | Fix |
 |---|---|---|
+| #116 | `feat/KIM-382-qr-activation-window` | `KIM-382` merged into `develop`: 60-minute QR activation window, auth coverage expansion, Vitest stability fixes |
 | #115 | `feat/KIM-381-equipment-aware-reservations` | `KIM-381` merged into `develop`: equipment-aware reservation flow, overlap validation, one-week booking window, a11y fix (Radix Checkbox label pattern), ghost reservation safety, and pagination hardening |
 | #111 | `feat/KIM-386-database-time-drift` | `KIM-386` merged into `develop`: DB-backed timestamp authority, club-time date helpers, deterministic reservation cutoff handling, and one-statement migration split |
-| #110 | `feat/KIM-379-password-recovery` | `KIM-379` merged into `develop`: admin-mediated password recovery, stale-session auth redirects, and root entry redirect hardening |
 
 ---
 
 ## Status Summary
 
-`KIM-382` is in progress on branch `feat/KIM-382-qr-activation-window`.
+`KIM-317` is in progress on branch `feat/KIM-317-30-minute-reservation-times`.
 
-Already committed on branch:
-- `lib/server/reservations-service.ts`: `CHECK_IN_LATE_MINUTES = 60` added, `GRACE_PERIOD_MINUTES` 20→60, activation window now `min(start+60min, reservationEnd)` instead of `reservationEnd`
-- `messages/en.json` + `messages/es.json`: `checkin.tooLate` updated to reference 60-minute window
+In progress on branch:
+- `lib/server/availability.ts`: day availability now uses 30-minute slots across the full 24-hour range
+- `components/rooms/reservation-dialog.tsx`: reservation time selection now offers `00:00`–`23:30` in 30-minute steps
+- `lib/server/reservations-service.ts` + `lib/club-time.ts`: reservation end boundary now accepts `24:00`
+- tests updated for half-hour availability, dialog rendering, and `24:00` rollover
 
-Test suite optimisation in progress (NOT yet committed — working tree changes):
-- `@vitest-environment node` added to 28 server/api/utils test files
-- `__tests__/server/reservations-activation.test.ts` created (split from reservations-service.test.ts, 21 tests)
-- `__tests__/server/reservations-service.test.ts` reduced (3 redundant update time-format tests removed, activation block removed → 67 tests)
-- `vitest.config.mts`: `teardownTimeout: 10000` added
+Validation:
+- `pnpm exec vitest run __tests__/server/availability.test.ts` ✅
+- `pnpm exec vitest run __tests__/components/rooms/reservation-dialog.test.tsx` ✅
+- `pnpm exec vitest run __tests__/server/reservations-service.test.ts` ✅
+- `pnpm test` ✅
+- `pnpm test:coverage` ✅
 
-**BLOCKER: `__tests__/components/rooms/reservation-dialog.test.tsx` crashes with `ERR_IPC_CHANNEL_CLOSED` even in isolation.**
-This is the root cause of the non-zero exit on the full suite. Fix is pending — see test optimization plan below.
-
-## Pending test optimisation plan
-
-Execute in this exact order:
-
-### Step 1 — Full audit
-```bash
-find __tests__ -name "*.test.ts" -o -name "*.test.tsx" | sort
-```
-Review every file. Do not assume coverage from prior session.
-
-### Step 2 — Add `@vitest-environment node` to remaining non-DOM files
-Criterion: no `render`, `screen`, `userEvent`, no React component imports → node.
-Confirmed pending candidates: `hooks/`, `lib/` (except `auth-context.test.tsx`), `app/middleware.test.ts`.
-
-### Step 3 — `vitest.config.mts` final config
-```typescript
-fileParallelism: false,
-teardownTimeout: 10000,
-```
-
-### Step 4 — `package.json`
-```json
-"test:coverage": "NODE_OPTIONS=--max-old-space-size=4096 vitest run --coverage"
-```
-
-### Step 5 — Fix `reservation-dialog.test.tsx`
-Crashes with `ERR_IPC_CHANNEL_CLOSED` even in isolation (505 lines, 13 tests, jsdom + userEvent).
-Check: missing `vi.useFakeTimers()`, unresolved async operations, or heavy component imports leaking timers.
-Likely fix: add `cleanup()` from `@testing-library/react` in `afterEach`, ensure all `waitFor` have explicit timeouts.
-
-### Step 6 — Validation
-```bash
-pnpm test          # exit 0, all green
-pnpm test:coverage # exit 0, no OOM
-```
-
-Plan source:
-- Use only `docs/PLAN.md`.
-- Ignore removed legacy planning docs and canceled legacy tickets.
+Next likely work:
+- open PR for `KIM-317`
+- follow-up equipment-model issue created in Linear: `KIM-389`
 
 ---
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,6 +1,6 @@
 # Alea Plan
 
-**Last updated:** 2026-04-21
+**Last updated:** 2026-04-24
 **Source of truth:** current repository state + active Linear issues for project `Alea`
 **Ignore:** canceled legacy tickets and removed migration-era planning docs
 
@@ -97,7 +97,7 @@ Reason:
 
 ## Recommended Next Build Step
 
-`KIM-382` is in progress on `feat/KIM-382-qr-activation-window`. PR #116 is open. Test suite optimisation is still in progress while review feedback is addressed. Full plan in `docs/HANDOFF.md` under "Pending test optimisation plan".
+`KIM-317` is in progress on `feat/KIM-317-30-minute-reservation-times`. Current focus: switch reservation availability and selection from hourly slots to 30-minute slots across the full day, while keeping validation and overlap checks aligned.
 
 ---
 

--- a/lib/club-time.ts
+++ b/lib/club-time.ts
@@ -54,11 +54,12 @@ function getFormatterParts(date: Date, timeZone: string) {
 
 function getTimeZoneOffsetMs(date: Date, timeZone: string) {
   const parts = getFormatterParts(date, timeZone)
+  const normalizedHour = parts.hour === 24 ? 0 : parts.hour!
   const asUtc = Date.UTC(
     parts.year!,
     parts.month! - 1,
     parts.day!,
-    parts.hour!,
+    normalizedHour,
     parts.minute!,
     parts.second!,
     0,
@@ -105,6 +106,13 @@ export function getCurrentClubDate(now: Date = new Date(), timeZone = CLUB_TIMEZ
 export function zonedDateTimeToUtc(date: string, time: string, timeZone = CLUB_TIMEZONE) {
   if (!isValidDateOnlyString(date)) {
     throw new Error(`Invalid date-only value: ${date}`)
+  }
+
+  if (time === '24:00' || time === '24:00:00') {
+    const [year, month, day] = date.split('-').map(Number)
+    const nextDay = new Date(Date.UTC(year!, month! - 1, day! + 1, 0, 0, 0, 0))
+    const nextDate = nextDay.toISOString().slice(0, 10)
+    return zonedDateTimeToUtc(nextDate, '00:00:00', timeZone)
   }
 
   const match = time.match(TIME_PATTERN)

--- a/lib/server/availability.ts
+++ b/lib/server/availability.ts
@@ -13,6 +13,16 @@ type ReservedSlot = {
   label?: string | null
 }
 
+const DAY_MINUTES = 24 * 60
+const SLOT_INTERVAL_MINUTES = 30
+
+function formatSlotMinutes(totalMinutes: number) {
+  if (totalMinutes === DAY_MINUTES) return '24:00'
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`
+}
+
 export function resolveDate(date?: string | null): string {
   const today = getCurrentClubDate()
   if (!date || date.trim() === '') return today
@@ -28,10 +38,11 @@ export function normalizeTime(time: string) {
 }
 
 export function generateDaySlots(reservedSlots: ReservedSlot[]): TimeSlot[] {
-  return Array.from({ length: 24 }, (_, i) => {
-    const slotStart = `${String(i).padStart(2, '0')}:00`
-    const nextHour = i + 1
-    const slotEnd = nextHour < 24 ? `${String(nextHour).padStart(2, '0')}:00` : '24:00'
+  return Array.from({ length: DAY_MINUTES / SLOT_INTERVAL_MINUTES }, (_, i) => {
+    const slotStartMinutes = i * SLOT_INTERVAL_MINUTES
+    const slotEndMinutes = slotStartMinutes + SLOT_INTERVAL_MINUTES
+    const slotStart = formatSlotMinutes(slotStartMinutes)
+    const slotEnd = formatSlotMinutes(slotEndMinutes)
     const reservation = reservedSlots.find((item) => item.start < slotEnd && slotStart < item.end)
     return {
       startTime: slotStart,

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -100,7 +100,10 @@ function parseDate(value: string): string {
   return value
 }
 
-function parseHHMM(value: string): string {
+function parseHHMM(value: string, options?: { allow24HourBoundary?: boolean }): string {
+  if (options?.allow24HourBoundary && value === '24:00') {
+    return value
+  }
   if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(value)) {
     serviceError('Time must be in HH:MM format (00:00–23:59)', 400)
   }
@@ -501,7 +504,7 @@ export async function listAvailableEquipmentForReservation(input: {
 }) {
   const date = parseDate(requireString(input.date))
   const startTime = parseHHMM(requireString(input.startTime))
-  const endTime = parseHHMM(requireString(input.endTime))
+  const endTime = parseHHMM(requireString(input.endTime), { allow24HourBoundary: true })
 
   if (startTime >= endTime) {
     serviceError('Invalid reservation time range', 400)
@@ -577,7 +580,7 @@ export async function createReservationForSession(
 
   const date = parseDate(rawDate)
   const startTime = parseHHMM(rawStartTime)
-  const endTime = parseHHMM(rawEndTime)
+  const endTime = parseHHMM(rawEndTime, { allow24HourBoundary: true })
 
   const table = await getTable(tableId)
   if (!table) {
@@ -693,7 +696,7 @@ export async function updateReservationForSession(
     : parseHHMM(String(body.startTime))
   const nextEndTime = body.endTime == null
     ? normalizeTime(existingReservation.end_time)
-    : parseHHMM(String(body.endTime))
+    : parseHHMM(String(body.endTime), { allow24HourBoundary: true })
   const nextDate = body.date == null ? existingReservation.date : parseDate(String(body.date))
   const nextSurface = body.surface === undefined || body.surface === null
     ? (existingReservation.surface ?? null)


### PR DESCRIPTION
## Summary

This PR implements `KIM-317` by switching reservation selection and availability from hourly slots to 30-minute slots across the full day.

## What changed

- changed room availability generation to 30-minute slots instead of 60-minute slots
- updated the reservation dialog to offer `00:00` through `23:30` in half-hour increments
- added backend support for reservation ranges ending at `24:00`
- fixed `club-time` handling so `24:00` resolves to next-day midnight correctly
- refreshed tests and planning docs for the new branch state

## Validation

- `pnpm test`
- `pnpm test:coverage`
- push hook: `pnpm typecheck`
- push hook: `pnpm lint`

## Notes

- `24:00` is accepted only as an end boundary, not as a start time
- follow-up issue created in Linear: `KIM-389` for the room-default-equipment vs reservable-equipment model split
