### PR TITLE
test(saved-games): route-level + per-user isolation tests [KIM-400]

### DIFF
--- a/__tests__/app/api/saved-games/renew-route.test.ts
+++ b/__tests__/app/api/saved-games/renew-route.test.ts
@@ -1,0 +1,267 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+import type { SessionUser } from '@/lib/server/auth'
+import { ServiceError } from '@/lib/server/service-error'
+
+// --- Top-level mock functions ---
+
+const renewSavedGameForSessionMock = vi.fn()
+const enforceMutationSecurityMock = vi.fn()
+const enforceRateLimitMock = vi.fn()
+const requireAuthMock = vi.fn()
+
+vi.mock('@/lib/server/saved-games-service', () => ({
+  renewSavedGameForSession: renewSavedGameForSessionMock,
+}))
+
+vi.mock('@/lib/server/security', () => ({
+  enforceMutationSecurity: enforceMutationSecurityMock,
+  enforceRateLimit: enforceRateLimitMock,
+  RATE_LIMIT_POLICIES: {
+    reservationMutation: { bucket: 'reservation-mutation', limit: 20, windowMs: 60_000 },
+  },
+}))
+
+vi.mock('@/lib/server/auth', () => ({
+  requireAuth: requireAuthMock,
+}))
+
+// --- Helpers ---
+
+function makeAuthContext(userId = 'user-1', role: 'member' | 'admin' = 'member') {
+  return {
+    session: { id: userId, role } satisfies SessionUser,
+    applyCookies: (res: NextResponse) => {
+      res.cookies.set('sb-access-token', 'test-session')
+      return res
+    },
+  }
+}
+
+function createJsonRequest(
+  path: string,
+  body?: unknown,
+) {
+  return new NextRequest(`http://localhost:3000${path}`, {
+    method: 'POST',
+    headers: {
+      host: 'localhost:3000',
+      origin: 'http://localhost:3000',
+      ...(body ? { 'content-type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+}
+
+// --- Tests ---
+
+describe('Saved Games API route: POST /api/saved-games/[id]/renew', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Security passes by default
+    enforceMutationSecurityMock.mockReturnValue(null)
+    enforceRateLimitMock.mockReturnValue(null)
+    // Auth passes by default
+    requireAuthMock.mockResolvedValue(makeAuthContext('user-1', 'member'))
+  })
+
+  it('returns 200 with renewed saved game when member renews their own game during renewal window', async () => {
+    const mockRenewed = {
+      id: 'sg-renewed-1',
+      tableId: 'table-1',
+      userId: 'user-1',
+      startDate: '2026-07-01',
+      endDate: '2026-09-30',
+      status: 'active' as const,
+      attendanceCount: 0,
+      renewedFromId: 'sg-1',
+      createdAt: '2026-06-19T10:00:00Z',
+      updatedAt: '2026-06-19T10:00:00Z',
+      tableName: 'Mesa doble',
+      roomName: 'Sala',
+      renewalOpensOn: '2026-09-16',
+      canRenew: false,
+    }
+    renewSavedGameForSessionMock.mockResolvedValue(mockRenewed)
+
+    const { POST } = await import('@/app/api/saved-games/[id]/renew/route')
+    const response = await POST(
+      createJsonRequest('/api/saved-games/sg-1/renew'),
+      { params: Promise.resolve({ id: 'sg-1' }) },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual(mockRenewed)
+    expect(renewSavedGameForSessionMock).toHaveBeenCalledWith(
+      { id: 'user-1', role: 'member' },
+      'sg-1',
+    )
+    expect(response.cookies.get('sb-access-token')?.value).toBe('test-session')
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    requireAuthMock.mockResolvedValue(
+      NextResponse.json({ message: 'Unauthorized', statusCode: 401 }, { status: 401 }),
+    )
+
+    const { POST } = await import('@/app/api/saved-games/[id]/renew/route')
+    const response = await POST(
+      createJsonRequest('/api/saved-games/sg-1/renew'),
+      { params: Promise.resolve({ id: 'sg-1' }) },
+    )
+
+    expect(response.status).toBe(401)
+    expect(renewSavedGameForSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when saved game does not exist', async () => {
+    renewSavedGameForSessionMock.mockRejectedValue(new ServiceError('Saved Game not found', 404))
+
+    const { POST } = await import('@/app/api/saved-games/[id]/renew/route')
+    const response = await POST(
+      createJsonRequest('/api/saved-games/nonexistent/renew'),
+      { params: Promise.resolve({ id: 'nonexistent' }) },
+    )
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toMatchObject({ statusCode: 404 })
+  })
+
+  it('per-user isolation: member cannot renew another member\'s saved game (403 Forbidden)', async () => {
+    // User-1 (member) tries to renew a saved game owned by User-2 (another member)
+    // Service checks: if (session.role !== 'admin' && current.user_id !== session.id) -> 403
+    renewSavedGameForSessionMock.mockRejectedValue(new ServiceError('Forbidden', 403))
+    requireAuthMock.mockResolvedValue(makeAuthContext('user-1', 'member'))
+
+    const { POST } = await import('@/app/api/saved-games/[id]/renew/route')
+    const response = await POST(
+      createJsonRequest('/api/saved-games/sg-foreign/renew'),
+      { params: Promise.resolve({ id: 'sg-foreign' }) },
+    )
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toMatchObject({ statusCode: 403, message: 'Forbidden' })
+    // Verify the service was called with the member's session
+    expect(renewSavedGameForSessionMock).toHaveBeenCalledWith(
+      { id: 'user-1', role: 'member' },
+      'sg-foreign',
+    )
+  })
+
+  it('per-user isolation: admin can renew any saved game (no ownership check)', async () => {
+    const mockRenewed = {
+      id: 'sg-renewed-2',
+      tableId: 'table-1',
+      userId: 'user-2', // Different user, but admin can renew it
+      startDate: '2026-07-01',
+      endDate: '2026-09-30',
+      status: 'active' as const,
+      attendanceCount: 0,
+      renewedFromId: 'sg-2',
+      createdAt: '2026-06-19T10:00:00Z',
+      updatedAt: '2026-06-19T10:00:00Z',
+      tableName: 'Mesa doble',
+      roomName: 'Sala',
+      renewalOpensOn: '2026-09-16',
+      canRenew: false,
+    }
+    renewSavedGameForSessionMock.mockResolvedValue(mockRenewed)
+    requireAuthMock.mockResolvedValue(makeAuthContext('admin-user', 'admin'))
+
+    const { POST } = await import('@/app/api/saved-games/[id]/renew/route')
+    const response = await POST(
+      createJsonRequest('/api/saved-games/sg-2/renew'),
+      { params: Promise.resolve({ id: 'sg-2' }) },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual(mockRenewed)
+    expect(renewSavedGameForSessionMock).toHaveBeenCalledWith(
+      { id: 'admin-user', role: 'admin' },
+      'sg-2',
+    )
+  })
+
+  it('returns 409 when game is not active', async () => {
+    renewSavedGameForSessionMock.mockRejectedValue(new ServiceError('SAVED_GAME_NOT_ACTIVE', 409))
+
+    const { POST } = await import('@/app/api/saved-games/[id]/renew/route')
+    const response = await POST(
+      createJsonRequest('/api/saved-games/sg-completed/renew'),
+      { params: Promise.resolve({ id: 'sg-completed' }) },
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toMatchObject({ statusCode: 409 })
+  })
+
+  it('returns 409 when renewal window is not open', async () => {
+    renewSavedGameForSessionMock.mockRejectedValue(new ServiceError('SAVED_GAME_RENEWAL_NOT_OPEN', 409))
+
+    const { POST } = await import('@/app/api/saved-games/[id]/renew/route')
+    const response = await POST(
+      createJsonRequest('/api/saved-games/sg-too-early/renew'),
+      { params: Promise.resolve({ id: 'sg-too-early' }) },
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toMatchObject({ statusCode: 409 })
+  })
+
+  it('returns 409 when renewed game already exists from this saved game', async () => {
+    renewSavedGameForSessionMock.mockRejectedValue(new ServiceError('SAVED_GAME_ALREADY_RENEWED', 409))
+
+    const { POST } = await import('@/app/api/saved-games/[id]/renew/route')
+    const response = await POST(
+      createJsonRequest('/api/saved-games/sg-already-renewed/renew'),
+      { params: Promise.resolve({ id: 'sg-already-renewed' }) },
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toMatchObject({ statusCode: 409 })
+  })
+
+  it('returns 409 when renewed period conflicts with event', async () => {
+    renewSavedGameForSessionMock.mockRejectedValue(new ServiceError('SAVED_GAME_EVENT_CONFLICT', 409))
+
+    const { POST } = await import('@/app/api/saved-games/[id]/renew/route')
+    const response = await POST(
+      createJsonRequest('/api/saved-games/sg-event-conflict/renew'),
+      { params: Promise.resolve({ id: 'sg-event-conflict' }) },
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toMatchObject({ statusCode: 409 })
+  })
+
+  it('rejects mutations with failed CSRF check', async () => {
+    enforceMutationSecurityMock.mockReturnValue(
+      NextResponse.json({ message: 'Invalid CSRF token' }, { status: 403 }),
+    )
+
+    const { POST } = await import('@/app/api/saved-games/[id]/renew/route')
+    const response = await POST(
+      createJsonRequest('/api/saved-games/sg-1/renew'),
+      { params: Promise.resolve({ id: 'sg-1' }) },
+    )
+
+    expect(response.status).toBe(403)
+    expect(renewSavedGameForSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects mutations with rate limit violation', async () => {
+    enforceRateLimitMock.mockReturnValue(
+      NextResponse.json({ message: 'Too many requests' }, { status: 429 }),
+    )
+
+    const { POST } = await import('@/app/api/saved-games/[id]/renew/route')
+    const response = await POST(
+      createJsonRequest('/api/saved-games/sg-1/renew'),
+      { params: Promise.resolve({ id: 'sg-1' }) },
+    )
+
+    expect(response.status).toBe(429)
+    expect(renewSavedGameForSessionMock).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/app/api/saved-games/route.test.ts
+++ b/__tests__/app/api/saved-games/route.test.ts
@@ -1,0 +1,387 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+import type { SessionUser } from '@/lib/server/auth'
+import { ServiceError } from '@/lib/server/service-error'
+
+// --- Top-level mock functions ---
+
+const listSavedGamesForSessionMock = vi.fn()
+const createSavedGameForSessionMock = vi.fn()
+const enforceMutationSecurityMock = vi.fn()
+const enforceRateLimitMock = vi.fn()
+const requireAuthMock = vi.fn()
+
+vi.mock('@/lib/server/saved-games-service', () => ({
+  listSavedGamesForSession: listSavedGamesForSessionMock,
+  createSavedGameForSession: createSavedGameForSessionMock,
+}))
+
+vi.mock('@/lib/server/security', () => ({
+  enforceMutationSecurity: enforceMutationSecurityMock,
+  enforceRateLimit: enforceRateLimitMock,
+  RATE_LIMIT_POLICIES: {
+    reservationMutation: { bucket: 'reservation-mutation', limit: 20, windowMs: 60_000 },
+  },
+}))
+
+vi.mock('@/lib/server/auth', () => ({
+  requireAuth: requireAuthMock,
+}))
+
+// --- Helpers ---
+
+function makeAuthContext(userId = 'user-1', role: 'member' | 'admin' = 'member') {
+  return {
+    session: { id: userId, role } satisfies SessionUser,
+    applyCookies: (res: NextResponse) => {
+      res.cookies.set('sb-access-token', 'test-session')
+      return res
+    },
+  }
+}
+
+function createJsonRequest(
+  path: string,
+  body?: unknown,
+  method: string = 'GET',
+) {
+  return new NextRequest(`http://localhost:3000${path}`, {
+    method,
+    headers: {
+      host: 'localhost:3000',
+      origin: 'http://localhost:3000',
+      ...(body ? { 'content-type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+}
+
+// --- Tests ---
+
+describe('Saved Games API routes: GET and POST /api/saved-games', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Security passes by default
+    enforceMutationSecurityMock.mockReturnValue(null)
+    enforceRateLimitMock.mockReturnValue(null)
+    // Auth passes by default
+    requireAuthMock.mockResolvedValue(makeAuthContext('user-1', 'member'))
+  })
+
+  // ===== GET /api/saved-games =====
+
+  describe('GET /api/saved-games', () => {
+    it('returns 200 with the member\'s saved games', async () => {
+      const mockGames = [
+        {
+          id: 'sg-1',
+          tableId: 'table-1',
+          userId: 'user-1',
+          startDate: '2026-06-20',
+          endDate: '2026-09-19',
+          status: 'active' as const,
+          attendanceCount: 2,
+          renewedFromId: null,
+          createdAt: '2026-06-19T10:00:00Z',
+          updatedAt: '2026-06-19T10:00:00Z',
+          tableName: 'Mesa doble',
+          roomName: 'Sala',
+          renewalOpensOn: '2026-09-05',
+          canRenew: false,
+        },
+      ]
+      listSavedGamesForSessionMock.mockResolvedValue(mockGames)
+
+      const { GET } = await import('@/app/api/saved-games/route')
+      const response = await GET(createJsonRequest('/api/saved-games'))
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual(mockGames)
+      expect(listSavedGamesForSessionMock).toHaveBeenCalledWith({ id: 'user-1', role: 'member' })
+      expect(response.cookies.get('sb-access-token')?.value).toBe('test-session')
+    })
+
+    it('returns 200 with empty array when member has no saved games', async () => {
+      listSavedGamesForSessionMock.mockResolvedValue([])
+
+      const { GET } = await import('@/app/api/saved-games/route')
+      const response = await GET(createJsonRequest('/api/saved-games'))
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual([])
+    })
+
+    it('returns 401 when user is not authenticated', async () => {
+      requireAuthMock.mockResolvedValue(
+        NextResponse.json({ message: 'Unauthorized', statusCode: 401 }, { status: 401 }),
+      )
+
+      const { GET } = await import('@/app/api/saved-games/route')
+      const response = await GET(createJsonRequest('/api/saved-games'))
+
+      expect(response.status).toBe(401)
+      expect(listSavedGamesForSessionMock).not.toHaveBeenCalled()
+    })
+
+    it('maps service errors to error response', async () => {
+      listSavedGamesForSessionMock.mockRejectedValue(new ServiceError('Internal server error', 500))
+
+      const { GET } = await import('@/app/api/saved-games/route')
+      const response = await GET(createJsonRequest('/api/saved-games'))
+
+      expect(response.status).toBe(500)
+      await expect(response.json()).resolves.toMatchObject({ statusCode: 500 })
+    })
+
+    it('per-user isolation: member only sees their own saved games (service filters by user_id)', async () => {
+      const memberGames = [
+        {
+          id: 'sg-member-1',
+          tableId: 'table-1',
+          userId: 'user-1',
+          startDate: '2026-06-20',
+          endDate: '2026-09-19',
+          status: 'active' as const,
+          attendanceCount: 0,
+          renewedFromId: null,
+          createdAt: '2026-06-19T10:00:00Z',
+          updatedAt: '2026-06-19T10:00:00Z',
+          tableName: 'Mesa A',
+          roomName: 'Sala',
+          renewalOpensOn: '2026-09-05',
+          canRenew: false,
+        },
+      ]
+      listSavedGamesForSessionMock.mockResolvedValue(memberGames)
+      requireAuthMock.mockResolvedValue(makeAuthContext('user-1', 'member'))
+
+      const { GET } = await import('@/app/api/saved-games/route')
+      const response = await GET(createJsonRequest('/api/saved-games'))
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual(memberGames)
+      // Verify the service was called with the member's session (isolation enforced by service)
+      expect(listSavedGamesForSessionMock).toHaveBeenCalledWith({ id: 'user-1', role: 'member' })
+    })
+
+    it('admin can see all saved games across all users', async () => {
+      const allGames = [
+        {
+          id: 'sg-1',
+          tableId: 'table-1',
+          userId: 'user-1',
+          startDate: '2026-06-20',
+          endDate: '2026-09-19',
+          status: 'active' as const,
+          attendanceCount: 0,
+          renewedFromId: null,
+          createdAt: '2026-06-19T10:00:00Z',
+          updatedAt: '2026-06-19T10:00:00Z',
+          tableName: 'Mesa A',
+          roomName: 'Sala',
+          renewalOpensOn: '2026-09-05',
+          canRenew: false,
+        },
+        {
+          id: 'sg-2',
+          tableId: 'table-2',
+          userId: 'user-2',
+          startDate: '2026-06-21',
+          endDate: '2026-09-20',
+          status: 'active' as const,
+          attendanceCount: 1,
+          renewedFromId: null,
+          createdAt: '2026-06-19T10:05:00Z',
+          updatedAt: '2026-06-19T10:05:00Z',
+          tableName: 'Mesa B',
+          roomName: 'Sala',
+          renewalOpensOn: '2026-09-06',
+          canRenew: false,
+        },
+      ]
+      listSavedGamesForSessionMock.mockResolvedValue(allGames)
+      requireAuthMock.mockResolvedValue(makeAuthContext('admin-user', 'admin'))
+
+      const { GET } = await import('@/app/api/saved-games/route')
+      const response = await GET(createJsonRequest('/api/saved-games'))
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual(allGames)
+      expect(listSavedGamesForSessionMock).toHaveBeenCalledWith({ id: 'admin-user', role: 'admin' })
+    })
+  })
+
+  // ===== POST /api/saved-games =====
+
+  describe('POST /api/saved-games', () => {
+    it('returns 201 with created saved game when payload is valid', async () => {
+      const mockCreated = {
+        id: 'sg-new-1',
+        tableId: 'table-1',
+        userId: 'user-1',
+        startDate: '2026-06-20',
+        endDate: '2026-09-19',
+        status: 'active' as const,
+        attendanceCount: 0,
+        renewedFromId: null,
+        createdAt: '2026-06-19T10:00:00Z',
+        updatedAt: '2026-06-19T10:00:00Z',
+        tableName: 'Mesa doble',
+        roomName: 'Sala',
+        renewalOpensOn: '2026-09-05',
+        canRenew: false,
+      }
+      createSavedGameForSessionMock.mockResolvedValue(mockCreated)
+
+      const { POST } = await import('@/app/api/saved-games/route')
+      const response = await POST(
+        createJsonRequest('/api/saved-games', {
+          tableId: 'table-1',
+          startDate: '2026-06-20',
+          endDate: '2026-09-19',
+        }, 'POST'),
+      )
+
+      expect(response.status).toBe(201)
+      await expect(response.json()).resolves.toEqual(mockCreated)
+      expect(createSavedGameForSessionMock).toHaveBeenCalledWith(
+        { id: 'user-1', role: 'member' },
+        { tableId: 'table-1', startDate: '2026-06-20', endDate: '2026-09-19' },
+      )
+      expect(response.cookies.get('sb-access-token')?.value).toBe('test-session')
+    })
+
+    it('returns 400 when tableId is missing', async () => {
+      createSavedGameForSessionMock.mockRejectedValue(new ServiceError('tableId is required', 400))
+
+      const { POST } = await import('@/app/api/saved-games/route')
+      const response = await POST(
+        createJsonRequest('/api/saved-games', {
+          startDate: '2026-06-20',
+          endDate: '2026-09-19',
+        }, 'POST'),
+      )
+
+      expect(response.status).toBe(400)
+      await expect(response.json()).resolves.toMatchObject({ statusCode: 400 })
+    })
+
+    it('returns 400 when startDate is invalid', async () => {
+      createSavedGameForSessionMock.mockRejectedValue(new ServiceError('startDate must be a valid date', 400))
+
+      const { POST } = await import('@/app/api/saved-games/route')
+      const response = await POST(
+        createJsonRequest('/api/saved-games', {
+          tableId: 'table-1',
+          startDate: 'invalid-date',
+          endDate: '2026-09-19',
+        }, 'POST'),
+      )
+
+      expect(response.status).toBe(400)
+      await expect(response.json()).resolves.toMatchObject({ statusCode: 400 })
+    })
+
+    it('returns 400 when endDate is invalid', async () => {
+      createSavedGameForSessionMock.mockRejectedValue(new ServiceError('endDate must be a valid date', 400))
+
+      const { POST } = await import('@/app/api/saved-games/route')
+      const response = await POST(
+        createJsonRequest('/api/saved-games', {
+          tableId: 'table-1',
+          startDate: '2026-06-20',
+          endDate: 'not-a-date',
+        }, 'POST'),
+      )
+
+      expect(response.status).toBe(400)
+    })
+
+    it('returns 401 when user is not authenticated', async () => {
+      requireAuthMock.mockResolvedValue(
+        NextResponse.json({ message: 'Unauthorized', statusCode: 401 }, { status: 401 }),
+      )
+
+      const { POST } = await import('@/app/api/saved-games/route')
+      const response = await POST(
+        createJsonRequest('/api/saved-games', {
+          tableId: 'table-1',
+          startDate: '2026-06-20',
+          endDate: '2026-09-19',
+        }, 'POST'),
+      )
+
+      expect(response.status).toBe(401)
+      expect(createSavedGameForSessionMock).not.toHaveBeenCalled()
+    })
+
+    it('returns 409 when saved game conflicts (overlapping active game on same table)', async () => {
+      createSavedGameForSessionMock.mockRejectedValue(new ServiceError('SAVED_GAME_CONFLICT', 409))
+
+      const { POST } = await import('@/app/api/saved-games/route')
+      const response = await POST(
+        createJsonRequest('/api/saved-games', {
+          tableId: 'table-1',
+          startDate: '2026-06-20',
+          endDate: '2026-09-19',
+        }, 'POST'),
+      )
+
+      expect(response.status).toBe(409)
+      await expect(response.json()).resolves.toMatchObject({ statusCode: 409 })
+    })
+
+    it('returns 409 when event conflict exists in date range', async () => {
+      createSavedGameForSessionMock.mockRejectedValue(new ServiceError('SAVED_GAME_EVENT_CONFLICT', 409))
+
+      const { POST } = await import('@/app/api/saved-games/route')
+      const response = await POST(
+        createJsonRequest('/api/saved-games', {
+          tableId: 'table-1',
+          startDate: '2026-06-20',
+          endDate: '2026-09-19',
+        }, 'POST'),
+      )
+
+      expect(response.status).toBe(409)
+      await expect(response.json()).resolves.toMatchObject({ statusCode: 409 })
+    })
+
+    it('rejects mutations with failed CSRF check', async () => {
+      enforceMutationSecurityMock.mockReturnValue(
+        NextResponse.json({ message: 'Invalid CSRF token' }, { status: 403 }),
+      )
+
+      const { POST } = await import('@/app/api/saved-games/route')
+      const response = await POST(
+        createJsonRequest('/api/saved-games', {
+          tableId: 'table-1',
+          startDate: '2026-06-20',
+          endDate: '2026-09-19',
+        }, 'POST'),
+      )
+
+      expect(response.status).toBe(403)
+      expect(createSavedGameForSessionMock).not.toHaveBeenCalled()
+    })
+
+    it('rejects mutations with rate limit violation', async () => {
+      enforceRateLimitMock.mockReturnValue(
+        NextResponse.json({ message: 'Too many requests' }, { status: 429 }),
+      )
+
+      const { POST } = await import('@/app/api/saved-games/route')
+      const response = await POST(
+        createJsonRequest('/api/saved-games', {
+          tableId: 'table-1',
+          startDate: '2026-06-20',
+          endDate: '2026-09-19',
+        }, 'POST'),
+      )
+
+      expect(response.status).toBe(429)
+      expect(createSavedGameForSessionMock).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds the missing **route-level** test coverage for the saved-games endpoints. Previously only the service had unit tests; the routes had none.

New files under `__tests__/app/api/saved-games/`:
- `route.test.ts` — `GET` and `POST /api/saved-games`
- `renew-route.test.ts` — `POST /api/saved-games/[id]/renew`

**26 new tests**, following the established route-test style (dynamic handler import via `await import('@/app/api/...')`, service/Supabase layer mocked — no live server).

## Coverage

| Route | Cases |
| --- | --- |
| `GET /api/saved-games` | happy path (200), empty list, 401 unauthenticated, 500 service error, member sees only own (delegates with member session), admin reads all |
| `POST /api/saved-games` | 201 create, 400 invalid tableId/startDate/endDate, 401, 409 overlap, 409 event conflict, 403 CSRF, 429 rate limit |
| `POST /api/saved-games/[id]/renew` | 200, 401, 404 not found, **403 member renewing another member's game**, admin bypass, 409 not-active / window-closed / already-renewed / event-conflict, 403 CSRF, 429 rate limit |

## Isolation (acceptance criterion)

- **renew**: a member attempting to renew a foreign saved-game is rejected with **403** (route propagates the service's `Forbidden`); admin bypasses the ownership check.
- **GET**: the route delegates with the member's own session; the actual `user_id` filtering / foreign-row rejection is enforced and tested in the service layer (KIM-397 `assertMemberRowsScoped`).

## Validation

- `pnpm typecheck` — pass
- `pnpm test` — **695/695** pass (+26), 0 skipped
- `pnpm build` — pass

Closes KIM-400

🤖 Generated with [Claude Code](https://claude.com/claude-code)