### PR TITLE
fix(cron): register mark-no-show on Vercel Cron + GET handler [KIM-404]

### DIFF
--- a/__tests__/app/api/cron/mark-no-show.test.ts
+++ b/__tests__/app/api/cron/mark-no-show.test.ts
@@ -111,4 +111,88 @@ describe('/api/cron/mark-no-show', () => {
       expect(await response.json()).toEqual({ marked: 0 })
     })
   })
+
+  describe('GET method', () => {
+    it('returns 401 when Authorization header is missing', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      const { GET } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'GET')
+      const response = await GET(request)
+
+      expect(response.status).toBe(401)
+      expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    })
+
+    it('returns 401 when Authorization header has wrong value', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      const { GET } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'GET', {
+        authorization: 'Bearer wrong-secret',
+      })
+      const response = await GET(request)
+
+      expect(response.status).toBe(401)
+      expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    })
+
+    it('returns 200 with marked count when Authorization header is correct', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      markNoShowReservationsMock.mockResolvedValueOnce(3)
+
+      const { GET } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'GET', {
+        authorization: 'Bearer test-secret',
+      })
+      const response = await GET(request)
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ marked: 3 })
+      expect(markNoShowReservationsMock).toHaveBeenCalledOnce()
+    })
+
+    it('returns 401 when CRON_SECRET is not set', async () => {
+      // CRON_SECRET not stubbed - tests default behavior
+      const { GET } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'GET', {
+        authorization: 'Bearer any-secret',
+      })
+      const response = await GET(request)
+
+      expect(response.status).toBe(401)
+    })
+
+    it('returns 500 when markNoShowReservations throws', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      markNoShowReservationsMock.mockRejectedValueOnce(new Error('Database error'))
+
+      const { GET } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'GET', {
+        authorization: 'Bearer test-secret',
+      })
+      const response = await GET(request)
+
+      expect(response.status).toBe(500)
+      expect(await response.json()).toEqual({ error: 'Internal server error' })
+    })
+
+    it('returns 200 with zero count when no reservations need marking', async () => {
+      vi.stubEnv('CRON_SECRET', 'test-secret')
+      markNoShowReservationsMock.mockResolvedValueOnce(0)
+
+      const { GET } = await import('@/app/api/cron/mark-no-show/route')
+
+      const request = createRequest('/api/cron/mark-no-show', 'GET', {
+        authorization: 'Bearer test-secret',
+      })
+      const response = await GET(request)
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ marked: 0 })
+    })
+  })
 })

--- a/app/api/cron/mark-no-show/route.ts
+++ b/app/api/cron/mark-no-show/route.ts
@@ -33,6 +33,10 @@ async function handleCronRequest(request: NextRequest) {
   }
 }
 
+export async function GET(request: NextRequest) {
+  return handleCronRequest(request)
+}
+
 export async function POST(request: NextRequest) {
   return handleCronRequest(request)
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,10 @@
 {
+  "framework": "nextjs",
+  "regions": ["arn1"],
+  "crons": [
+    { "path": "/api/cron/mark-no-show", "schedule": "*/15 * * * *" }
+  ],
   "functions": {
-    "app/api/cron/cancel-pending/route.ts": {
-      "maxDuration": 10
-    }
+    "app/api/cron/mark-no-show/route.ts": { "maxDuration": 60 }
   }
 }


### PR DESCRIPTION
## Summary

`vercel.json` only registered the deprecated `cancel-pending` route (returns 410). The active `app/api/cron/mark-no-show` route was unregistered, unpinned, and had no `maxDuration`.

### Changes
- **`vercel.json`**: drop the dead `cancel-pending` entry; register `/api/cron/mark-no-show` as a Vercel Cron (`*/15 * * * *`); pin `regions: ["arn1"]` (Stockholm, matching the Supabase eu-north-1 region); set `maxDuration: 60` for the cron function; add `framework: "nextjs"`.
- **`app/api/cron/mark-no-show/route.ts`**: add a `GET` handler. **Vercel Cron invokes the registered path via GET**, but the route only exported `POST` — it would have returned 405 and the cron would never run. The new `GET` delegates to the same `handleCronRequest`, so the `Authorization: Bearer $CRON_SECRET` check (which Vercel Cron satisfies automatically) still gates it. `POST` is kept unchanged.

## Validation

- `pnpm typecheck` — pass
- `pnpm test` — **675/675** pass (mark-no-show: 6 POST + 6 GET), 0 skipped
- `pnpm build` — pass

## Follow-up for the user
Set `CRON_SECRET` in Vercel project env so Vercel Cron's requests authenticate. Once this deploys, the external cron-job.org trigger can be retired.

Closes KIM-404

🤖 Generated with [Claude Code](https://claude.com/claude-code)