### PR TITLE
fix(security): override ws to >=8.20.1 (GHSA-58qx-3vcg-4xpx) [KIM-396]

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
     "xlsx": "^0.18.5",
     "zod": "^3.25.76"
   },
+  "pnpm": {
+    "overrides": {
+      "ws": ">=8.20.1"
+    }
+  },
   "devDependencies": {
     "@tanstack/react-query-devtools": "^5.96.2",
     "@testing-library/jest-dom": "^6.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ws: '>=8.20.1'
+
 importers:
 
   .:
@@ -3786,8 +3789,8 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4998,7 +5001,7 @@ snapshots:
       '@supabase/phoenix': 0.4.0
       '@types/ws': 8.18.1
       tslib: 2.8.1
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6499,7 +6502,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.20.0
+      ws: 8.21.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -7635,7 +7638,7 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   xlsx@0.18.5:
     dependencies:


### PR DESCRIPTION
## Summary

Adds a pnpm override forcing `ws >= 8.20.1` to remediate **GHSA-58qx-3vcg-4xpx** (uninitialized server-side WebSocket memory disclosure). `ws@8.20.0` is pulled in transitively via `@supabase/realtime-js`; the override resolves it to `8.21.0`.

```json
"pnpm": { "overrides": { "ws": ">=8.20.1" } }
```

## Notes

- Realtime is not used by the app, so exposure is limited, but the vulnerable package is present in the tree.
- **Temporary:** remove this override when `@supabase/supabase-js` is dropped during migration Phase 4.
- Only `package.json` + `pnpm-lock.yaml` change.

## Validation

- `pnpm install --frozen-lockfile` — consistent
- `ws` resolves to `8.21.0` everywhere (no `8.20.0` left)
- `pnpm test` — **669/669** pass
- `pnpm build` — pass
- `pnpm audit --prod --audit-level high` — GHSA-58qx-3vcg-4xpx gone

Closes KIM-396

🤖 Generated with [Claude Code](https://claude.com/claude-code)