### PR TITLE
persist reservation E2E runners into repo (qa/e2e/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ AGENTS.md
 
 # Claude tooling lockfiles (ephemeral, not for commit)
 .claude/*.lock
+
+# E2E runner artifacts (screenshots, videos)
+qa/e2e/*.png
+qa/e2e/*.webm
+qa/e2e/*.pdf

--- a/qa/e2e/README.md
+++ b/qa/e2e/README.md
@@ -1,0 +1,110 @@
+# Alea — Reservation E2E Runners
+
+Standalone Node.js/Playwright scripts that validate the reservation system end-to-end against a running dev server. They are **not** picked up by Vitest (which only scans `__tests__/**`).
+
+---
+
+## Prerequisites
+
+### 1. Install dependencies
+
+The runners need `playwright` and `dotenv`. Install them locally in this directory or use the repo devDependencies:
+
+```bash
+# From repo root (if playwright/dotenv are already devDeps):
+pnpm install
+
+# Or install locally inside qa/e2e/:
+cd qa/e2e
+npm install playwright dotenv
+npx playwright install chromium
+```
+
+### 2. Environment variables
+
+Ensure `.env.local` at the **repo root** contains:
+
+| Variable | Description |
+|---|---|
+| `PLAYWRIGHT_QA_USER` | Member number of the admin QA user |
+| `PLAYWRIGHT_QA_PASSWORD` | Password for the admin QA user |
+| `PLAYWRIGHT_QA_SECONDARY_USER` | Member number of a regular (non-admin) member |
+| `PLAYWRIGHT_QA_SECONDARY_PASSWORD` | Password for the secondary user |
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL |
+| `SUPABASE_SECRET_DEFAULT_KEY` | Supabase service-role key (bypasses RLS for fixtures) |
+| `CRON_SECRET` | Secret used to authenticate the no-show cron endpoint |
+
+### 3. Override variables (optional)
+
+| Variable | Default | Description |
+|---|---|---|
+| `E2E_BASE_URL` | `http://localhost:3001` | Base URL of the running app |
+| `CHROME_PATH` | `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` | Path to Chrome executable |
+
+---
+
+## Start the dev server
+
+```bash
+# From repo root:
+pnpm exec next dev -p 3001
+```
+
+Wait until the server is ready (you should see "Ready in Xs" in the terminal), then run the runners.
+
+---
+
+## Running the runners
+
+From the repo root (each runner resolves `.env.local` relative to its own file location):
+
+```bash
+node qa/e2e/qa-reservation-lifecycle.mjs
+node qa/e2e/qa-reservation-cancellation.mjs
+node qa/e2e/qa-no-show-expiry.mjs
+node qa/e2e/qa-reservation-equipment.mjs
+```
+
+Each runner prints a JSON summary: `{ summary: { passed, total }, checks: [...] }` and exits 0 on success, non-zero on failure.
+
+---
+
+## What each runner validates
+
+### `qa-reservation-lifecycle.mjs`
+Full pending → active reservation lifecycle for a regular (non-removable-top) table:
+- Create reservation via API → assert 201 + `status: pending`
+- Assert table slot is blocked in the availability endpoint
+- Inject a backdated pending reservation (admin REST) → activate via `POST /api/tables/:id/activate`
+- Assert `status: active` after check-in
+- Assert second check-in attempt returns 409 `CHECK_IN_ALREADY_ACTIVE`
+
+### `qa-reservation-cancellation.mjs`
+Cancellation cutoff enforcement (must run as a non-admin member):
+- Create reservation for tomorrow → cancel within cutoff window → assert 200 + `status: cancelled`
+- Assert slot is re-available in the availability endpoint after cancellation
+- Inject a reservation starting within 60 minutes (admin REST) → attempt member cancel → assert 403 `CANCELLATION_CUTOFF`
+
+### `qa-no-show-expiry.mjs`
+No-show cron endpoint (`POST /api/cron/mark-no-show`):
+- Assert unauthenticated call → 401
+- Assert call with wrong secret → 401
+- Insert a backdated pending reservation (slot ended 60+ minutes ago)
+- Call cron with correct `CRON_SECRET` → assert 200 + `marked >= 1`
+- Assert reservation transitioned to `no_show` in DB
+
+### `qa-reservation-equipment.mjs`
+Equipment conflict and validation:
+- Create equipment item via admin REST
+- Admin books table with that equipment → assert 201 + equipment appears in response
+- Assert equipment shows as unavailable in `GET /api/rooms/:id/available-equipment`
+- Assert booking with unknown equipment UUID returns 400 `INVALID_ROOM_EQUIPMENT`
+- Secondary user books a different table (same room, same slot) with the same equipment → assert 409 `EQUIPMENT_ALREADY_RESERVED`
+
+---
+
+## Notes
+
+- All runners clean up their DB fixtures in the `finally` block (reservations, equipment, extra tables).
+- Time-sensitive checks (check-in window, cancellation cutoff) are skipped gracefully if the time of day makes the fixture impossible.
+- Screenshots or videos generated during a run are gitignored (`qa/e2e/*.png`, `*.webm`, `*.pdf`).

--- a/qa/e2e/README.md
+++ b/qa/e2e/README.md
@@ -22,7 +22,7 @@ npx playwright install chromium
 
 ### 2. Environment variables
 
-Ensure `.env.local` at the **repo root** contains:
+Create a dedicated `.env.e2e.local` at the **repo root**. The runners intentionally do not load the app's `.env.local` because they perform privileged fixture writes and deletes.
 
 | Variable | Description |
 |---|---|
@@ -33,13 +33,14 @@ Ensure `.env.local` at the **repo root** contains:
 | `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL |
 | `SUPABASE_SECRET_DEFAULT_KEY` | Supabase service-role key (bypasses RLS for fixtures) |
 | `CRON_SECRET` | Secret used to authenticate the no-show cron endpoint |
+| `E2E_ALLOW_DESTRUCTIVE` | Must be exactly `1` to acknowledge privileged fixture writes/deletes |
 
 ### 3. Override variables (optional)
 
 | Variable | Default | Description |
 |---|---|---|
 | `E2E_BASE_URL` | `http://localhost:3001` | Base URL of the running app |
-| `CHROME_PATH` | `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` | Path to Chrome executable |
+| `CHROME_PATH` | Playwright bundled Chromium | Optional path to a custom Chrome executable |
 
 ---
 
@@ -56,7 +57,7 @@ Wait until the server is ready (you should see "Ready in Xs" in the terminal), t
 
 ## Running the runners
 
-From the repo root (each runner resolves `.env.local` relative to its own file location):
+From the repo root (each runner resolves `.env.e2e.local` relative to its own file location):
 
 ```bash
 node qa/e2e/qa-reservation-lifecycle.mjs
@@ -105,6 +106,7 @@ Equipment conflict and validation:
 
 ## Notes
 
-- All runners clean up their DB fixtures in the `finally` block (reservations, equipment, extra tables).
+- The runners refuse to start unless `E2E_ALLOW_DESTRUCTIVE=1` is present in `.env.e2e.local`.
+- All runners clean up only the exact DB fixture IDs they created in the `finally` block.
 - Time-sensitive checks (check-in window, cancellation cutoff) are skipped gracefully if the time of day makes the fixture impossible.
 - Screenshots or videos generated during a run are gitignored (`qa/e2e/*.png`, `*.webm`, `*.pdf`).

--- a/qa/e2e/env.mjs
+++ b/qa/e2e/env.mjs
@@ -1,0 +1,25 @@
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const envPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../.env.e2e.local');
+dotenv.config({ path: envPath });
+
+export const env = process.env;
+
+export function requireE2EEnv(required) {
+  for (const name of required) {
+    if (!env[name]) throw new Error(`Missing env var in .env.e2e.local: ${name}`);
+  }
+  if (env.E2E_ALLOW_DESTRUCTIVE !== '1') {
+    throw new Error('Refusing privileged E2E writes. Set E2E_ALLOW_DESTRUCTIVE=1 in .env.e2e.local.');
+  }
+  new URL(env.NEXT_PUBLIC_SUPABASE_URL);
+}
+
+export function chromiumLaunchOptions() {
+  return {
+    headless: true,
+    ...(env.CHROME_PATH ? { executablePath: env.CHROME_PATH } : {}),
+  };
+}

--- a/qa/e2e/package.json
+++ b/qa/e2e/package.json
@@ -2,9 +2,10 @@
   "name": "e2e",
   "version": "1.0.0",
   "description": "Standalone Node.js/Playwright scripts that validate the reservation system end-to-end against a running dev server. They are **not** picked up by Vitest (which only scans `__tests__/**`).",
-  "main": "index.js",
+  "private": true,
+  "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "check": "node --check env.mjs && node --check qa-no-show-expiry.mjs && node --check qa-reservation-cancellation.mjs && node --check qa-reservation-equipment.mjs && node --check qa-reservation-lifecycle.mjs"
   },
   "keywords": [],
   "author": "",

--- a/qa/e2e/package.json
+++ b/qa/e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "description": "Standalone Node.js/Playwright scripts that validate the reservation system end-to-end against a running dev server. They are **not** picked up by Vitest (which only scans `__tests__/**`).",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "dotenv": "^17.4.2",
+    "playwright": "^1.61.0"
+  }
+}

--- a/qa/e2e/qa-no-show-expiry.mjs
+++ b/qa/e2e/qa-no-show-expiry.mjs
@@ -1,0 +1,131 @@
+/**
+ * qa-no-show-expiry.mjs
+ * Tests the no-show cron endpoint:
+ *  1. Insert a pending reservation with a backdated start/end time (already past the check-in window)
+ *  2. Call POST /api/cron/mark-no-show with correct Bearer CRON_SECRET
+ *  3. Assert DB status transitions to no_show
+ *  4. Assert that slot is released (slot is available again)
+ *  5. Assert that cron without auth returns 401
+ */
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const envPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../.env.local');
+dotenv.config({ path: envPath });
+const env = process.env;
+const required = ['PLAYWRIGHT_QA_USER', 'CRON_SECRET', 'NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SECRET_DEFAULT_KEY'];
+for (const name of required) if (!env[name]) throw new Error(`Missing env var: ${name}`);
+
+const appUrl = process.env.E2E_BASE_URL || 'http://localhost:3001';
+const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = env.SUPABASE_SECRET_DEFAULT_KEY;
+const adminHeaders = { apikey: serviceKey, Authorization: `Bearer ${serviceKey}`, 'Content-Type': 'application/json' };
+const rest = (path, options = {}) =>
+  fetch(`${supabaseUrl}/rest/v1/${path}`, { ...options, headers: { ...adminHeaders, ...options.headers } });
+const json = (r) => r.json().catch(() => null);
+
+const checks = [];
+const check = (name, pass, evidence) => {
+  checks.push({ name, pass, evidence });
+  if (!pass) throw new Error(`FAIL [${name}]: ${JSON.stringify(evidence)}`);
+};
+
+const created = { reservationId: null, tableId: null };
+
+try {
+  // ── 0. Auth guard: cron without secret must return 401 ────────────────────
+  const unauthResp = await fetch(`${appUrl}/api/cron/mark-no-show`, { method: 'POST' });
+  check('cron without auth → 401', unauthResp.status === 401, { status: unauthResp.status });
+
+  const badAuthResp = await fetch(`${appUrl}/api/cron/mark-no-show`, {
+    method: 'POST',
+    headers: { Authorization: 'Bearer wrong-secret' },
+  });
+  check('cron with wrong secret → 401', badAuthResp.status === 401, { status: badAuthResp.status });
+
+  // ── 1. Resolve admin profile ───────────────────────────────────────────────
+  const profileResp = await rest(
+    `profiles?select=id&member_number=eq.${encodeURIComponent(env.PLAYWRIGHT_QA_USER)}&limit=1`
+  );
+  const [profile] = await json(profileResp);
+  check('admin profile resolved', Boolean(profile?.id), { profile });
+
+  // ── 2. Fixture table ──────────────────────────────────────────────────────
+  const tableResp = await rest('tables?select=id,room_id,type,name&type=eq.small&limit=1');
+  const [table] = await json(tableResp);
+  check('fixture table', tableResp.status === 200 && Boolean(table?.id), { status: tableResp.status });
+  created.tableId = table.id;
+
+  // ── 3. Get DB time and compute backdated slot ─────────────────────────────
+  const timeResp = await rest('rpc/get_database_time', { method: 'POST', body: '{}' });
+  const dbNow = new Date(await json(timeResp));
+
+  // Convert to club timezone (Atlantic/Canary) to get today's date
+  const dbParts = Object.fromEntries(
+    new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Atlantic/Canary',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(dbNow)
+      .filter((p) => p.type !== 'literal')
+      .map((p) => [p.type, p.value])
+  );
+  const today = `${dbParts.year}-${dbParts.month}-${dbParts.day}`;
+  const nowMins = Number(dbParts.hour) * 60 + Number(dbParts.minute);
+
+  // Slot ended 90 minutes ago — definitely past the 60-min check-in window
+  if (nowMins < 90) {
+    console.log(JSON.stringify({ summary: { passed: checks.filter(c=>c.pass).length, total: checks.length }, skipped: 'Too early in day (< 90 min past midnight) to create an expired slot', checks }, null, 2));
+    process.exit(0);
+  }
+
+  const fmt = (m) => `${String(Math.floor(m / 60)).padStart(2, '0')}:${String(m % 60).padStart(2, '0')}`;
+  const slotStart = fmt(nowMins - 90);  // started 90 min ago
+  const slotEnd = fmt(nowMins - 60);    // ended 60 min ago — fully in the past, past the check-in window
+
+  // ── 4. Insert backdated pending reservation via admin REST ────────────────
+  const insertResp = await rest('reservations', {
+    method: 'POST',
+    headers: { Prefer: 'return=representation' },
+    body: JSON.stringify({
+      table_id: table.id,
+      user_id: profile.id,
+      date: today,
+      start_time: slotStart,
+      end_time: slotEnd,
+      status: 'pending',
+    }),
+  });
+  const [inserted] = await json(insertResp);
+  created.reservationId = inserted?.id;
+  check('backdated pending reservation inserted', insertResp.status === 201 && Boolean(created.reservationId), {
+    status: insertResp.status,
+    body: inserted,
+  });
+
+  // ── 5. Call the no-show cron endpoint ─────────────────────────────────────
+  const cronResp = await fetch(`${appUrl}/api/cron/mark-no-show`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${env.CRON_SECRET}` },
+  });
+  const cronBody = await json(cronResp);
+  check('cron returns 200', cronResp.status === 200, { status: cronResp.status, body: cronBody });
+  check('cron returns marked count >= 1', (cronBody?.marked ?? 0) >= 1, { marked: cronBody?.marked });
+
+  // ── 6. Assert reservation is now no_show in DB ────────────────────────────
+  const checkResp = await rest(`reservations?select=status&id=eq.${created.reservationId}`);
+  const [row] = await json(checkResp);
+  check('reservation transitioned to no_show', row?.status === 'no_show', { status: row?.status });
+
+  const passed = checks.filter((c) => c.pass).length;
+  const total = checks.length;
+  console.log(JSON.stringify({ summary: { passed, total }, checks }, null, 2));
+  if (passed < total) throw new Error(`${total - passed} check(s) failed`);
+} finally {
+  if (created.reservationId) {
+    await rest(`reservations?id=eq.${created.reservationId}`, { method: 'DELETE' });
+  }
+  console.log(JSON.stringify({ cleanup: 'done' }));
+}

--- a/qa/e2e/qa-no-show-expiry.mjs
+++ b/qa/e2e/qa-no-show-expiry.mjs
@@ -7,15 +7,10 @@
  *  4. Assert that slot is released (slot is available again)
  *  5. Assert that cron without auth returns 401
  */
-import dotenv from 'dotenv';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
+import { env, requireE2EEnv } from './env.mjs';
 
-const envPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../.env.local');
-dotenv.config({ path: envPath });
-const env = process.env;
 const required = ['PLAYWRIGHT_QA_USER', 'CRON_SECRET', 'NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SECRET_DEFAULT_KEY'];
-for (const name of required) if (!env[name]) throw new Error(`Missing env var: ${name}`);
+requireE2EEnv(required);
 
 const appUrl = process.env.E2E_BASE_URL || 'http://localhost:3001';
 const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL;

--- a/qa/e2e/qa-reservation-cancellation.mjs
+++ b/qa/e2e/qa-reservation-cancellation.mjs
@@ -7,19 +7,14 @@
  * NOTE: The cutoff guard is `session.role !== 'admin'` — must use member (secondary) user.
  */
 import { chromium } from 'playwright';
-import dotenv from 'dotenv';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
+import { chromiumLaunchOptions, env, requireE2EEnv } from './env.mjs';
 
-const envPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../.env.local');
-dotenv.config({ path: envPath });
-const env = process.env;
 const required = [
   'PLAYWRIGHT_QA_USER', 'PLAYWRIGHT_QA_PASSWORD',
   'PLAYWRIGHT_QA_SECONDARY_USER', 'PLAYWRIGHT_QA_SECONDARY_PASSWORD',
   'NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SECRET_DEFAULT_KEY',
 ];
-for (const name of required) if (!env[name]) throw new Error(`Missing env var: ${name}`);
+requireE2EEnv(required);
 
 const appUrl = process.env.E2E_BASE_URL || 'http://localhost:3001';
 const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL;
@@ -37,10 +32,7 @@ const check = (name, pass, evidence) => {
 
 const created = { earlyReservationId: null, lateReservationId: null, tableId: null };
 
-const browser = await chromium.launch({
-  headless: true,
-  executablePath: process.env.CHROME_PATH || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-});
+const browser = await chromium.launch(chromiumLaunchOptions());
 
 try {
   // ── Fixture: regular table ─────────────────────────────────────────────────

--- a/qa/e2e/qa-reservation-cancellation.mjs
+++ b/qa/e2e/qa-reservation-cancellation.mjs
@@ -1,0 +1,186 @@
+/**
+ * qa-reservation-cancellation.mjs
+ * Tests:
+ *  1. Member creates reservation → cancels within cutoff → assert cancelled + slot re-available
+ *  2. Member attempts cancel on a reservation starting within 60 min → assert 403 CANCELLATION_CUTOFF
+ *
+ * NOTE: The cutoff guard is `session.role !== 'admin'` — must use member (secondary) user.
+ */
+import { chromium } from 'playwright';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const envPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../.env.local');
+dotenv.config({ path: envPath });
+const env = process.env;
+const required = [
+  'PLAYWRIGHT_QA_USER', 'PLAYWRIGHT_QA_PASSWORD',
+  'PLAYWRIGHT_QA_SECONDARY_USER', 'PLAYWRIGHT_QA_SECONDARY_PASSWORD',
+  'NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SECRET_DEFAULT_KEY',
+];
+for (const name of required) if (!env[name]) throw new Error(`Missing env var: ${name}`);
+
+const appUrl = process.env.E2E_BASE_URL || 'http://localhost:3001';
+const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = env.SUPABASE_SECRET_DEFAULT_KEY;
+const adminHeaders = { apikey: serviceKey, Authorization: `Bearer ${serviceKey}`, 'Content-Type': 'application/json' };
+const rest = (path, options = {}) =>
+  fetch(`${supabaseUrl}/rest/v1/${path}`, { ...options, headers: { ...adminHeaders, ...options.headers } });
+const json = (r) => r.json().catch(() => null);
+
+const checks = [];
+const check = (name, pass, evidence) => {
+  checks.push({ name, pass, evidence });
+  if (!pass) throw new Error(`FAIL [${name}]: ${JSON.stringify(evidence)}`);
+};
+
+const created = { earlyReservationId: null, lateReservationId: null, tableId: null };
+
+const browser = await chromium.launch({
+  headless: true,
+  executablePath: process.env.CHROME_PATH || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+});
+
+try {
+  // ── Fixture: regular table ─────────────────────────────────────────────────
+  const tableResp = await rest('tables?select=id,room_id,type,name&type=eq.small&limit=1');
+  const [table] = await json(tableResp);
+  check('fixture table', tableResp.status === 200 && Boolean(table?.id), { status: tableResp.status });
+  created.tableId = table.id;
+
+  // ── DB time ───────────────────────────────────────────────────────────────
+  const timeResp = await rest('rpc/get_database_time', { method: 'POST', body: '{}' });
+  const dbNow = new Date(await json(timeResp));
+  const tomorrow = new Date(Date.UTC(dbNow.getUTCFullYear(), dbNow.getUTCMonth(), dbNow.getUTCDate() + 1));
+  const tomorrowStr = tomorrow.toISOString().slice(0, 10);
+
+  // ── Login as MEMBER (secondary user) ─────────────────────────────────────
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  await page.goto(`${appUrl}/es/login`, { waitUntil: 'networkidle' });
+  await page.getByLabel('Número de socio').fill(env.PLAYWRIGHT_QA_SECONDARY_USER);
+  await page.getByLabel('Contraseña', { exact: true }).fill(env.PLAYWRIGHT_QA_SECONDARY_PASSWORD);
+  await Promise.all([
+    page.waitForURL('**/es/rooms', { timeout: 60000 }),
+    page.getByRole('button', { name: 'Iniciar sesión' }).click(),
+  ]);
+  const csrf = (await ctx.cookies()).find((c) => c.name === 'alea-csrf-token')?.value;
+  check('member session + CSRF', Boolean(csrf), { url: page.url() });
+
+  const mh = { Origin: appUrl, 'x-csrf-token': csrf, 'Content-Type': 'application/json' };
+  const post = (path, data) => page.request.post(`${appUrl}/api${path}`, { headers: mh, data });
+  const put  = (path, data) => page.request.put(`${appUrl}/api${path}`, { headers: mh, data });
+
+  // ── Test 1: Cancel within cutoff (>60 min away) ──────────────────────────
+  const createResp = await post('/reservations', {
+    tableId: table.id,
+    date: tomorrowStr,
+    startTime: '14:00',
+    endTime: '15:00',
+    equipmentIds: [],
+  });
+  const created1 = await json(createResp);
+  created.earlyReservationId = created1?.id;
+  check('member reservation created (201)', createResp.status() === 201 && Boolean(created.earlyReservationId), {
+    status: createResp.status(), body: created1,
+  });
+
+  // Verify slot blocked
+  const availBefore = await page.request.get(
+    `${appUrl}/api/tables/${table.id}/availability?date=${tomorrowStr}`
+  );
+  const ab = await json(availBefore);
+  const slotsArr = Array.isArray(ab) ? ab : (ab?.slots ?? []);
+  check('slot blocked after creation', slotsArr.some((s) => s.startTime === '14:00' && s.available === false), {
+    sample: slotsArr.slice(0, 4),
+  });
+
+  // Cancel within cutoff
+  const cancelResp = await put(`/reservations/${created.earlyReservationId}`, { status: 'cancelled' });
+  const cancelBody = await json(cancelResp);
+  check('cancel within cutoff succeeds (200)', cancelResp.status() === 200, {
+    status: cancelResp.status(), body: cancelBody,
+  });
+  check('status is cancelled', cancelBody?.status === 'cancelled', { status: cancelBody?.status });
+
+  // Verify slot released
+  const availAfter = await page.request.get(
+    `${appUrl}/api/tables/${table.id}/availability?date=${tomorrowStr}`
+  );
+  const aa = await json(availAfter);
+  const slotsAfter = Array.isArray(aa) ? aa : (aa?.slots ?? []);
+  check('slot released after cancellation', slotsAfter.some((s) => s.startTime === '14:00' && s.available === true), {
+    sample: slotsAfter.slice(0, 4),
+  });
+
+  // ── Test 2: Cancel AFTER cutoff — inject via admin REST ──────────────────
+  // Resolve secondary profile id
+  const profileResp = await rest(
+    `profiles?select=id&member_number=eq.${encodeURIComponent(env.PLAYWRIGHT_QA_SECONDARY_USER)}&limit=1`
+  );
+  const [profile] = await json(profileResp);
+
+  // Get club-local time
+  const dbParts = Object.fromEntries(
+    new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Atlantic/Canary',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(dbNow)
+      .filter((p) => p.type !== 'literal')
+      .map((p) => [p.type, p.value])
+  );
+  const today = `${dbParts.year}-${dbParts.month}-${dbParts.day}`;
+  const nowMins = Number(dbParts.hour) * 60 + Number(dbParts.minute);
+  const fmt = (m) => `${String(Math.floor(m / 60)).padStart(2, '0')}:${String(m % 60).padStart(2, '0')}`;
+
+  // Slot starts in 30 min → within the 60-min cutoff
+  if (nowMins + 60 <= 1440) {
+    const nearStart = fmt(nowMins + 30);
+    const nearEnd   = fmt(nowMins + 60);
+
+    const lateInsert = await rest('reservations', {
+      method: 'POST',
+      headers: { Prefer: 'return=representation' },
+      body: JSON.stringify({
+        table_id: table.id,
+        user_id: profile.id,
+        date: today,
+        start_time: nearStart,
+        end_time: nearEnd,
+        status: 'pending',
+      }),
+    });
+    const [lateRes] = await json(lateInsert);
+    created.lateReservationId = lateRes?.id;
+    check('late-fixture inserted', lateInsert.status === 201 && Boolean(created.lateReservationId), {
+      status: lateInsert.status, body: lateRes,
+    });
+
+    // Member tries to cancel — must be rejected (< 60 min to start)
+    const lateCancelResp = await put(`/reservations/${created.lateReservationId}`, { status: 'cancelled' });
+    const lateCancelBody = await json(lateCancelResp);
+    check('cancel after cutoff rejected (403)', lateCancelResp.status() === 403, {
+      status: lateCancelResp.status(), message: lateCancelBody?.message,
+    });
+    check('cancel after cutoff message is CANCELLATION_CUTOFF', lateCancelBody?.message === 'CANCELLATION_CUTOFF', {
+      message: lateCancelBody?.message,
+    });
+  } else {
+    checks.push({ name: 'late cancel fixture', pass: true, evidence: { note: 'too late in day to fit +30/+60 min slot; skipped' } });
+  }
+
+  await ctx.close();
+
+  const passed = checks.filter((c) => c.pass).length;
+  const total = checks.length;
+  console.log(JSON.stringify({ summary: { passed, total }, checks }, null, 2));
+  if (passed < total) throw new Error(`${total - passed} check(s) failed`);
+} finally {
+  await browser.close();
+  if (created.earlyReservationId) await rest(`reservations?id=eq.${created.earlyReservationId}`, { method: 'DELETE' });
+  if (created.lateReservationId)  await rest(`reservations?id=eq.${created.lateReservationId}`,  { method: 'DELETE' });
+  console.log(JSON.stringify({ cleanup: 'done' }));
+}

--- a/qa/e2e/qa-reservation-equipment.mjs
+++ b/qa/e2e/qa-reservation-equipment.mjs
@@ -8,19 +8,14 @@
  *  4. Use unknown equipment ID → assert 400 INVALID_ROOM_EQUIPMENT
  */
 import { chromium } from 'playwright';
-import dotenv from 'dotenv';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
+import { chromiumLaunchOptions, env, requireE2EEnv } from './env.mjs';
 
-const envPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../.env.local');
-dotenv.config({ path: envPath });
-const env = process.env;
 const required = [
   'PLAYWRIGHT_QA_USER', 'PLAYWRIGHT_QA_PASSWORD',
   'PLAYWRIGHT_QA_SECONDARY_USER', 'PLAYWRIGHT_QA_SECONDARY_PASSWORD',
   'NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SECRET_DEFAULT_KEY',
 ];
-for (const name of required) if (!env[name]) throw new Error(`Missing env var: ${name}`);
+requireE2EEnv(required);
 
 const appUrl = process.env.E2E_BASE_URL || 'http://localhost:3001';
 const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL;
@@ -36,12 +31,9 @@ const check = (name, pass, evidence) => {
   if (!pass) throw new Error(`FAIL [${name}]: ${JSON.stringify(evidence)}`);
 };
 
-const created = { equipmentId: null, reservation1Id: null, reservation2Id: null, extraTableId: null };
+const created = { equipmentId: null, reservation1Id: null, reservation2Id: null, extraTableId: null, roomDefaultSeeded: false };
 
-const browser = await chromium.launch({
-  headless: true,
-  executablePath: process.env.CHROME_PATH || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-});
+const browser = await chromium.launch(chromiumLaunchOptions());
 
 try {
   // ── 1. Create a fresh equipment item via admin REST ───────────────────────
@@ -84,6 +76,13 @@ try {
   } else {
     check('fixture table 2 (same room)', Boolean(table2.id), { table2 });
   }
+
+  const roomDefaultResp = await rest('room_default_equipment', {
+    method: 'POST',
+    body: JSON.stringify({ room_id: table.room_id, equipment_id: created.equipmentId }),
+  });
+  created.roomDefaultSeeded = roomDefaultResp.status === 201;
+  check('equipment assigned to fixture room', created.roomDefaultSeeded, { status: roomDefaultResp.status });
 
   // ── 4. Compute date: tomorrow ─────────────────────────────────────────────
   const timeResp = await rest('rpc/get_database_time', { method: 'POST', body: '{}' });
@@ -131,16 +130,12 @@ try {
     `${appUrl}/api/rooms/${table.room_id}/available-equipment?date=${date}&startTime=${startTime}&endTime=${endTime}`
   );
   const eqAvailBody = await json(eqAvailResp);
-  if (eqAvailResp.status() === 200 && Array.isArray(eqAvailBody)) {
-    const eqEntry = eqAvailBody.find((e) => e.id === created.equipmentId);
-    if (eqEntry) {
-      check('equipment shows as unavailable after booking', eqEntry.available === false, { eqEntry });
-    } else {
-      checks.push({ name: 'equipment availability', pass: true, evidence: { note: 'not in pool (may be locked to another room)' } });
-    }
-  } else {
-    checks.push({ name: 'equipment availability', pass: true, evidence: { note: `endpoint status ${eqAvailResp.status()}` } });
-  }
+  check('equipment availability endpoint returns 200', eqAvailResp.status() === 200 && Array.isArray(eqAvailBody), {
+    status: eqAvailResp.status(), body: eqAvailBody,
+  });
+  const eqEntry = eqAvailBody.find((e) => e.id === created.equipmentId);
+  check('equipment appears in room pool', Boolean(eqEntry), { equipmentId: created.equipmentId, body: eqAvailBody });
+  check('equipment shows as unavailable after booking', eqEntry.available === false, { eqEntry });
 
   // ── 8. Unknown equipment ID → 400 INVALID_ROOM_EQUIPMENT ─────────────────
   const unknownResp = await post1('/reservations', {
@@ -209,6 +204,9 @@ try {
   if (created.reservation2Id) {
     await rest(`reservation_equipment?reservation_id=eq.${created.reservation2Id}`, { method: 'DELETE' });
     await rest(`reservations?id=eq.${created.reservation2Id}`, { method: 'DELETE' });
+  }
+  if (created.roomDefaultSeeded && created.equipmentId) {
+    await rest(`room_default_equipment?equipment_id=eq.${created.equipmentId}`, { method: 'DELETE' });
   }
   if (created.equipmentId) {
     await rest(`equipment?id=eq.${created.equipmentId}`, { method: 'DELETE' });

--- a/qa/e2e/qa-reservation-equipment.mjs
+++ b/qa/e2e/qa-reservation-equipment.mjs
@@ -1,0 +1,220 @@
+/**
+ * qa-reservation-equipment.mjs
+ * Tests equipment reservation lifecycle:
+ *  1. Create an equipment item via admin REST
+ *  2. Admin creates reservation with that equipmentId → assert equipment in response
+ *  3. Secondary user books a DIFFERENT table in same room same slot with same equipment
+ *     → should get 409 EQUIPMENT_ALREADY_RESERVED
+ *  4. Use unknown equipment ID → assert 400 INVALID_ROOM_EQUIPMENT
+ */
+import { chromium } from 'playwright';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const envPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../.env.local');
+dotenv.config({ path: envPath });
+const env = process.env;
+const required = [
+  'PLAYWRIGHT_QA_USER', 'PLAYWRIGHT_QA_PASSWORD',
+  'PLAYWRIGHT_QA_SECONDARY_USER', 'PLAYWRIGHT_QA_SECONDARY_PASSWORD',
+  'NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SECRET_DEFAULT_KEY',
+];
+for (const name of required) if (!env[name]) throw new Error(`Missing env var: ${name}`);
+
+const appUrl = process.env.E2E_BASE_URL || 'http://localhost:3001';
+const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = env.SUPABASE_SECRET_DEFAULT_KEY;
+const adminHeaders = { apikey: serviceKey, Authorization: `Bearer ${serviceKey}`, 'Content-Type': 'application/json' };
+const rest = (path, options = {}) =>
+  fetch(`${supabaseUrl}/rest/v1/${path}`, { ...options, headers: { ...adminHeaders, ...options.headers } });
+const json = (r) => r.json().catch(() => null);
+
+const checks = [];
+const check = (name, pass, evidence) => {
+  checks.push({ name, pass, evidence });
+  if (!pass) throw new Error(`FAIL [${name}]: ${JSON.stringify(evidence)}`);
+};
+
+const created = { equipmentId: null, reservation1Id: null, reservation2Id: null, extraTableId: null };
+
+const browser = await chromium.launch({
+  headless: true,
+  executablePath: process.env.CHROME_PATH || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+});
+
+try {
+  // ── 1. Create a fresh equipment item via admin REST ───────────────────────
+  const eqInsertResp = await rest('equipment', {
+    method: 'POST',
+    headers: { Prefer: 'return=representation' },
+    body: JSON.stringify({ name: `QA Equipment ${Date.now()}`, description: 'E2E test fixture' }),
+  });
+  const [eq] = await json(eqInsertResp);
+  created.equipmentId = eq?.id;
+  check('equipment item created', eqInsertResp.status === 201 && Boolean(created.equipmentId), {
+    status: eqInsertResp.status, eq,
+  });
+
+  // ── 2. Pick a regular table (primary booking table) ──────────────────────
+  const tableResp = await rest('tables?select=id,room_id,type,name&type=eq.small&limit=1');
+  const [table] = await json(tableResp);
+  check('fixture table 1', tableResp.status === 200 && Boolean(table?.id), { status: tableResp.status });
+
+  // ── 3. Pick a second regular table in the SAME room ─────────────────────
+  // (needed so secondary user's booking doesn't hit SLOT_TAKEN on the same table)
+  const table2Resp = await rest(
+    `tables?select=id,room_id,type,name&type=eq.small&room_id=eq.${table.room_id}&id=neq.${table.id}&limit=1`
+  );
+  let [table2] = await json(table2Resp);
+
+  // If there's no second table in the same room, create a temporary one
+  if (!table2?.id) {
+    const createTable2 = await rest('tables', {
+      method: 'POST',
+      headers: { Prefer: 'return=representation' },
+      body: JSON.stringify({ room_id: table.room_id, name: `QA Extra ${Date.now()}`, type: 'small' }),
+    });
+    const [t2] = await json(createTable2);
+    created.extraTableId = t2?.id;
+    check('created extra table for conflict test', createTable2.status === 201 && Boolean(t2?.id), {
+      status: createTable2.status,
+    });
+    table2 = { id: t2.id, room_id: table.room_id };
+  } else {
+    check('fixture table 2 (same room)', Boolean(table2.id), { table2 });
+  }
+
+  // ── 4. Compute date: tomorrow ─────────────────────────────────────────────
+  const timeResp = await rest('rpc/get_database_time', { method: 'POST', body: '{}' });
+  const dbNow = new Date(await json(timeResp));
+  const tomorrow = new Date(Date.UTC(dbNow.getUTCFullYear(), dbNow.getUTCMonth(), dbNow.getUTCDate() + 1));
+  const date = tomorrow.toISOString().slice(0, 10);
+  const startTime = '15:00';
+  const endTime = '16:00';
+
+  // ── 5. Login as admin user ────────────────────────────────────────────────
+  const ctx1 = await browser.newContext();
+  const page1 = await ctx1.newPage();
+  await page1.goto(`${appUrl}/es/login`, { waitUntil: 'networkidle' });
+  await page1.getByLabel('Número de socio').fill(env.PLAYWRIGHT_QA_USER);
+  await page1.getByLabel('Contraseña', { exact: true }).fill(env.PLAYWRIGHT_QA_PASSWORD);
+  await Promise.all([
+    page1.waitForURL('**/es/rooms', { timeout: 60000 }),
+    page1.getByRole('button', { name: 'Iniciar sesión' }).click(),
+  ]);
+  const csrf1 = (await ctx1.cookies()).find((c) => c.name === 'alea-csrf-token')?.value;
+  check('admin session + CSRF', Boolean(csrf1), { url: page1.url() });
+
+  const mh1 = { Origin: appUrl, 'x-csrf-token': csrf1, 'Content-Type': 'application/json' };
+  const post1 = (path, data) => page1.request.post(`${appUrl}/api${path}`, { headers: mh1, data });
+
+  // ── 6. Admin creates reservation on table1 with equipment ─────────────────
+  const createResp = await post1('/reservations', {
+    tableId: table.id,
+    date,
+    startTime,
+    endTime,
+    equipmentIds: [created.equipmentId],
+  });
+  const created1 = await json(createResp);
+  created.reservation1Id = created1?.id;
+  check('reservation with equipment created (201)', createResp.status() === 201 && Boolean(created.reservation1Id), {
+    status: createResp.status(), body: created1,
+  });
+  check('equipment appears in reservation response', Array.isArray(created1?.equipment) && created1.equipment.some((e) => e.id === created.equipmentId), {
+    equipment: created1?.equipment,
+  });
+
+  // ── 7. Check available-equipment endpoint shows equipment as unavailable ──
+  const eqAvailResp = await page1.request.get(
+    `${appUrl}/api/rooms/${table.room_id}/available-equipment?date=${date}&startTime=${startTime}&endTime=${endTime}`
+  );
+  const eqAvailBody = await json(eqAvailResp);
+  if (eqAvailResp.status() === 200 && Array.isArray(eqAvailBody)) {
+    const eqEntry = eqAvailBody.find((e) => e.id === created.equipmentId);
+    if (eqEntry) {
+      check('equipment shows as unavailable after booking', eqEntry.available === false, { eqEntry });
+    } else {
+      checks.push({ name: 'equipment availability', pass: true, evidence: { note: 'not in pool (may be locked to another room)' } });
+    }
+  } else {
+    checks.push({ name: 'equipment availability', pass: true, evidence: { note: `endpoint status ${eqAvailResp.status()}` } });
+  }
+
+  // ── 8. Unknown equipment ID → 400 INVALID_ROOM_EQUIPMENT ─────────────────
+  const unknownResp = await post1('/reservations', {
+    tableId: table.id,
+    date,
+    startTime: '16:00',
+    endTime: '17:00',
+    equipmentIds: ['00000000-0000-0000-0000-000000000000'],
+  });
+  const unknownBody = await json(unknownResp);
+  check('unknown equipment ID rejected (400)', unknownResp.status() === 400, {
+    status: unknownResp.status(), message: unknownBody?.message,
+  });
+  check('unknown equipment message is INVALID_ROOM_EQUIPMENT', unknownBody?.message === 'INVALID_ROOM_EQUIPMENT', {
+    message: unknownBody?.message,
+  });
+
+  await ctx1.close();
+
+  // ── 9. Secondary user books table2 (same room, same slot) with same equipment ─
+  const ctx2 = await browser.newContext();
+  const page2 = await ctx2.newPage();
+  await page2.goto(`${appUrl}/es/login`, { waitUntil: 'networkidle' });
+  await page2.getByLabel('Número de socio').fill(env.PLAYWRIGHT_QA_SECONDARY_USER);
+  await page2.getByLabel('Contraseña', { exact: true }).fill(env.PLAYWRIGHT_QA_SECONDARY_PASSWORD);
+  await Promise.all([
+    page2.waitForURL('**/es/rooms', { timeout: 60000 }),
+    page2.getByRole('button', { name: 'Iniciar sesión' }).click(),
+  ]);
+  const csrf2 = (await ctx2.cookies()).find((c) => c.name === 'alea-csrf-token')?.value;
+  check('secondary session + CSRF', Boolean(csrf2), { url: page2.url() });
+
+  const mh2 = { Origin: appUrl, 'x-csrf-token': csrf2, 'Content-Type': 'application/json' };
+  const post2 = (path, data) => page2.request.post(`${appUrl}/api${path}`, { headers: mh2, data });
+
+  // Secondary user books table2 in the same room, same slot, same equipment
+  // table2 has no slot conflict, so the equipment conflict is what triggers
+  const conflictResp = await post2('/reservations', {
+    tableId: table2.id,
+    date,
+    startTime,
+    endTime,
+    equipmentIds: [created.equipmentId],
+  });
+  const conflictBody = await json(conflictResp);
+  created.reservation2Id = conflictBody?.id; // null if correctly rejected
+  check('conflicting equipment booking rejected (409)', conflictResp.status() === 409, {
+    status: conflictResp.status(), message: conflictBody?.message,
+  });
+  check('conflict message is EQUIPMENT_ALREADY_RESERVED', conflictBody?.message === 'EQUIPMENT_ALREADY_RESERVED', {
+    message: conflictBody?.message,
+  });
+
+  await ctx2.close();
+
+  const passed = checks.filter((c) => c.pass).length;
+  const total = checks.length;
+  console.log(JSON.stringify({ summary: { passed, total }, checks }, null, 2));
+  if (passed < total) throw new Error(`${total - passed} check(s) failed`);
+} finally {
+  await browser.close();
+  if (created.reservation1Id) {
+    await rest(`reservation_equipment?reservation_id=eq.${created.reservation1Id}`, { method: 'DELETE' });
+    await rest(`reservations?id=eq.${created.reservation1Id}`, { method: 'DELETE' });
+  }
+  if (created.reservation2Id) {
+    await rest(`reservation_equipment?reservation_id=eq.${created.reservation2Id}`, { method: 'DELETE' });
+    await rest(`reservations?id=eq.${created.reservation2Id}`, { method: 'DELETE' });
+  }
+  if (created.equipmentId) {
+    await rest(`equipment?id=eq.${created.equipmentId}`, { method: 'DELETE' });
+  }
+  if (created.extraTableId) {
+    await rest(`tables?id=eq.${created.extraTableId}`, { method: 'DELETE' });
+  }
+  console.log(JSON.stringify({ cleanup: 'done' }));
+}

--- a/qa/e2e/qa-reservation-lifecycle.mjs
+++ b/qa/e2e/qa-reservation-lifecycle.mjs
@@ -8,15 +8,10 @@
  *  5. second activate rejected (CHECK_IN_ALREADY_ACTIVE)
  */
 import { chromium } from 'playwright';
-import dotenv from 'dotenv';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
+import { chromiumLaunchOptions, env, requireE2EEnv } from './env.mjs';
 
-const envPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../.env.local');
-dotenv.config({ path: envPath });
-const env = process.env;
 const required = ['PLAYWRIGHT_QA_USER', 'PLAYWRIGHT_QA_PASSWORD', 'NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SECRET_DEFAULT_KEY'];
-for (const name of required) if (!env[name]) throw new Error(`Missing env var: ${name}`);
+requireE2EEnv(required);
 
 const appUrl = process.env.E2E_BASE_URL || 'http://localhost:3001';
 const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL;
@@ -32,12 +27,9 @@ const check = (name, pass, evidence) => {
   if (!pass) throw new Error(`FAIL [${name}]: ${JSON.stringify(evidence)}`);
 };
 
-const created = { reservationId: null, tableId: null };
+const created = { reservationId: null, checkinReservationId: null, tableId: null };
 
-const browser = await chromium.launch({
-  headless: true,
-  executablePath: process.env.CHROME_PATH || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-});
+const browser = await chromium.launch(chromiumLaunchOptions());
 
 try {
   // ── Fixture: pick a regular (non-removable-top) table ─────────────────────
@@ -155,6 +147,7 @@ try {
     });
     const [inserted] = await json(insertResp);
     checkinReservationId = inserted?.id;
+    created.checkinReservationId = checkinReservationId;
 
     if (checkinReservationId) {
       // ── 4. Activate via app API ─────────────────────────────────────────────
@@ -179,44 +172,26 @@ try {
         message: secondBody?.message,
       });
     } else {
-      // Log as non-blocking; timing might make fixture impossible
-      checks.push({ name: 'check-in fixture', pass: false, evidence: { reason: 'Could not insert today fixture' } });
+      checks.push({ name: 'check-in fixture', skipped: true, evidence: { reason: 'Could not insert today fixture' } });
     }
   } else {
-    checks.push({ name: 'check-in fixture', pass: false, evidence: { reason: 'Time unsuitable for check-in fixture', nowMins } });
+    checks.push({ name: 'check-in fixture', skipped: true, evidence: { reason: 'Time unsuitable for check-in fixture', nowMins } });
   }
 
   await context.close();
 
   const passed = checks.filter((c) => c.pass).length;
-  const total = checks.length;
-  console.log(JSON.stringify({ summary: { passed, total }, checks }, null, 2));
-  if (passed < total) throw new Error(`${total - passed} check(s) failed`);
+  const failed = checks.filter((c) => c.pass === false).length;
+  const skipped = checks.filter((c) => c.skipped).length;
+  console.log(JSON.stringify({ summary: { passed, failed, skipped }, checks }, null, 2));
+  if (failed > 0) throw new Error(`${failed} check(s) failed`);
 } finally {
   await browser.close();
   if (created.reservationId) {
     await rest(`reservations?id=eq.${created.reservationId}`, { method: 'DELETE' });
   }
-  // Clean up any lingering today fixtures inserted by this runner
-  const profileResp2 = await rest(
-    `profiles?select=id&member_number=eq.${encodeURIComponent(env.PLAYWRIGHT_QA_USER)}&limit=1`
-  ).catch(() => null);
-  if (profileResp2) {
-    const [p2] = await json(profileResp2).catch(() => []);
-    if (p2?.id && created.tableId) {
-      const tomorrow2 = (() => {
-        const d = new Date(); d.setUTCDate(d.getUTCDate() + 1); return d.toISOString().slice(0, 10);
-      })();
-      await rest(
-        `reservations?table_id=eq.${created.tableId}&date=eq.${tomorrow2}&user_id=eq.${p2.id}`,
-        { method: 'DELETE' }
-      ).catch(() => null);
-      const today2 = new Date().toISOString().slice(0, 10);
-      await rest(
-        `reservations?table_id=eq.${created.tableId}&date=eq.${today2}&user_id=eq.${p2.id}`,
-        { method: 'DELETE' }
-      ).catch(() => null);
-    }
+  if (created.checkinReservationId) {
+    await rest(`reservations?id=eq.${created.checkinReservationId}`, { method: 'DELETE' });
   }
   console.log(JSON.stringify({ cleanup: 'done' }));
 }

--- a/qa/e2e/qa-reservation-lifecycle.mjs
+++ b/qa/e2e/qa-reservation-lifecycle.mjs
@@ -1,0 +1,222 @@
+/**
+ * qa-reservation-lifecycle.mjs
+ * REGULAR PLAY reservation lifecycle:
+ *  1. create via API
+ *  2. assert table availability now blocked for that slot
+ *  3. activate/check-in
+ *  4. assert status active + attendance recorded
+ *  5. second activate rejected (CHECK_IN_ALREADY_ACTIVE)
+ */
+import { chromium } from 'playwright';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const envPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../.env.local');
+dotenv.config({ path: envPath });
+const env = process.env;
+const required = ['PLAYWRIGHT_QA_USER', 'PLAYWRIGHT_QA_PASSWORD', 'NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SECRET_DEFAULT_KEY'];
+for (const name of required) if (!env[name]) throw new Error(`Missing env var: ${name}`);
+
+const appUrl = process.env.E2E_BASE_URL || 'http://localhost:3001';
+const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = env.SUPABASE_SECRET_DEFAULT_KEY;
+const adminHeaders = { apikey: serviceKey, Authorization: `Bearer ${serviceKey}`, 'Content-Type': 'application/json' };
+const rest = (path, options = {}) =>
+  fetch(`${supabaseUrl}/rest/v1/${path}`, { ...options, headers: { ...adminHeaders, ...options.headers } });
+const json = (response) => response.json().catch(() => null);
+
+const checks = [];
+const check = (name, pass, evidence) => {
+  checks.push({ name, pass, evidence });
+  if (!pass) throw new Error(`FAIL [${name}]: ${JSON.stringify(evidence)}`);
+};
+
+const created = { reservationId: null, tableId: null };
+
+const browser = await chromium.launch({
+  headless: true,
+  executablePath: process.env.CHROME_PATH || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+});
+
+try {
+  // ── Fixture: pick a regular (non-removable-top) table ─────────────────────
+  const tableResp = await rest('tables?select=id,room_id,type,name&type=eq.small&limit=1');
+  const [table] = await json(tableResp);
+  check('fixture table found', tableResp.status === 200 && Boolean(table?.id), { status: tableResp.status, table });
+  created.tableId = table.id;
+
+  // ── Compute a slot: tomorrow, 10:00–11:00 ─────────────────────────────────
+  const timeResp = await rest('rpc/get_database_time', { method: 'POST', body: '{}' });
+  const dbNow = new Date(await json(timeResp));
+  const tomorrow = new Date(Date.UTC(dbNow.getUTCFullYear(), dbNow.getUTCMonth(), dbNow.getUTCDate() + 1));
+  const date = tomorrow.toISOString().slice(0, 10);
+  const startTime = '10:00';
+  const endTime = '11:00';
+
+  // ── Login as admin user ────────────────────────────────────────────────────
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  page.on('console', (msg) => {
+    if (
+      msg.type() === 'error' &&
+      !msg.text().includes('favicon') &&
+      !(msg.location()?.url ?? '').includes('favicon')
+    ) {
+      // suppress non-critical browser console errors
+    }
+  });
+
+  await page.goto(`${appUrl}/es/login`, { waitUntil: 'networkidle' });
+  await page.getByLabel('Número de socio').fill(env.PLAYWRIGHT_QA_USER);
+  await page.getByLabel('Contraseña', { exact: true }).fill(env.PLAYWRIGHT_QA_PASSWORD);
+  await Promise.all([
+    page.waitForURL('**/es/rooms', { timeout: 60000 }),
+    page.getByRole('button', { name: 'Iniciar sesión' }).click(),
+  ]);
+  const csrf = (await context.cookies()).find((c) => c.name === 'alea-csrf-token')?.value;
+  check('session + CSRF', Boolean(csrf), { url: page.url() });
+
+  const mutationHeaders = { Origin: appUrl, 'x-csrf-token': csrf, 'Content-Type': 'application/json' };
+  const post = (path, data) =>
+    page.request.post(`${appUrl}/api${path}`, { headers: mutationHeaders, data });
+
+  // ── 1. Create reservation via API ─────────────────────────────────────────
+  const createResp = await post('/reservations', {
+    tableId: table.id,
+    date,
+    startTime,
+    endTime,
+    equipmentIds: [],
+  });
+  const created1 = await json(createResp);
+  created.reservationId = created1?.id;
+  check('reservation created (201)', createResp.status() === 201 && Boolean(created.reservationId), {
+    status: createResp.status(),
+    body: created1,
+  });
+  check('reservation status is pending', created1?.status === 'pending', { status: created1?.status });
+
+  // ── 2. Assert slot now blocked in availability ─────────────────────────────
+  const availResp = await page.request.get(
+    `${appUrl}/api/tables/${table.id}/availability?date=${date}`
+  );
+  const avail = await json(availResp);
+  check('availability endpoint 200', availResp.status() === 200, { status: availResp.status() });
+
+  // For a regular (non-removable-top) table, slots is a flat array
+  const slots = Array.isArray(avail) ? avail : (avail?.slots ?? avail?.top ?? []);
+  const isBlocked = slots.some(
+    (s) => s.startTime === startTime && s.available === false
+  );
+  check('slot is blocked in availability', isBlocked, {
+    startTime,
+    sampleSlots: slots.slice(0, 5),
+  });
+
+  // ── 3. Inject pending reservation backdated to right now for check-in ──────
+  // The reservation was created for tomorrow; we can't check-in to it.
+  // Instead, create a separate fixture for today via admin REST.
+  const profileResp = await rest(
+    `profiles?select=id&member_number=eq.${encodeURIComponent(env.PLAYWRIGHT_QA_USER)}&limit=1`
+  );
+  const [profile] = await json(profileResp);
+
+  const dbParts = Object.fromEntries(
+    new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Atlantic/Canary',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(dbNow)
+      .filter((p) => p.type !== 'literal')
+      .map((p) => [p.type, p.value])
+  );
+  const today = `${dbParts.year}-${dbParts.month}-${dbParts.day}`;
+  const nowMins = Number(dbParts.hour) * 60 + Number(dbParts.minute);
+
+  let checkinReservationId = null;
+  if (nowMins >= 2 && nowMins <= 1410) {
+    const fmt = (m) => `${String(Math.floor(m / 60)).padStart(2, '0')}:${String(m % 60).padStart(2, '0')}`;
+    const slotStart = fmt(nowMins - 1);
+    const slotEnd = fmt(nowMins + 30);
+
+    const insertResp = await rest('reservations', {
+      method: 'POST',
+      headers: { Prefer: 'return=representation' },
+      body: JSON.stringify({
+        table_id: table.id,
+        user_id: profile.id,
+        date: today,
+        start_time: slotStart,
+        end_time: slotEnd,
+        status: 'pending',
+      }),
+    });
+    const [inserted] = await json(insertResp);
+    checkinReservationId = inserted?.id;
+
+    if (checkinReservationId) {
+      // ── 4. Activate via app API ─────────────────────────────────────────────
+      const activateResp = await post(`/tables/${table.id}/activate`, {});
+      const activateBody = await json(activateResp);
+      check('check-in returns 200', activateResp.status() === 200, {
+        status: activateResp.status(),
+        body: activateBody,
+      });
+      check('reservation status is active after check-in', activateBody?.reservation?.status === 'active', {
+        status: activateBody?.reservation?.status,
+      });
+
+      // ── 5. Second activate is rejected ──────────────────────────────────────
+      const secondResp = await post(`/tables/${table.id}/activate`, {});
+      const secondBody = await json(secondResp);
+      check('second check-in rejected (409)', secondResp.status() === 409, {
+        status: secondResp.status(),
+        message: secondBody?.message,
+      });
+      check('second check-in message is CHECK_IN_ALREADY_ACTIVE', secondBody?.message === 'CHECK_IN_ALREADY_ACTIVE', {
+        message: secondBody?.message,
+      });
+    } else {
+      // Log as non-blocking; timing might make fixture impossible
+      checks.push({ name: 'check-in fixture', pass: false, evidence: { reason: 'Could not insert today fixture' } });
+    }
+  } else {
+    checks.push({ name: 'check-in fixture', pass: false, evidence: { reason: 'Time unsuitable for check-in fixture', nowMins } });
+  }
+
+  await context.close();
+
+  const passed = checks.filter((c) => c.pass).length;
+  const total = checks.length;
+  console.log(JSON.stringify({ summary: { passed, total }, checks }, null, 2));
+  if (passed < total) throw new Error(`${total - passed} check(s) failed`);
+} finally {
+  await browser.close();
+  if (created.reservationId) {
+    await rest(`reservations?id=eq.${created.reservationId}`, { method: 'DELETE' });
+  }
+  // Clean up any lingering today fixtures inserted by this runner
+  const profileResp2 = await rest(
+    `profiles?select=id&member_number=eq.${encodeURIComponent(env.PLAYWRIGHT_QA_USER)}&limit=1`
+  ).catch(() => null);
+  if (profileResp2) {
+    const [p2] = await json(profileResp2).catch(() => []);
+    if (p2?.id && created.tableId) {
+      const tomorrow2 = (() => {
+        const d = new Date(); d.setUTCDate(d.getUTCDate() + 1); return d.toISOString().slice(0, 10);
+      })();
+      await rest(
+        `reservations?table_id=eq.${created.tableId}&date=eq.${tomorrow2}&user_id=eq.${p2.id}`,
+        { method: 'DELETE' }
+      ).catch(() => null);
+      const today2 = new Date().toISOString().slice(0, 10);
+      await rest(
+        `reservations?table_id=eq.${created.tableId}&date=eq.${today2}&user_id=eq.${p2.id}`,
+        { method: 'DELETE' }
+      ).catch(() => null);
+    }
+  }
+  console.log(JSON.stringify({ cleanup: 'done' }));
+}


### PR DESCRIPTION
## Summary

- Adds 4 standalone Playwright/Node.js E2E runners to `qa/e2e/` (previously ephemeral in `/tmp/alea-qa`)
- Parameterizes all hardcoded paths: dedicated `.env.e2e.local` resolved relative to runner file, optional `CHROME_PATH` env override, `E2E_BASE_URL` env override
- Adds `qa/e2e/README.md` documenting prerequisites, setup, and what each runner validates
- Adds `qa/e2e/package.json` pinning `playwright` + `dotenv` as devDependencies
- Appends `qa/e2e/*.png`, `qa/e2e/*.webm`, `qa/e2e/*.pdf` artifact globs to `.gitignore`

## Review fixes

- Added an explicit `E2E_ALLOW_DESTRUCTIVE=1` safety gate and dedicated `.env.e2e.local`.
- Defaulted to Playwright bundled Chromium for Linux/CI portability.
- Restricted cleanup to exact fixture IDs.
- Made skipped checks distinct from failures.
- Seeded equipment into the room pool and removed false-positive assertions.

## Runners

| File | What it validates |
|---|---|
| `qa-reservation-lifecycle.mjs` | Create → slot blocked → check-in → `status: active` → second check-in → 409 `CHECK_IN_ALREADY_ACTIVE` |
| `qa-reservation-cancellation.mjs` | Cancel within cutoff → 200 + slot released; cancel within 60 min → 403 `CANCELLATION_CUTOFF` (member role) |
| `qa-no-show-expiry.mjs` | Cron auth guards (401 without/wrong secret); backdated pending → cron → `no_show` transition |
| `qa-reservation-equipment.mjs` | Equipment booking → availability blocked → unknown equipment 400 `INVALID_ROOM_EQUIPMENT` → conflict 409 `EQUIPMENT_ALREADY_RESERVED` |

## Validation results

**`node --check` (syntax):** All 4 files pass.

**Vitest isolation:** `vitest.config.mts` include glob is `__tests__/**/*.{test,spec}.{ts,tsx}` — `qa/e2e/` is not matched.

**`pnpm build`:** Passes with no errors or warnings.

**Run results from repo path (`node qa/e2e/<runner>.mjs`):**

| Runner | Result | Notes |
|---|---|---|
| `qa-no-show-expiry.mjs` | **8/8 passed** | Clean pass |
| `qa-reservation-lifecycle.mjs` | BLOCKED (env) | See below |
| `qa-reservation-cancellation.mjs` | BLOCKED (env) | See below |
| `qa-reservation-equipment.mjs` | BLOCKED (env) | See below |

**Environment regression (pre-existing, not caused by this PR):**

Three runners remain blocked on the current `develop` base at `POST /api/reservations` because `get_database_time` is correctly revoked from `authenticated` while the service still uses the session client there. PR #131 already fixes this by using the admin client; do not restore authenticated execute permission. Re-run the live runners after #131 is merged or rebased into this branch.

## How to run

```bash
pnpm exec next dev -p 3001
# ensure .env.e2e.local has E2E_ALLOW_DESTRUCTIVE=1 and PLAYWRIGHT_QA_USER/PASSWORD, PLAYWRIGHT_QA_SECONDARY_USER/PASSWORD,
# NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SECRET_DEFAULT_KEY, CRON_SECRET
cd qa/e2e && npm install && npx playwright install chromium && cd ../..
node qa/e2e/qa-no-show-expiry.mjs
node qa/e2e/qa-reservation-lifecycle.mjs
node qa/e2e/qa-reservation-cancellation.mjs
node qa/e2e/qa-reservation-equipment.mjs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)