### PR TITLE
docs(migration): Pre-01 verification — Edge middleware crypto blocker already resolved

### DIFF
--- a/.claude/agent-progress.md
+++ b/.claude/agent-progress.md
@@ -833,3 +833,13 @@ Real-time log of all agent work. Agents append entries as work progresses.
 - [11:26] Security Status: APPROVE — 0 CRITICAL/HIGH/MEDIUM, 0 LOW findings
 - [11:26] ✅ Complete — opening PR chore/pre-push-full-validation -> main
 - [11:26] PR opened: https://github.com/KimoxStudio/alea-webapp/pull/157 (chore/pre-push-full-validation -> main)
+
+#### [f8e91ebe] software-engineer — verify + commit docs
+- [16:49] Started: independent verification of Pre-01 Edge middleware crypto blocker
+- [16:49] Confirmed middleware.ts imports only from lib/server/security-edge (line 4), not lib/server/security
+- [16:49] Traced full import chain (security-edge.ts, i18n/config.ts, supabase/config.client.ts); grep for Node crypto/fs/net APIs found zero matches
+- [16:49] Confirmed lib/server/security.ts (Node crypto, timingSafeEqual/createHash, import 'server-only') is not reachable from middleware.ts
+- [16:49] Confirmed regression test coverage in __tests__/server/security.test.ts lines 51,62,74,87 for the edge-safe cookie-secure-flag split
+- [16:49] pnpm build succeeded (exit 0, Compiled successfully in 2.7s)
+- [16:49] Verified prior fix commits exist on origin/main: 2541044, 2423dff
+- [16:49] Complete — blocker already resolved, no code changes needed; committed docs/issues/migration-pre-01-crypto-edge-middleware.md and -STATUS.md

--- a/docs/issues/migration-pre-01-crypto-edge-middleware-STATUS.md
+++ b/docs/issues/migration-pre-01-crypto-edge-middleware-STATUS.md
@@ -1,0 +1,51 @@
+# Pre-01: Verification Status — ALREADY RESOLVED
+
+**Verdict:** This blocker was already resolved by prior work on `main`. No code changes were made as part of this task; this document records the independent verification evidence.
+
+## Prior fix commits (verified to exist in `origin/main`)
+
+- `2541044` — `feat(security): harden security layer for Vercel (rate limit, edge crypto, cookie flag)`
+  Splits the Edge-safe CSRF/cookie helpers into `lib/server/security-edge.ts` (Web Crypto only, no Node builtins) and re-exports them from `lib/server/security.ts` for backward-compatible route imports. Repoints `middleware.ts` to import from `security-edge` instead of `security`, removing Node `crypto` (`timingSafeEqual`/`createHash`) from the Edge bundle.
+- `2423dff` — `test(security): cover async rate limit, runtime Secure flag, edge split`
+  Updates `__tests__/server/security.test.ts` and `__tests__/app/middleware.test.ts` to cover the async rate limit change and the edge/runtime cookie-secure-flag split.
+
+## Verification evidence gathered independently
+
+**a) middleware.ts import** — `middleware.ts:4`:
+```
+import { ensureCsrfCookie, getSupabaseCookieOptions } from './lib/server/security-edge'
+```
+No import from `./lib/server/security` anywhere in `middleware.ts`.
+
+**b) Full transitive import chain of middleware.ts:**
+- `middleware.ts` → `lib/server/security-edge.ts`, `lib/i18n/config.ts`, `lib/supabase/config.client.ts` (plus external packages `next-intl`, `@supabase/ssr`, `next/server`)
+- `lib/server/security-edge.ts` → only imports `next/server` and `@supabase/ssr` types (no local imports)
+- `lib/i18n/config.ts` → no imports (leaf file, constant exports only)
+- `lib/supabase/config.client.ts` → no imports (leaf file, reads `process.env` only)
+
+Grep for Node-only APIs across the entire chain:
+```
+grep -nE "node:crypto|require\('crypto'\)|from 'crypto'|from \"crypto\"|[^a-zA-Z]fs\.|require\('fs'\)|from 'fs'|require\('net'\)|from 'net'" \
+  middleware.ts lib/server/security-edge.ts lib/i18n/config.ts lib/supabase/config.client.ts
+```
+Result: no matches (exit code 1 / empty). The only occurrence of the string "crypto" in `lib/server/security-edge.ts` is `crypto.getRandomValues(bytes)` (line 41), which is the Web Crypto global API available in both Edge and Node runtimes — not Node's `crypto` module.
+
+**c) `lib/server/security.ts` not reachable from middleware:**
+`lib/server/security.ts` still contains `import 'server-only'` and `import { timingSafeEqual, createHash } from 'crypto'` (lines 1-2). It is imported by API route handlers (`app/api/**/route.ts`) and `lib/supabase/server.ts` / `lib/server/auth.ts`, none of which are in the middleware import chain. `security.ts` re-exports the Edge-safe helpers from `security-edge.ts` (lines 9-17) purely so existing route-handler imports (`@/lib/server/security`) keep working unchanged — this re-export does not affect `middleware.ts`, which imports directly from `security-edge.ts`.
+
+**d) `lib/server/security-edge.ts` docblock (lines 1-14):**
+> Edge-safe security helpers. This module contains ONLY helpers that are safe to run in the Edge Runtime: no Node.js built-ins (`crypto`, `buffer`, etc.), uses Web Crypto API (`crypto.getRandomValues`) which is available everywhere. `middleware.ts` imports from here directly to keep its transitive dependency graph free of Node-only modules. Node-only helpers (`tokensMatch`, `enforceMutationSecurity`, rate limiting) stay in `security.ts`, which re-exports everything from this file so that existing route-handler imports from `@/lib/server/security` are unaffected.
+
+**e) Regression test coverage for the edge-safe split** — `__tests__/server/security.test.ts`:
+- Line 51: `it('uses secure:false when COOKIE_SECURE is explicitly set to false', ...)`
+- Line 62: `it('uses secure:true when COOKIE_SECURE is explicitly set to true', ...)`
+- Line 74: `it('uses secure:true when COOKIE_SECURE is unset and NODE_ENV is production', ...)`
+- Line 87: `it('uses secure:false when COOKIE_SECURE is unset and NODE_ENV is not production', ...)`
+
+These four cases call `security.getSupabaseCookieOptions()` (re-exported from `security-edge.ts`) and exercise the runtime `isSecureContext()` logic that backs the Edge-safe cookie helpers used by `middleware.ts`.
+
+**f) `pnpm build`:** Ran in the isolated worktree — succeeded (exit code 0, "Compiled successfully in 2.7s"), including the `ƒ Middleware` bundle entry with no Edge Runtime crypto warning. Some unrelated `Dynamic server usage: ... couldn't be rendered statically because it used cookies` log lines appeared for the `/[locale]` static-generation pass (pre-existing, caught/handled, unrelated to this blocker) but did not fail the build.
+
+## Conclusion
+
+middleware.ts and its entire transitive import chain are free of Node-only APIs. `lib/server/security.ts` (the Node-crypto module) is not reachable from middleware. `pnpm build` passes. No code changes were required for this task.

--- a/docs/issues/migration-pre-01-crypto-edge-middleware.md
+++ b/docs/issues/migration-pre-01-crypto-edge-middleware.md
@@ -1,0 +1,6 @@
+# Pre-01: Fix Node crypto import in Edge middleware
+Phase: Pre (Supabase to Neon migration blockers). Depends on: none.
+Problem: lib/server/security.ts imports Node crypto module. It is imported (directly or transitively) by middleware.ts, which runs on Vercel Edge runtime. Edge runtime does not support Node crypto -- causes runtime failure on deploy.
+Scope: Identify every function in lib/server/security.ts that uses Node crypto and is reachable from middleware.ts. Replace with Web Crypto API equivalents OR split module so middleware.ts only imports Edge-safe code. Do not change external behavior/signature of functions used outside middleware.ts unless required.
+Acceptance criteria: middleware.ts and everything it imports contains no Node-only APIs (crypto, fs, net, etc). pnpm build succeeds. Existing tests for lib/server/security.ts still pass; add a regression test if the fix changes behavior.
+Out of scope: No changes to lib/server/ files unrelated to the middleware import chain. No changes to auth/session logic beyond what is required.


### PR DESCRIPTION
## Summary

This is a **VERIFICATION-ONLY PR** — no code changes. It confirms that the Pre-01 Supabase→Neon migration blocker ("Edge middleware crypto blocker: `middleware.ts` transitively imports Node's `crypto` module, which is unsupported on Vercel Edge Runtime") was **already resolved** by prior work on `main`, before this verification task began.

## Evidence

- `middleware.ts` imports `ensureCsrfCookie` / `getSupabaseCookieOptions` only from `lib/server/security-edge.ts` — never from `lib/server/security.ts`.
- The full transitive import chain of `middleware.ts` (`lib/server/security-edge.ts`, `lib/i18n/config.ts`, `lib/supabase/config.client.ts`) contains **no Node-only APIs** (`crypto`, `fs`, `net`, etc.) — verified by direct inspection and grep.
- `lib/server/security.ts` (which still imports Node's `timingSafeEqual`/`createHash` from `crypto` and is marked `import 'server-only'`) is **not reachable** from `middleware.ts`. It re-exports the Edge-safe helpers from `security-edge.ts` purely so existing route-handler imports (`@/lib/server/security`) keep working unchanged.
- `pnpm build` passes, including the Edge middleware bundle, with no Node-API-in-Edge-Runtime warning.
- Existing regression tests in `__tests__/server/security.test.ts` cover the edge-safe cookie-secure-flag split (COOKIE_SECURE / NODE_ENV branches) — 15 tests, all passing.

## Prior fix commits

- `2541044` — `feat(security): harden security layer for Vercel` — split Edge-safe CSRF/cookie helpers into `lib/server/security-edge.ts` (Web Crypto only) and repointed `middleware.ts` to import from it, removing Node `crypto` from the Edge bundle.
- `2423dff` — `test: cover async rate limit, runtime Secure flag, edge split` — added regression test coverage for the async rate limit change and the edge/runtime cookie-secure-flag split.

## What changed in this PR

Docs only:
- `docs/issues/migration-pre-01-crypto-edge-middleware.md` — problem statement / scope / acceptance criteria
- `docs/issues/migration-pre-01-crypto-edge-middleware-STATUS.md` — verification status and evidence gathered

No `app/`, `lib/`, `middleware.ts`, or test files were modified.

## Test plan

- [x] QA: 961 tests green, build succeeds, diff confirmed docs-only
- [x] Security review: diff confirmed docs-only, no secrets/env values/credentials in new docs, claims independently verified against `origin/main` source (middleware.ts import, security-edge.ts docblock, security.ts re-export, test file line numbers)
- [ ] User merge to `main` (manual, per repo policy — this PR must not be auto-merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)