### PR TITLE
Add admin event scheduling and reservation blocking

### DIFF
--- a/__tests__/server/availability.test.ts
+++ b/__tests__/server/availability.test.ts
@@ -158,6 +158,14 @@ describe('buildAvailability', () => {
     expect(blockedSlot?.available).toBe(false)
   })
 
+  it('marks the slot blocked by an event as unavailable', () => {
+    const table = makeGameTable()
+    const result = buildAvailability(table, '2025-06-15', [], [{ start: '14:00', end: '16:00' }])
+
+    expect(result.slots.find((s) => s.startTime === '14:00')?.available).toBe(false)
+    expect(result.slots.find((s) => s.startTime === '13:00')?.available).toBe(true)
+  })
+
   it('leaves slots outside a reservation range as available', () => {
     const table = makeGameTable()
     const reservation = makeReservationRow({ start_time: '10:00:00', end_time: '11:00:00' })

--- a/__tests__/server/reservations-service.test.ts
+++ b/__tests__/server/reservations-service.test.ts
@@ -31,6 +31,19 @@ type RoomRow = {
   name: string
 }
 
+type EventRoomRow = {
+  event_id: string
+  room_id: string
+}
+
+type EventScheduleRow = {
+  id: string
+  event_id: string
+  date: string
+  start_time: string
+  end_time: string
+}
+
 const adminSession: SessionUser = {
   id: '1',
   role: 'admin',
@@ -42,6 +55,8 @@ const memberSession: SessionUser = {
 }
 
 const reservationsState: ReservationRow[] = []
+const eventRoomsState: EventRoomRow[] = []
+const eventSchedulesState: EventScheduleRow[] = []
 const tablesState = new Map<string, TableRow>()
 const profilesMap = new Map<string, { member_number: string }>()
 const roomsMap = new Map<string, RoomRow>()
@@ -93,6 +108,8 @@ function seedState() {
   })
 
   reservationsState.length = 0
+  eventRoomsState.length = 0
+  eventSchedulesState.length = 0
 
   const r1base = makeReservation()
   const t1 = tablesState.get(r1base.table_id)!
@@ -127,6 +144,10 @@ function buildSelectChain<T>(rows: T[]) {
     },
     neq(column: string, value: string) {
       current = current.filter((row) => String((row as Record<string, unknown>)[column]) !== value)
+      return this
+    },
+    in(column: string, values: string[]) {
+      current = current.filter((row) => values.includes(String((row as Record<string, unknown>)[column])))
       return this
     },
     order(column: string, { ascending }: { ascending: boolean }) {
@@ -214,13 +235,25 @@ vi.mock('@/lib/supabase/server', () => ({
   })),
   createSupabaseServerAdminClient: vi.fn(() => ({
     from: vi.fn((table: string) => {
-      if (table !== 'reservations') {
-        throw new Error(`Unexpected admin table ${table}`)
+      if (table === 'reservations') {
+        return {
+          select: vi.fn(() => buildSelectChain(reservationsState)),
+        }
       }
 
-      return {
-        select: vi.fn(() => buildSelectChain(reservationsState)),
+      if (table === 'event_rooms') {
+        return {
+          select: vi.fn(() => buildSelectChain(eventRoomsState)),
+        }
       }
+
+      if (table === 'event_schedules') {
+        return {
+          select: vi.fn(() => buildSelectChain(eventSchedulesState)),
+        }
+      }
+
+      throw new Error(`Unexpected admin table ${table}`)
     }),
   })),
 }))
@@ -373,6 +406,28 @@ describe('reservations service', () => {
         date: '2026-04-04',
         startTime: '17:00',
         endTime: '18:30',
+      })).rejects.toMatchObject({
+        name: 'ServiceError',
+        statusCode: 409,
+      })
+    })
+
+    it('maps overlapping event blocks to a 409 service error', async () => {
+      eventRoomsState.push({ event_id: 'event-1', room_id: 'room-1' })
+      eventSchedulesState.push({
+        id: 'event-schedule-1',
+        event_id: 'event-1',
+        date: '2026-04-05',
+        start_time: '12:00:00',
+        end_time: '14:00:00',
+      })
+      const { createReservationForSession } = await loadReservationModules()
+
+      await expect(createReservationForSession(memberSession, {
+        tableId: 't1',
+        date: '2026-04-05',
+        startTime: '13:00',
+        endTime: '14:00',
       })).rejects.toMatchObject({
         name: 'ServiceError',
         statusCode: 409,

--- a/__tests__/server/rooms-service.test.ts
+++ b/__tests__/server/rooms-service.test.ts
@@ -5,6 +5,8 @@ const maybeSingleMock = vi.fn()
 const listRoomsMock = vi.fn()
 const listTablesMock = vi.fn()
 const listReservationsMock = vi.fn()
+const listEventRoomsMock = vi.fn()
+const listEventSchedulesMock = vi.fn()
 const updateMock = vi.fn()
 
 vi.mock('@/lib/supabase/server', () => ({
@@ -30,6 +32,24 @@ vi.mock('@/lib/supabase/server', () => ({
           select: vi.fn(() => ({
             eq: vi.fn(() => ({
               order: listTablesMock,
+            })),
+          })),
+        }
+      }
+
+      if (table === 'event_rooms') {
+        return {
+          select: vi.fn(() => ({
+            in: listEventRoomsMock,
+          })),
+        }
+      }
+
+      if (table === 'event_schedules') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              in: listEventSchedulesMock,
             })),
           })),
         }
@@ -73,6 +93,24 @@ vi.mock('@/lib/supabase/server', () => ({
           insert: vi.fn(() => ({
             select: vi.fn(() => ({
               maybeSingle: maybeSingleMock,
+            })),
+          })),
+        }
+      }
+
+      if (table === 'event_rooms') {
+        return {
+          select: vi.fn(() => ({
+            in: listEventRoomsMock,
+          })),
+        }
+      }
+
+      if (table === 'event_schedules') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              in: listEventSchedulesMock,
             })),
           })),
         }
@@ -255,6 +293,8 @@ describe('createTableEntry', () => {
       data: { id: 't1', room_id: '1', name: 'Mesa 1', type: 'small', qr_code: null, pos_x: null, pos_y: null },
       error: null,
     })
+    listEventRoomsMock.mockResolvedValue({ data: [], error: null })
+    listEventSchedulesMock.mockResolvedValue({ data: [], error: null })
   })
 
   it('maps a foreign-key violation (23503) to a 400 ServiceError', async () => {

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/server/auth'
+import { deleteEvent, updateEvent } from '@/lib/server/events-service'
+import { toServiceErrorResponse } from '@/lib/server/http-error'
+import { enforceMutationSecurity, enforceRateLimit, RATE_LIMIT_POLICIES } from '@/lib/server/security'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export async function PUT(request: NextRequest, context: RouteContext) {
+  const securityError = enforceMutationSecurity(request)
+  if (securityError) return securityError
+
+  const rateLimitError = enforceRateLimit(request, RATE_LIMIT_POLICIES.adminMutation)
+  if (rateLimitError) return rateLimitError
+
+  const admin = await requireAdmin(request)
+  if (admin instanceof NextResponse) return admin
+
+  try {
+    const { id } = await context.params
+    const body = await request.json()
+    return admin.applyCookies(NextResponse.json(await updateEvent(id, body)))
+  } catch (error) {
+    return admin.applyCookies(toServiceErrorResponse(error))
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const securityError = enforceMutationSecurity(request)
+  if (securityError) return securityError
+
+  const rateLimitError = enforceRateLimit(request, RATE_LIMIT_POLICIES.adminMutation)
+  if (rateLimitError) return rateLimitError
+
+  const admin = await requireAdmin(request)
+  if (admin instanceof NextResponse) return admin
+
+  try {
+    const { id } = await context.params
+    await deleteEvent(id)
+    return admin.applyCookies(new NextResponse(null, { status: 204 }))
+  } catch (error) {
+    return admin.applyCookies(toServiceErrorResponse(error))
+  }
+}

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/server/auth'
+import { createEvent, listEvents } from '@/lib/server/events-service'
+import { toServiceErrorResponse } from '@/lib/server/http-error'
+import { enforceMutationSecurity, enforceRateLimit, RATE_LIMIT_POLICIES } from '@/lib/server/security'
+
+export async function GET(request: NextRequest) {
+  const admin = await requireAdmin(request)
+  if (admin instanceof NextResponse) return admin
+
+  try {
+    return admin.applyCookies(NextResponse.json(await listEvents()))
+  } catch (error) {
+    return admin.applyCookies(toServiceErrorResponse(error))
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const securityError = enforceMutationSecurity(request)
+  if (securityError) return securityError
+
+  const rateLimitError = enforceRateLimit(request, RATE_LIMIT_POLICIES.adminMutation)
+  if (rateLimitError) return rateLimitError
+
+  const admin = await requireAdmin(request)
+  if (admin instanceof NextResponse) return admin
+
+  try {
+    const body = await request.json()
+    return admin.applyCookies(NextResponse.json(await createEvent(body), { status: 201 }))
+  } catch (error) {
+    return admin.applyCookies(toServiceErrorResponse(error))
+  }
+}

--- a/components/admin/admin-dashboard.tsx
+++ b/components/admin/admin-dashboard.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import { useTranslations } from 'next-intl'
-import { LayoutDashboard, Users, CalendarDays, DoorOpen } from 'lucide-react'
+import { LayoutDashboard, Users, CalendarDays, DoorOpen, CalendarRange } from 'lucide-react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { UsersSection } from './users-section'
 import { ReservationsSection } from './reservations-section'
 import { RoomsSection } from './rooms-section'
+import { EventsSection } from './events-section'
 
 export function AdminDashboard() {
   const t = useTranslations('admin')
@@ -47,6 +48,10 @@ export function AdminDashboard() {
             <DoorOpen className="h-4 w-4" aria-hidden="true" />
             {t('rooms')}
           </TabsTrigger>
+          <TabsTrigger value="events" className="gap-2 data-[state=active]:border data-[state=active]:border-primary/30">
+            <CalendarRange className="h-4 w-4" aria-hidden="true" />
+            {t('events')}
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="users">
@@ -59,6 +64,10 @@ export function AdminDashboard() {
 
         <TabsContent value="rooms">
           <RoomsSection />
+        </TabsContent>
+
+        <TabsContent value="events">
+          <EventsSection />
         </TabsContent>
       </Tabs>
     </div>

--- a/components/admin/events-section.tsx
+++ b/components/admin/events-section.tsx
@@ -1,0 +1,312 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { CalendarRange, Clock, Pencil, Plus, Trash2 } from 'lucide-react'
+import { DiceLoader } from '@/components/ui/dice-loader'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
+} from '@/components/ui/dialog'
+import {
+  useAdminRooms,
+  useAdminEvents,
+  useAdminCreateEvent,
+  useAdminUpdateEvent,
+  useAdminDeleteEvent,
+} from '@/lib/hooks/use-admin'
+import type { AdminEvent, CreateEventRequest } from '@/lib/types'
+import { formatDate, formatTime } from '@/lib/utils'
+
+type ScheduleDraft = { date: string; startTime: string; endTime: string }
+
+const emptySchedule = (): ScheduleDraft => ({
+  date: new Date().toISOString().slice(0, 10),
+  startTime: '10:00',
+  endTime: '12:00',
+})
+
+function eventToDraft(event?: AdminEvent): CreateEventRequest {
+  return {
+    title: event?.title ?? '',
+    description: event?.description ?? '',
+    roomIds: event?.roomIds ?? [],
+    schedules: event?.schedules.map((schedule) => ({
+      date: schedule.date,
+      startTime: schedule.startTime,
+      endTime: schedule.endTime,
+    })) ?? [emptySchedule()],
+  }
+}
+
+export function EventsSection() {
+  const t = useTranslations('admin')
+  const tc = useTranslations('common')
+  const { data: events, isLoading } = useAdminEvents()
+  const { data: rooms } = useAdminRooms()
+  const createEvent = useAdminCreateEvent()
+  const updateEvent = useAdminUpdateEvent()
+  const deleteEvent = useAdminDeleteEvent()
+
+  const [editing, setEditing] = useState<AdminEvent | null>(null)
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState<CreateEventRequest>(eventToDraft())
+
+  const roomNames = useMemo(() => {
+    return new Map((rooms ?? []).map((room) => [room.id, room.name]))
+  }, [rooms])
+
+  function openCreate() {
+    setEditing(null)
+    setDraft(eventToDraft())
+    setOpen(true)
+  }
+
+  function openEdit(event: AdminEvent) {
+    setEditing(event)
+    setDraft(eventToDraft(event))
+    setOpen(true)
+  }
+
+  function toggleRoom(roomId: string, checked: boolean) {
+    setDraft((current) => ({
+      ...current,
+      roomIds: checked
+        ? [...current.roomIds, roomId]
+        : current.roomIds.filter((id) => id !== roomId),
+    }))
+  }
+
+  function updateSchedule(index: number, patch: Partial<ScheduleDraft>) {
+    setDraft((current) => ({
+      ...current,
+      schedules: current.schedules.map((schedule, i) => i === index ? { ...schedule, ...patch } : schedule),
+    }))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (editing) {
+      await updateEvent.mutateAsync({ id: editing.id, data: draft })
+    } else {
+      await createEvent.mutateAsync(draft)
+    }
+    setOpen(false)
+  }
+
+  const saving = createEvent.isPending || updateEvent.isPending
+
+  return (
+    <section aria-labelledby="events-heading" className="space-y-5">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center justify-center w-8 h-8 rounded-md bg-primary/10 border border-primary/20">
+            <CalendarRange className="h-4 w-4 text-primary" aria-hidden="true" />
+          </div>
+          <h2 id="events-heading" className="font-cinzel text-xl font-semibold text-foreground">
+            {t('eventManagement')}
+          </h2>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={openCreate}
+          className="gap-1.5 border-primary/30 text-primary/80 hover:bg-primary/10"
+        >
+          <Plus className="h-4 w-4" aria-hidden="true" />
+          {t('createEvent')}
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="rpg-card px-4 py-4 space-y-3">
+              <Skeleton className="h-5 w-44 rounded" />
+              <Skeleton className="h-4 w-72 rounded" />
+              <Skeleton className="h-8 w-full rounded" />
+            </div>
+          ))}
+        </div>
+      ) : (events ?? []).length === 0 ? (
+        <div className="rpg-card p-12 text-center flex flex-col items-center gap-4">
+          <div className="w-12 h-12 rounded-full bg-muted/40 flex items-center justify-center">
+            <CalendarRange className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
+          </div>
+          <p className="font-cinzel text-sm font-semibold text-muted-foreground">{t('noEvents')}</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {(events ?? []).map((event) => (
+            <article key={event.id} className="rpg-card p-4 space-y-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 className="font-cinzel font-semibold text-foreground truncate">{event.title}</h3>
+                  {event.description && (
+                    <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{event.description}</p>
+                  )}
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => openEdit(event)} aria-label={t('editEvent')}>
+                    <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-destructive hover:text-destructive"
+                    onClick={() => deleteEvent.mutate(event.id)}
+                    aria-label={t('deleteEvent')}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Button>
+                </div>
+              </div>
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="rounded-md border border-border/50 bg-background-secondary/30 p-3">
+                  <p className="text-xs font-cinzel font-semibold uppercase text-muted-foreground mb-2">{t('blockedRooms')}</p>
+                  <div className="flex flex-wrap gap-2">
+                    {event.roomIds.map((roomId) => (
+                      <span key={roomId} className="rounded-full border border-primary/20 bg-primary/10 px-2 py-1 text-xs text-primary">
+                        {roomNames.get(roomId) ?? roomId.slice(0, 8)}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <div className="rounded-md border border-border/50 bg-background-secondary/30 p-3">
+                  <p className="text-xs font-cinzel font-semibold uppercase text-muted-foreground mb-2">{t('eventSchedules')}</p>
+                  <div className="space-y-1.5">
+                    {event.schedules.map((schedule) => (
+                      <p key={schedule.id} className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <Clock className="h-3.5 w-3.5 text-primary/70" aria-hidden="true" />
+                        <span className="text-foreground">{formatDate(schedule.date)}</span>
+                        <span>{formatTime(schedule.startTime)} - {formatTime(schedule.endTime)}</span>
+                      </p>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="bg-card border-border max-w-2xl">
+          <DialogHeader>
+            <DialogTitle className="font-cinzel text-gradient-gold">
+              {editing ? t('editEvent') : t('createEvent')}
+            </DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-5 py-2">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="event-title">{t('eventTitle')}</Label>
+                <Input
+                  id="event-title"
+                  value={draft.title}
+                  onChange={(e) => setDraft((current) => ({ ...current, title: e.target.value }))}
+                  required
+                  className="bg-background-secondary border-border"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="event-description">{t('eventDescription')}</Label>
+                <Input
+                  id="event-description"
+                  value={draft.description ?? ''}
+                  onChange={(e) => setDraft((current) => ({ ...current, description: e.target.value }))}
+                  className="bg-background-secondary border-border"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label>{t('blockedRooms')}</Label>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {(rooms ?? []).map((room) => (
+                  <label key={room.id} className="flex items-center gap-2 rounded-md border border-border/60 bg-background-secondary/30 px-3 py-2 text-sm">
+                    <Checkbox
+                      checked={draft.roomIds.includes(room.id)}
+                      onCheckedChange={(checked) => toggleRoom(room.id, checked === true)}
+                    />
+                    <span>{room.name}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <Label>{t('eventSchedules')}</Label>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setDraft((current) => ({ ...current, schedules: [...current.schedules, emptySchedule()] }))}
+                >
+                  <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+                  {t('addSchedule')}
+                </Button>
+              </div>
+              <div className="space-y-2">
+                {draft.schedules.map((schedule, index) => (
+                  <div key={index} className="grid gap-2 rounded-md border border-border/60 bg-background-secondary/30 p-3 sm:grid-cols-[1fr_1fr_1fr_auto]">
+                    <Input
+                      type="date"
+                      value={schedule.date}
+                      onChange={(e) => updateSchedule(index, { date: e.target.value })}
+                      required
+                      className="bg-background border-border"
+                    />
+                    <Input
+                      type="time"
+                      value={schedule.startTime}
+                      onChange={(e) => updateSchedule(index, { startTime: e.target.value })}
+                      required
+                      className="bg-background border-border"
+                    />
+                    <Input
+                      type="time"
+                      value={schedule.endTime}
+                      onChange={(e) => updateSchedule(index, { endTime: e.target.value })}
+                      required
+                      className="bg-background border-border"
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={t('deleteSchedule')}
+                      onClick={() => setDraft((current) => ({
+                        ...current,
+                        schedules: current.schedules.filter((_, i) => i !== index),
+                      }))}
+                      disabled={draft.schedules.length === 1}
+                    >
+                      <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setOpen(false)} className="border-border">
+                {tc('cancel')}
+              </Button>
+              <Button type="submit" disabled={saving || draft.roomIds.length === 0 || draft.schedules.length === 0}>
+                {saving ? (
+                  <span className="inline-flex items-center gap-2"><DiceLoader size="sm" hideRole /><span>{t('saving')}</span></span>
+                ) : tc('save')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </section>
+  )
+}

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -26,4 +26,8 @@ export const endpoints = {
     },
     byId: (id: string) => `/reservations/${id}`,
   },
+  events: {
+    list: '/events',
+    byId: (id: string) => `/events/${id}`,
+  },
 } as const

--- a/lib/hooks/use-admin.ts
+++ b/lib/hooks/use-admin.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import type { User, Room, GameTable, Reservation, PaginatedResponse } from '@/lib/types'
+import type { User, Room, GameTable, Reservation, PaginatedResponse, AdminEvent, CreateEventRequest } from '@/lib/types'
 import { apiClient } from '@/lib/api/client'
 import { endpoints } from '@/lib/api/endpoints'
 
@@ -114,6 +114,50 @@ export function useAdminCreateTable() {
     onSuccess: (_created, variables) => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'rooms', variables.roomId, 'tables'] })
       queryClient.invalidateQueries({ queryKey: ['rooms', variables.roomId, 'tables'] })
+    },
+  })
+}
+
+// ----- Events -----
+
+export function useAdminEvents() {
+  return useQuery<AdminEvent[]>({
+    queryKey: ['admin', 'events'],
+    queryFn: () => apiClient.get<AdminEvent[]>(endpoints.events.list),
+    staleTime: 30_000,
+  })
+}
+
+export function useAdminCreateEvent() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: CreateEventRequest) => apiClient.post<AdminEvent>(endpoints.events.list, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'events'] })
+      queryClient.invalidateQueries({ queryKey: ['availability'] })
+    },
+  })
+}
+
+export function useAdminUpdateEvent() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: CreateEventRequest }) =>
+      apiClient.put<AdminEvent>(endpoints.events.byId(id), data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'events'] })
+      queryClient.invalidateQueries({ queryKey: ['availability'] })
+    },
+  })
+}
+
+export function useAdminDeleteEvent() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => apiClient.delete<void>(endpoints.events.byId(id)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'events'] })
+      queryClient.invalidateQueries({ queryKey: ['availability'] })
     },
   })
 }

--- a/lib/server/availability.ts
+++ b/lib/server/availability.ts
@@ -3,6 +3,7 @@ import type { Tables } from '@/lib/supabase/types'
 import { serviceError } from '@/lib/server/service-error'
 
 type ReservationRow = Tables<'reservations'>
+type EventBlock = { start: string; end: string }
 
 export function resolveDate(date?: string | null): string {
   const today = new Date().toISOString().split('T')[0]
@@ -32,25 +33,34 @@ export function generateDaySlots(reservedSlots: Array<{ start: string; end: stri
   })
 }
 
-export function buildAvailability(table: GameTable, date: string, reservations: ReservationRow[]): TableAvailability {
+export function buildAvailability(
+  table: GameTable,
+  date: string,
+  reservations: ReservationRow[],
+  eventBlocks: EventBlock[] = [],
+): TableAvailability {
   const reserved = reservations.map((reservation) => ({
     start: normalizeTime(reservation.start_time),
     end: normalizeTime(reservation.end_time),
     surface: reservation.surface ?? undefined,
   }))
+  const blocked = [
+    ...reserved,
+    ...eventBlocks.map((block) => ({ ...block, surface: undefined })),
+  ]
 
   const availability: TableAvailability = {
     tableId: table.id,
     date,
-    slots: generateDaySlots(reserved),
+    slots: generateDaySlots(blocked),
   }
 
   if (table.type === 'removable_top') {
-    const topReserved = reserved.filter((reservation) => reservation.surface == null || reservation.surface === 'top')
-    const bottomReserved = reserved.filter((reservation) => reservation.surface == null || reservation.surface === 'bottom')
+    const topReserved = blocked.filter((reservation) => reservation.surface == null || reservation.surface === 'top')
+    const bottomReserved = blocked.filter((reservation) => reservation.surface == null || reservation.surface === 'bottom')
     availability.top = generateDaySlots(topReserved)
     availability.bottom = generateDaySlots(bottomReserved)
-    availability.conflicts = generateDaySlots(reserved)
+    availability.conflicts = generateDaySlots(blocked)
   }
 
   return availability

--- a/lib/server/events-service.ts
+++ b/lib/server/events-service.ts
@@ -1,0 +1,308 @@
+import type { AdminEvent, CreateEventRequest } from '@/lib/types'
+import { serviceError } from '@/lib/server/service-error'
+import { createSupabaseServerAdminClient } from '@/lib/supabase/server'
+import type { Tables, TablesInsert } from '@/lib/supabase/types'
+
+type EventRow = Tables<'events'>
+type EventRoomRow = Tables<'event_rooms'>
+type EventScheduleRow = Tables<'event_schedules'>
+type EventBlock = { start: string; end: string }
+
+const EVENT_COLUMNS = 'id, title, description, created_at, updated_at'
+const EVENT_ROOM_COLUMNS = 'event_id, room_id'
+const EVENT_SCHEDULE_COLUMNS = 'id, event_id, date, start_time, end_time'
+
+function parseDate(value: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    serviceError('Date must be in YYYY-MM-DD format', 400)
+  }
+  const d = new Date(value)
+  if (isNaN(d.getTime())) {
+    serviceError('Invalid date value', 400)
+  }
+  return value
+}
+
+function parseHHMM(value: string): string {
+  if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(value)) {
+    serviceError('Time must be in HH:MM format (00:00-23:59)', 400)
+  }
+  return value
+}
+
+function normalizeTime(value: string) {
+  return value.slice(0, 5)
+}
+
+function uniqueStrings(values: unknown[]): string[] {
+  return [...new Set(values.map((value) => String(value ?? '').trim()).filter(Boolean))]
+}
+
+function parseEventBody(body: Partial<CreateEventRequest>) {
+  const title = String(body.title ?? '').trim()
+  if (!title) {
+    serviceError('Event title is required', 400)
+  }
+
+  const roomIds = uniqueStrings(Array.isArray(body.roomIds) ? body.roomIds : [])
+  if (roomIds.length === 0) {
+    serviceError('At least one room is required', 400)
+  }
+
+  const rawSchedules = Array.isArray(body.schedules) ? body.schedules : []
+  if (rawSchedules.length === 0) {
+    serviceError('At least one schedule is required', 400)
+  }
+
+  const schedules = rawSchedules.map((schedule) => {
+    const date = parseDate(String(schedule.date ?? ''))
+    const startTime = parseHHMM(String(schedule.startTime ?? ''))
+    const endTime = parseHHMM(String(schedule.endTime ?? ''))
+    if (startTime >= endTime) {
+      serviceError('Invalid event time range', 400)
+    }
+    return { date, startTime, endTime }
+  })
+
+  return {
+    title,
+    description: body.description ? String(body.description).trim() : null,
+    roomIds,
+    schedules,
+  }
+}
+
+function mapEvent(
+  event: EventRow,
+  rooms: EventRoomRow[],
+  schedules: EventScheduleRow[],
+): AdminEvent {
+  return {
+    id: event.id,
+    title: event.title,
+    description: event.description,
+    roomIds: rooms.filter((room) => room.event_id === event.id).map((room) => room.room_id),
+    schedules: schedules
+      .filter((schedule) => schedule.event_id === event.id)
+      .map((schedule) => ({
+        id: schedule.id,
+        eventId: schedule.event_id,
+        date: schedule.date,
+        startTime: normalizeTime(schedule.start_time),
+        endTime: normalizeTime(schedule.end_time),
+      })),
+    createdAt: event.created_at,
+    updatedAt: event.updated_at,
+  }
+}
+
+async function fetchEventParts(eventIds: string[]) {
+  const admin = createSupabaseServerAdminClient()
+  if (eventIds.length === 0) {
+    return { rooms: [] as EventRoomRow[], schedules: [] as EventScheduleRow[] }
+  }
+
+  const [roomsResult, schedulesResult] = await Promise.all([
+    admin.from('event_rooms').select(EVENT_ROOM_COLUMNS).in('event_id', eventIds),
+    admin.from('event_schedules').select(EVENT_SCHEDULE_COLUMNS).in('event_id', eventIds),
+  ])
+
+  if (roomsResult.error || schedulesResult.error) {
+    serviceError('Internal server error', 500)
+  }
+
+  return {
+    rooms: (roomsResult.data ?? []) as EventRoomRow[],
+    schedules: (schedulesResult.data ?? []) as EventScheduleRow[],
+  }
+}
+
+export async function listEvents() {
+  const admin = createSupabaseServerAdminClient()
+  const { data, error } = await admin
+    .from('events')
+    .select(EVENT_COLUMNS)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    serviceError('Internal server error', 500)
+  }
+
+  const events = (data ?? []) as EventRow[]
+  const parts = await fetchEventParts(events.map((event) => event.id))
+  return events.map((event) => mapEvent(event, parts.rooms, parts.schedules))
+}
+
+export async function createEvent(body: Partial<CreateEventRequest>) {
+  const input = parseEventBody(body)
+  const admin = createSupabaseServerAdminClient()
+
+  const { data, error } = await admin
+    .from('events')
+    .insert({ title: input.title, description: input.description } satisfies TablesInsert<'events'>)
+    .select(EVENT_COLUMNS)
+    .maybeSingle()
+
+  if (error || !data) {
+    serviceError('Internal server error', 500)
+  }
+
+  await replaceEventChildren(data.id, input.roomIds, input.schedules)
+  const parts = await fetchEventParts([data.id])
+  return mapEvent(data as EventRow, parts.rooms, parts.schedules)
+}
+
+export async function updateEvent(eventId: string, body: Partial<CreateEventRequest>) {
+  const input = parseEventBody(body)
+  const admin = createSupabaseServerAdminClient()
+
+  const { data, error } = await admin
+    .from('events')
+    .update({ title: input.title, description: input.description, updated_at: new Date().toISOString() })
+    .eq('id', eventId)
+    .select(EVENT_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    serviceError('Internal server error', 500)
+  }
+  if (!data) {
+    serviceError('Event not found', 404)
+  }
+
+  await replaceEventChildren(eventId, input.roomIds, input.schedules)
+  const parts = await fetchEventParts([eventId])
+  return mapEvent(data as EventRow, parts.rooms, parts.schedules)
+}
+
+export async function deleteEvent(eventId: string) {
+  const admin = createSupabaseServerAdminClient()
+  const { error } = await admin.from('events').delete().eq('id', eventId)
+
+  if (error) {
+    serviceError('Internal server error', 500)
+  }
+}
+
+async function replaceEventChildren(
+  eventId: string,
+  roomIds: string[],
+  schedules: Array<{ date: string; startTime: string; endTime: string }>,
+) {
+  const admin = createSupabaseServerAdminClient()
+  const [roomsDelete, schedulesDelete] = await Promise.all([
+    admin.from('event_rooms').delete().eq('event_id', eventId),
+    admin.from('event_schedules').delete().eq('event_id', eventId),
+  ])
+
+  if (roomsDelete.error || schedulesDelete.error) {
+    serviceError('Internal server error', 500)
+  }
+
+  const [roomsInsert, schedulesInsert] = await Promise.all([
+    admin.from('event_rooms').insert(roomIds.map((roomId) => ({ event_id: eventId, room_id: roomId }))),
+    admin.from('event_schedules').insert(schedules.map((schedule) => ({
+      event_id: eventId,
+      date: schedule.date,
+      start_time: schedule.startTime,
+      end_time: schedule.endTime,
+    }))),
+  ])
+
+  if (roomsInsert.error || schedulesInsert.error) {
+    serviceError('Internal server error', 500)
+  }
+}
+
+export function hasEventConflict(
+  blocks: EventBlock[],
+  input: { startTime: string; endTime: string },
+) {
+  return blocks.some((block) => block.start < input.endTime && input.startTime < block.end)
+}
+
+export async function listEventBlocksForRoom(input: {
+  roomId: string
+  date: string
+}): Promise<EventBlock[]> {
+  const admin = createSupabaseServerAdminClient()
+  const roomsResult = await admin
+    .from('event_rooms')
+    .select(EVENT_ROOM_COLUMNS)
+    .eq('room_id', input.roomId)
+
+  if (roomsResult.error) {
+    serviceError('Internal server error', 500)
+  }
+
+  const eventIds = ((roomsResult.data ?? []) as EventRoomRow[]).map((row) => row.event_id)
+  if (eventIds.length === 0) {
+    return []
+  }
+
+  const schedulesResult = await admin
+    .from('event_schedules')
+    .select(EVENT_SCHEDULE_COLUMNS)
+    .eq('date', input.date)
+    .in('event_id', eventIds)
+
+  if (schedulesResult.error) {
+    serviceError('Internal server error', 500)
+  }
+
+  return ((schedulesResult.data ?? []) as EventScheduleRow[]).map((schedule) => ({
+    start: normalizeTime(schedule.start_time),
+    end: normalizeTime(schedule.end_time),
+  }))
+}
+
+export async function listEventBlocksForRooms(input: {
+  roomIds: string[]
+  date: string
+}): Promise<Map<string, EventBlock[]>> {
+  const admin = createSupabaseServerAdminClient()
+  const blocksByRoom = new Map<string, EventBlock[]>()
+  if (input.roomIds.length === 0) {
+    return blocksByRoom
+  }
+
+  const roomsResult = await admin
+    .from('event_rooms')
+    .select(EVENT_ROOM_COLUMNS)
+    .in('room_id', input.roomIds)
+
+  if (roomsResult.error) {
+    serviceError('Internal server error', 500)
+  }
+
+  const eventRooms = (roomsResult.data ?? []) as EventRoomRow[]
+  const eventIds = uniqueStrings(eventRooms.map((row) => row.event_id))
+  if (eventIds.length === 0) {
+    return blocksByRoom
+  }
+
+  const schedulesResult = await admin
+    .from('event_schedules')
+    .select(EVENT_SCHEDULE_COLUMNS)
+    .eq('date', input.date)
+    .in('event_id', eventIds)
+
+  if (schedulesResult.error) {
+    serviceError('Internal server error', 500)
+  }
+
+  const schedulesByEvent = new Map<string, EventBlock[]>()
+  for (const schedule of (schedulesResult.data ?? []) as EventScheduleRow[]) {
+    const items = schedulesByEvent.get(schedule.event_id) ?? []
+    items.push({ start: normalizeTime(schedule.start_time), end: normalizeTime(schedule.end_time) })
+    schedulesByEvent.set(schedule.event_id, items)
+  }
+
+  for (const eventRoom of eventRooms) {
+    const items = blocksByRoom.get(eventRoom.room_id) ?? []
+    items.push(...(schedulesByEvent.get(eventRoom.event_id) ?? []))
+    blocksByRoom.set(eventRoom.room_id, items)
+  }
+
+  return blocksByRoom
+}

--- a/lib/server/reservations-service.ts
+++ b/lib/server/reservations-service.ts
@@ -2,6 +2,7 @@ import type { Reservation, TableSurface } from '@/lib/types'
 import type { SessionUser } from '@/lib/server/auth'
 import { serviceError } from '@/lib/server/service-error'
 import { createSupabaseServerAdminClient, createSupabaseServerClient } from '@/lib/supabase/server'
+import { hasEventConflict, listEventBlocksForRoom } from '@/lib/server/events-service'
 import type { Tables, TablesInsert, TablesUpdate } from '@/lib/supabase/types'
 
 type ReservationRow = Tables<'reservations'>
@@ -290,6 +291,10 @@ export async function createReservationForSession(
   if (hasReservationConflict(conflictingReservations, { startTime, endTime, surface })) {
     serviceError('Time slot is already reserved', 409)
   }
+  const eventBlocks = await listEventBlocksForRoom({ roomId: table.room_id, date })
+  if (hasEventConflict(eventBlocks, { startTime, endTime })) {
+    serviceError('Room is blocked by an event', 409)
+  }
 
   const supabase = await createSupabaseServerClient()
   const insertPayload: TablesInsert<'reservations'> = {
@@ -362,6 +367,14 @@ export async function updateReservationForSession(
     surface: nextSurface ?? undefined,
   })) {
     serviceError('Time slot is already reserved', 409)
+  }
+  const table = await getTable(existingReservation.table_id)
+  if (!table) {
+    serviceError('Table not found', 404)
+  }
+  const eventBlocks = await listEventBlocksForRoom({ roomId: table.room_id, date: nextDate })
+  if (hasEventConflict(eventBlocks, { startTime: nextStartTime, endTime: nextEndTime })) {
+    serviceError('Room is blocked by an event', 409)
   }
 
   const supabase = await createSupabaseServerClient()

--- a/lib/server/rooms-service.ts
+++ b/lib/server/rooms-service.ts
@@ -2,6 +2,7 @@ import type { GameTable, Room, TableAvailability } from '@/lib/types'
 import { createSupabaseServerAdminClient, createSupabaseServerClient } from '@/lib/supabase/server'
 import { serviceError } from '@/lib/server/service-error'
 import { resolveDate, buildAvailability } from '@/lib/server/availability'
+import { listEventBlocksForRooms } from '@/lib/server/events-service'
 import type { Tables, TablesInsert, TablesUpdate } from '@/lib/supabase/types'
 
 type RoomRow = Tables<'rooms'>
@@ -202,8 +203,18 @@ export async function getRoomTablesAvailability(roomId: string, date?: string | 
     reservationsByTable.set(reservation.table_id, items)
   }
 
+  const eventBlocksByRoom = await listEventBlocksForRooms({
+    roomIds: [...new Set(tables.map((table) => table.roomId))],
+    date: effectiveDate,
+  })
+
   return tables.reduce<Record<string, TableAvailability>>((acc, table) => {
-    acc[table.id] = buildAvailability(table, effectiveDate, reservationsByTable.get(table.id) ?? [])
+    acc[table.id] = buildAvailability(
+      table,
+      effectiveDate,
+      reservationsByTable.get(table.id) ?? [],
+      eventBlocksByRoom.get(table.roomId) ?? [],
+    )
     return acc
   }, {})
 }

--- a/lib/server/tables-service.ts
+++ b/lib/server/tables-service.ts
@@ -2,6 +2,7 @@ import type { GameTable } from '@/lib/types'
 import { createSupabaseServerAdminClient, createSupabaseServerClient } from '@/lib/supabase/server'
 import { serviceError } from '@/lib/server/service-error'
 import { resolveDate, buildAvailability } from '@/lib/server/availability'
+import { listEventBlocksForRoom } from '@/lib/server/events-service'
 import type { Tables } from '@/lib/supabase/types'
 
 type TableRow = Tables<'tables'>
@@ -52,5 +53,6 @@ export async function getTableAvailability(tableId: string, date?: string | null
     serviceError('Internal server error', 500)
   }
 
-  return buildAvailability(toGameTable(table!), effectiveDate, reservations)
+  const eventBlocks = await listEventBlocksForRoom({ roomId: table.room_id, date: effectiveDate })
+  return buildAvailability(toGameTable(table!), effectiveDate, reservations, eventBlocks)
 }

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -34,6 +34,92 @@ export type Database = {
   }
   public: {
     Tables: {
+      event_rooms: {
+        Row: {
+          event_id: string
+          room_id: string
+        }
+        Insert: {
+          event_id: string
+          room_id: string
+        }
+        Update: {
+          event_id?: string
+          room_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "event_rooms_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "event_rooms_room_id_fkey"
+            columns: ["room_id"]
+            isOneToOne: false
+            referencedRelation: "rooms"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      event_schedules: {
+        Row: {
+          date: string
+          end_time: string
+          event_id: string
+          id: string
+          start_time: string
+        }
+        Insert: {
+          date: string
+          end_time: string
+          event_id: string
+          id?: string
+          start_time: string
+        }
+        Update: {
+          date?: string
+          end_time?: string
+          event_id?: string
+          id?: string
+          start_time?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "event_schedules_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      events: {
+        Row: {
+          created_at: string
+          description: string | null
+          id: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          id?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          id?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       profiles: {
         Row: {
           created_at: string

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -44,6 +44,35 @@ export interface Reservation {
   tableName?: string | null;
 }
 
+export interface EventSchedule {
+  id: string;
+  eventId: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+}
+
+export interface AdminEvent {
+  id: string;
+  title: string;
+  description?: string | null;
+  roomIds: string[];
+  schedules: EventSchedule[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateEventRequest {
+  title: string;
+  description?: string;
+  roomIds: string[];
+  schedules: Array<{
+    date: string;
+    startTime: string;
+    endTime: string;
+  }>;
+}
+
 export interface RemovableTopTableStatus {
   topAvailable: boolean;
   bottomAvailable: boolean;

--- a/messages/en.json
+++ b/messages/en.json
@@ -86,10 +86,10 @@
   },
   "admin": {
     "dashboard": "Admin Dashboard", "users": "Users", "rooms": "Rooms",
-    "tables": "Tables", "reservations": "Reservations", "totalUsers": "Total users",
+    "tables": "Tables", "reservations": "Reservations", "events": "Events", "totalUsers": "Total users",
     "todayReservations": "Today's reservations", "occupancyRate": "Occupancy rate",
     "activeRooms": "Active rooms", "userManagement": "User management",
-    "roomManagement": "Room management", "reservationManagement": "Reservation management",
+    "roomManagement": "Room management", "reservationManagement": "Reservation management", "eventManagement": "Event management",
     "createRoom": "Create room", "createTable": "Create table",
     "editUser": "Edit user", "deleteUser": "Delete user",
     "deleteUserConfirm": "Are you sure you want to delete this user? This action cannot be undone.",
@@ -105,8 +105,12 @@
     "tableCount": "Table count", "tableName": "Table name", "tableType": "Table type",
     "cancelReservation": "Cancel reservation",
     "cancelReservationConfirm": "Are you sure you want to cancel this reservation?",
-    "noReservations": "No reservations found",
-    "table": "Table", "user": "User"
+    "noReservations": "No reservations found", "noEvents": "No events found",
+    "table": "Table", "user": "User",
+    "createEvent": "Create event", "editEvent": "Edit event", "deleteEvent": "Delete event",
+    "eventTitle": "Title", "eventDescription": "Description",
+    "blockedRooms": "Blocked rooms", "eventSchedules": "Schedules",
+    "addSchedule": "Add schedule", "deleteSchedule": "Delete schedule"
   },
   "home": {
     "heroTitle": "Your Adventure Starts Here",

--- a/messages/es.json
+++ b/messages/es.json
@@ -86,10 +86,10 @@
   },
   "admin": {
     "dashboard": "Panel de Administracion", "users": "Usuarios", "rooms": "Salas",
-    "tables": "Mesas", "reservations": "Reservas", "totalUsers": "Total usuarios",
+    "tables": "Mesas", "reservations": "Reservas", "events": "Eventos", "totalUsers": "Total usuarios",
     "todayReservations": "Reservas hoy", "occupancyRate": "Ocupacion", "activeRooms": "Salas activas",
     "userManagement": "Gestion de usuarios", "roomManagement": "Gestion de salas",
-    "reservationManagement": "Gestion de reservas", "createRoom": "Crear sala",
+    "reservationManagement": "Gestion de reservas", "eventManagement": "Gestion de eventos", "createRoom": "Crear sala",
     "createTable": "Crear mesa", "editUser": "Editar usuario", "deleteUser": "Eliminar usuario",
     "deleteUserConfirm": "¿Estás seguro de que deseas eliminar este usuario? Esta acción no se puede deshacer.",
     "role": "Rol", "member": "Socio", "admin": "Administrador", "joinDate": "Fecha de registro",
@@ -104,8 +104,12 @@
     "tableCount": "Número de mesas", "tableName": "Nombre de mesa", "tableType": "Tipo de mesa",
     "cancelReservation": "Cancelar reserva",
     "cancelReservationConfirm": "¿Estás seguro de que deseas cancelar esta reserva? Esta acción no se puede deshacer.",
-    "noReservations": "No hay reservas",
-    "table": "Mesa", "user": "Usuario"
+    "noReservations": "No hay reservas", "noEvents": "No hay eventos",
+    "table": "Mesa", "user": "Usuario",
+    "createEvent": "Crear evento", "editEvent": "Editar evento", "deleteEvent": "Eliminar evento",
+    "eventTitle": "Titulo", "eventDescription": "Descripcion",
+    "blockedRooms": "Salas bloqueadas", "eventSchedules": "Horarios",
+    "addSchedule": "Anadir horario", "deleteSchedule": "Eliminar horario"
   },
   "home": {
     "heroTitle": "Tu Aventura Comienza Aquí",

--- a/supabase/migrations/20260617000000_create_events.sql
+++ b/supabase/migrations/20260617000000_create_events.sql
@@ -1,0 +1,44 @@
+CREATE TABLE public.events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title text NOT NULL CHECK (length(trim(title)) > 0),
+  description text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE public.event_rooms (
+  event_id uuid NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  room_id uuid NOT NULL REFERENCES public.rooms(id) ON DELETE CASCADE,
+  PRIMARY KEY (event_id, room_id)
+);
+
+CREATE TABLE public.event_schedules (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id uuid NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  date date NOT NULL,
+  start_time time NOT NULL,
+  end_time time NOT NULL,
+  CONSTRAINT event_schedules_time_valid CHECK (end_time > start_time)
+);
+
+CREATE INDEX event_rooms_room_id_idx ON public.event_rooms(room_id);
+CREATE INDEX event_schedules_event_date_idx ON public.event_schedules(event_id, date);
+
+ALTER TABLE public.events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.event_rooms ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.event_schedules ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "events_admin_all"
+  ON public.events FOR ALL
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+CREATE POLICY "event_rooms_admin_all"
+  ON public.event_rooms FOR ALL
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+CREATE POLICY "event_schedules_admin_all"
+  ON public.event_schedules FOR ALL
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());


### PR DESCRIPTION
## Summary

Implements KIM-383 by adding administrator-managed events that can block one or more rooms across one or more scheduled time ranges.

## What changed

- Added database tables for events, event-room assignments, and event schedules.
- Added admin-only event CRUD endpoints under `/api/events`.
- Added an Events tab to the admin dashboard with create, edit, list, and delete flows.
- Supports selecting multiple rooms per event.
- Supports multiple date/time schedules per event.
- Integrates event occupancy into table and room availability checks.
- Blocks new or edited reservations when their room overlaps an event schedule.
- Added domain types, API endpoint helpers, TanStack Query hooks, and i18n copy.
- Added test coverage for event-blocked availability and reservation conflicts.

## Impact

Admins can now reserve room capacity for events without using normal member reservations. Members see affected slots as unavailable, and backend validation prevents bypassing the UI by posting overlapping reservations directly.

## Validation

Local push hook and manual checks passed:

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (190/190)
- `pnpm build`

Note: the existing local security warning about `NEXT_PUBLIC_APP_URL` being unset appears during middleware tests, but the suite passes.