### PR TITLE
feat: dev seed + admin bootstrap on Neon (KIM-432)

### DIFF
--- a/.claude/agent-progress.md
+++ b/.claude/agent-progress.md
@@ -1662,3 +1662,11 @@ No blocking issues. No modifications needed. Code is ready for security-reviewer
 - Validation: pnpm typecheck ✅, pnpm lint ✅ (no warnings), pnpm test — full suite green (see validation summary below), pnpm build ✅.
 - Pushed --force-with-lease to origin/docs/migration-status-update.
 - ✅ Complete — PR #175 rebased cleanly onto origin/develop, all conflicts resolved, 9 additional stale references from newer develop PRs fixed, full validation green.
+
+#### [KIM-432] software-engineer — Dev seed + admin bootstrap on Neon
+- Started. Branch migration-f2b-dev-seed-admin-bootstrap created off origin/develop.
+- Added scripts/seed.ts: Drizzle/Neon-native TS seed (own local pg.Pool + drizzle-orm/node-postgres client, does not touch lib/db/index.ts or lib/authjs/db.ts). Seeds 1 admin + 3 member profiles (email == authEmail for Auth.js credentials-user.ts compat, isActive=true, bcryptjs passwordHash), 2 rooms, 5 tables (varied type). Profiles upserted via onConflictDoUpdate on authEmail; rooms/tables via check-then-insert by name (documented in-file).
+- Guard: aborts unless NODE_ENV!=='production' AND DEV_SEED_CONFIRM===YES_SEED_NEON_DEV_DB. Verified all 3 abort paths (missing confirm, NODE_ENV=production, missing POSTGRES_URL) exit 1 before any Pool/connection is created — never ran against a real DB.
+- Added tsx ^4.23.1 devDependency + "db:seed": "tsx scripts/seed.ts" script. Documented DEV_SEED_CONFIRM in .env.example (name only) and added README.md "Dev seed on Neon" section with dev-only seeded credentials.
+- Validation: pnpm typecheck ✅, pnpm lint ✅. Did not run drizzle-kit push/migrate or pnpm db:seed for real, per hard constraint.
+- ✅ Complete — branch migration-f2b-dev-seed-admin-bootstrap, committed locally (not pushed, no PR opened per instructions).

--- a/.claude/agent-progress.md
+++ b/.claude/agent-progress.md
@@ -1679,3 +1679,10 @@ No blocking issues. No modifications needed. Code is ready for security-reviewer
 - [08:08] Confirmed lib/db/index.ts, lib/authjs/db.ts, lib/db/schema/*, supabase/migrations/, supabase/seed.sql are untouched (empty diff).
 - [08:08] tests/unit/seed-guard.test.ts: reimplements guard logic inline rather than importing scripts/seed.ts; does not touch a DB or leak anything. LOW note: could drift from the real implementation over time (QA follow-up, non-blocking).
 - [08:08] ✅ Complete — APPROVE. No CRITICAL/HIGH findings. Pushing branch and opening PR.
+
+#### [KIM-432] security-reviewer — PR opened after isolated-worktree unblock
+- [08:40] Push from shared checkout failed due to stale node_modules there (pre-existing env drift unrelated to this change, missing drizzle-orm/next-auth/pg/bcryptjs/@vercel/blob despite develop's own package.json declaring them).
+- [08:40] Used a fresh throwaway worktree outside the shared checkout for pnpm install + re-verification only — shared checkout HEAD/node_modules never touched.
+- [08:40] Re-ran full validation in the clean worktree: typecheck OK, lint OK, test OK (1151 passed, 21 skipped, 0 failed), build OK.
+- [08:40] Pushed migration-f2b-dev-seed-admin-bootstrap and opened PR.
+- [08:40] Complete — PR #177: https://github.com/KimoxStudio/alea-webapp/pull/177

--- a/.claude/agent-progress.md
+++ b/.claude/agent-progress.md
@@ -1670,3 +1670,12 @@ No blocking issues. No modifications needed. Code is ready for security-reviewer
 - Added tsx ^4.23.1 devDependency + "db:seed": "tsx scripts/seed.ts" script. Documented DEV_SEED_CONFIRM in .env.example (name only) and added README.md "Dev seed on Neon" section with dev-only seeded credentials.
 - Validation: pnpm typecheck ✅, pnpm lint ✅. Did not run drizzle-kit push/migrate or pnpm db:seed for real, per hard constraint.
 - ✅ Complete — branch migration-f2b-dev-seed-admin-bootstrap, committed locally (not pushed, no PR opened per instructions).
+
+#### [KIM-432] security-reviewer — Dev seed + admin bootstrap security review
+- [08:08] Started. Read-only inspection via git show/git diff, no checkout of shared repo.
+- [08:08] scripts/seed.ts: confirmed assertDevSeedAllowed() runs first in main(), before createSeedDbClient() — no bypass path. No POSTGRES_URL*/password values logged anywhere. bcryptjs salt rounds=10 (reasonable default). Drizzle query builder used throughout (eq/and), no raw SQL/string concat — no injection surface.
+- [08:08] pnpm-lock.yaml diff verified minimal and expected: tsx@4.23.1 was already a transitive dep (via vite/vitest) in develop's lockfile; this PR only promotes it to an explicit devDependency — no new/unexpected packages pulled in.
+- [08:08] .env.example / README.md changes document DEV_SEED_CONFIRM by name only; README's seeded credentials table is clearly dev-only/placeholder (admin@devseed.local etc, password dev-only-Seed123!), not a real secret.
+- [08:08] Confirmed lib/db/index.ts, lib/authjs/db.ts, lib/db/schema/*, supabase/migrations/, supabase/seed.sql are untouched (empty diff).
+- [08:08] tests/unit/seed-guard.test.ts: reimplements guard logic inline rather than importing scripts/seed.ts; does not touch a DB or leak anything. LOW note: could drift from the real implementation over time (QA follow-up, non-blocking).
+- [08:08] ✅ Complete — APPROVE. No CRITICAL/HIGH findings. Pushing branch and opening PR.

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,19 @@ POSTGRES_URL=
 POSTGRES_URL_NON_POOLING=
 
 # ============================================================
+# DEV SEED SCRIPT (scripts/seed.ts, `pnpm db:seed`) — KIM-432
+# Bootstraps a dev admin + minimal fixtures directly on Neon via Drizzle.
+# See README.md "Local seed data" for the seeded dev-only credentials.
+# ============================================================
+
+# Explicit opt-in guard for `pnpm db:seed`. The script also refuses to run
+# whenever NODE_ENV=production, regardless of this value. Leave unset
+# everywhere except your own local shell/.env.local when you intentionally
+# want to (re-)seed the dev database configured via POSTGRES_URL above.
+# Required exact value: DEV_SEED_CONFIRM=YES_SEED_NEON_DEV_DB
+DEV_SEED_CONFIRM=
+
+# ============================================================
 # APPLICATION
 # ============================================================
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,31 @@ Stop local Supabase:
 supabase stop
 ```
 
+### Dev seed on Neon (`pnpm db:seed`, KIM-432)
+
+Once the app targets Neon/Vercel Postgres (see Auth.js / F1-F2 migration scaffolding above), `scripts/seed.ts` bootstraps a minimal, idempotent set of dev fixtures directly via Drizzle — an admin profile, a few member profiles, 2 rooms, and a handful of tables (varied `type`). This is a **separate script from the legacy `supabase/seed.sql`** above: it targets the Neon-native `profiles`/`rooms`/`tables` schema in `lib/db/schema`, not Supabase's `auth.users`.
+
+This script is safe to re-run: it upserts profiles by email and only inserts rooms/tables that don't already exist by name.
+
+**Guard:** the script refuses to run unless `NODE_ENV !== 'production'` **and** `DEV_SEED_CONFIRM` is set to the exact value `YES_SEED_NEON_DEV_DB` (see `.env.example`). Never set `DEV_SEED_CONFIRM` outside your own local shell/`.env.local`.
+
+Requires `POSTGRES_URL` (or `POSTGRES_URL_NON_POOLING`) to already be configured, pointing at your dev database.
+
+```bash
+DEV_SEED_CONFIRM=YES_SEED_NEON_DEV_DB pnpm db:seed
+```
+
+Seeded dev-only credentials (never real secrets — do not reuse anywhere else):
+
+| Role | Email | Password |
+|---|---|---|
+| admin | `admin@devseed.local` | `dev-only-Seed123!` |
+| member | `member1@devseed.local` | `dev-only-Seed123!` |
+| member | `member2@devseed.local` | `dev-only-Seed123!` |
+| member | `member3@devseed.local` | `dev-only-Seed123!` |
+
+Note: as of KIM-432, Auth.js is not yet wired into any page/layout/middleware (see `lib/authjs/config.ts`), so logging in against these seeded credentials through `/api/authjs/*` (once `AUTH_JS_ENABLED=true`) does not by itself grant access to the admin UI pages — that gating still runs through the legacy Supabase-session path. This is expected and tracked separately; it is not a bug in this seed script.
+
 ## Local CI Hook
 
 The repository uses a local `pre-push` hook to run the core validation checks before a push. The hook is not installed automatically after cloning.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "typecheck": "next typegen && node -e \"require('node:fs').rmSync('.next/cache/.tsbuildinfo', { force: true })\" && tsc --noEmit",
     "security:deps": "pnpm audit --prod --audit-level high",
     "cutover:rehearsal": "bash ./scripts/cutover-rehearsal.sh",
+    "db:seed": "tsx scripts/seed.ts",
     "hooks:install": "node -e \"if (process.platform === 'win32') { console.log('Skipping hook installation on Windows: pnpm hooks:install requires Bash/WSL to run scripts/install-hooks.sh.'); process.exit(0); } require('node:child_process').execFileSync('bash', ['./scripts/install-hooks.sh'], { stdio: 'inherit' });\"",
     "hooks:verify:worktree": "node -e \"if (process.platform === 'win32') { console.log('Skipping worktree hook smoke test on Windows: requires Bash/WSL to run scripts/verify-hooks-worktree.sh.'); process.exit(0); } require('node:child_process').execFileSync('bash', ['./scripts/verify-hooks-worktree.sh'], { stdio: 'inherit' });\""
   },
@@ -100,6 +101,7 @@
     "postcss": "^8.5.8",
     "tailwindcss": "^3.4.19",
     "tailwindcss-animate": "^1.0.7",
+    "tsx": "^4.23.1",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.19(tsx@4.23.1)(yaml@2.9.0))
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,281 @@
+#!/usr/bin/env tsx
+/**
+ * scripts/seed.ts — dev-only seed + admin bootstrap on Neon (KIM-432).
+ *
+ * Part of the Supabase→Neon migration (Linear KIM-393..422). All Supabase
+ * dev data is throwaway — there is no data migration. This script seeds a
+ * minimal, working fixture set directly on the target Neon/Postgres
+ * database via Drizzle so a human can manually test admin flows (e.g. admin
+ * image upload) once the app runs against Neon.
+ *
+ * This is intentionally NOT `supabase/seed.sql`: that file is Supabase-era
+ * (writes into `auth.users` / the old `public.profiles` shape) and is out of
+ * scope here — see the `supabase/seed.sql` header for the legacy flow. This
+ * script is Drizzle/Neon-native TypeScript and talks to `lib/db/schema`
+ * directly with its own local `pg.Pool` + `drizzle-orm/node-postgres`
+ * client (see `createSeedDbClient` below). It intentionally does NOT reuse
+ * `lib/db/index.ts` (still Supabase-backed) or `lib/authjs/db.ts` (raw SQL
+ * only, explicitly avoids importing Drizzle) — both are unrelated seams and
+ * must not be touched by this script.
+ *
+ * SAFETY: this script refuses to run unless BOTH `NODE_ENV !== 'production'`
+ * AND `DEV_SEED_CONFIRM` is set to the exact confirmation value below (see
+ * `assertDevSeedAllowed`). Never set `DEV_SEED_CONFIRM` in a shared,
+ * staging, or production environment — it exists only to make running this
+ * against the wrong database a deliberate, explicit action.
+ *
+ * Idempotency:
+ *  - `profiles` rows are upserted keyed on `authEmail` (the schema's natural
+ *    unique identity column, backed by the `profiles_auth_email_key` unique
+ *    index) via `onConflictDoUpdate`, so re-running this script updates the
+ *    existing dev fixtures in place instead of duplicating them.
+ *  - `rooms` / `tables` have no unique business key in the Drizzle schema.
+ *    This script uses an explicit check-then-insert by `name` (and, for
+ *    tables, `roomId` + `name`) instead of a DB-level upsert, so re-running
+ *    it does not pile up duplicate fixture rows. This is a deliberate
+ *    trade-off for a dev-only fixture script — do not copy this pattern for
+ *    production data paths.
+ *
+ * Usage:
+ *   DEV_SEED_CONFIRM=<see below> pnpm db:seed
+ *
+ * Requires `POSTGRES_URL` (or `POSTGRES_URL_NON_POOLING`) to be set, e.g. in
+ * `.env.local`. Never logs, prints, or otherwise surfaces either value.
+ */
+import { config as loadEnv } from 'dotenv'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { Pool } from 'pg'
+import { drizzle } from 'drizzle-orm/node-postgres'
+import { and, eq } from 'drizzle-orm'
+import bcrypt from 'bcryptjs'
+import { profiles, rooms, tables, tableTypeEnum } from '../lib/db/schema'
+
+type TableType = (typeof tableTypeEnum.enumValues)[number]
+
+// Load `.env.local` (the repo's documented local-env convention, see
+// .env.example) so `pnpm db:seed` works the same way `pnpm dev` does,
+// without requiring callers to export vars manually.
+loadEnv({ path: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../.env.local') })
+
+/**
+ * Exact value `DEV_SEED_CONFIRM` must be set to for this script to proceed.
+ * Deliberately not a bare "true"/"1" so it can't be flipped on by accident
+ * (e.g. copy-pasting an unrelated boolean env block).
+ */
+const DEV_SEED_CONFIRM_VALUE = 'YES_SEED_NEON_DEV_DB'
+
+/** Dev-only password shared by all seeded profiles. Not a real secret —
+ * documented in README.md's "Local seed data" section, never stored in any
+ * `.env*` file. Hashed with bcryptjs before being written to
+ * `profiles.password_hash`. */
+const DEV_SEED_PASSWORD = 'dev-only-Seed123!'
+
+function assertDevSeedAllowed(): void {
+  if (process.env.NODE_ENV === 'production') {
+    console.error(
+      '[seed] Refusing to run: NODE_ENV=production. This script seeds throwaway dev fixtures ' +
+        'and must never run against a production database.'
+    )
+    process.exit(1)
+  }
+
+  if (process.env.DEV_SEED_CONFIRM !== DEV_SEED_CONFIRM_VALUE) {
+    console.error(
+      '[seed] Refusing to run: missing or incorrect DEV_SEED_CONFIRM.\n' +
+        `  Set DEV_SEED_CONFIRM=${DEV_SEED_CONFIRM_VALUE} to confirm you intend to seed the ` +
+        'database currently configured via POSTGRES_URL / POSTGRES_URL_NON_POOLING.\n' +
+        '  Never set this variable in a shared, staging, or production environment.'
+    )
+    process.exit(1)
+  }
+}
+
+/**
+ * Builds a local, one-off Drizzle client for this seed script only. Reads
+ * `POSTGRES_URL` / `POSTGRES_URL_NON_POOLING` by name only — never logs
+ * either value. Intentionally not shared with any other module (see file
+ * header).
+ */
+function createSeedDbClient() {
+  const connectionString = process.env.POSTGRES_URL_NON_POOLING ?? process.env.POSTGRES_URL
+
+  if (!connectionString) {
+    console.error(
+      '[seed] Refusing to run: neither POSTGRES_URL nor POSTGRES_URL_NON_POOLING is set. ' +
+        'Configure one in .env.local (see .env.example).'
+    )
+    process.exit(1)
+  }
+
+  const pool = new Pool({ connectionString })
+  const db = drizzle(pool, { schema: { profiles, rooms, tables } })
+
+  return { db, pool }
+}
+
+type SeedDb = ReturnType<typeof createSeedDbClient>['db']
+
+interface SeedProfileInput {
+  memberNumber: string
+  email: string
+  role: 'admin' | 'member'
+  fullName: string
+}
+
+/**
+ * Upserts a dev profile keyed on `authEmail`. `email` is set to the same
+ * value as `authEmail` — required so `lib/authjs/credentials-user.ts`'s
+ * `verifyCredentials()` (which looks up rows by the nullable `email`
+ * column, not `authEmail`) can find these seeded rows too. This mirrors a
+ * documented discrepancy between the legacy Supabase-session auth path and
+ * the Auth.js scaffolding; not something this script can or should "fix".
+ */
+async function upsertDevProfile(db: SeedDb, input: SeedProfileInput): Promise<void> {
+  const passwordHash = await bcrypt.hash(DEV_SEED_PASSWORD, 10)
+
+  await db
+    .insert(profiles)
+    .values({
+      id: randomUUID(),
+      memberNumber: input.memberNumber,
+      email: input.email,
+      authEmail: input.email,
+      role: input.role,
+      isActive: true,
+      fullName: input.fullName,
+      passwordHash,
+    })
+    .onConflictDoUpdate({
+      target: profiles.authEmail,
+      set: {
+        memberNumber: input.memberNumber,
+        email: input.email,
+        role: input.role,
+        isActive: true,
+        fullName: input.fullName,
+        passwordHash,
+        updatedAt: new Date(),
+      },
+    })
+
+  console.log(`[seed] upserted profile ${input.email} (role=${input.role})`)
+}
+
+/** Check-then-insert by `name` — see file header "Idempotency" note. */
+async function findOrCreateRoom(
+  db: SeedDb,
+  input: { name: string; description: string; tableCount: number }
+): Promise<string> {
+  const existing = await db
+    .select({ id: rooms.id })
+    .from(rooms)
+    .where(eq(rooms.name, input.name))
+    .limit(1)
+
+  if (existing[0]) {
+    console.log(`[seed] room "${input.name}" already exists, skipping insert`)
+    return existing[0].id
+  }
+
+  const [inserted] = await db
+    .insert(rooms)
+    .values({
+      name: input.name,
+      description: input.description,
+      tableCount: input.tableCount,
+    })
+    .returning({ id: rooms.id })
+
+  console.log(`[seed] created room "${input.name}"`)
+  return inserted.id
+}
+
+/** Check-then-insert by `roomId` + `name` — see file header "Idempotency" note. */
+async function findOrCreateTable(
+  db: SeedDb,
+  input: { roomId: string; name: string; type: TableType }
+): Promise<void> {
+  const existing = await db
+    .select({ id: tables.id })
+    .from(tables)
+    .where(and(eq(tables.roomId, input.roomId), eq(tables.name, input.name)))
+    .limit(1)
+
+  if (existing[0]) {
+    console.log(`[seed] table "${input.name}" already exists, skipping insert`)
+    return
+  }
+
+  await db.insert(tables).values({
+    roomId: input.roomId,
+    name: input.name,
+    type: input.type,
+  })
+
+  console.log(`[seed] created table "${input.name}" (type=${input.type})`)
+}
+
+async function main(): Promise<void> {
+  assertDevSeedAllowed()
+
+  const { db, pool } = createSeedDbClient()
+
+  try {
+    await upsertDevProfile(db, {
+      memberNumber: 'DEV-ADMIN-001',
+      email: 'admin@devseed.local',
+      role: 'admin',
+      fullName: 'Dev Seed Admin',
+    })
+
+    await upsertDevProfile(db, {
+      memberNumber: 'DEV-MEM-001',
+      email: 'member1@devseed.local',
+      role: 'member',
+      fullName: 'Dev Seed Member One',
+    })
+
+    await upsertDevProfile(db, {
+      memberNumber: 'DEV-MEM-002',
+      email: 'member2@devseed.local',
+      role: 'member',
+      fullName: 'Dev Seed Member Two',
+    })
+
+    await upsertDevProfile(db, {
+      memberNumber: 'DEV-MEM-003',
+      email: 'member3@devseed.local',
+      role: 'member',
+      fullName: 'Dev Seed Member Three',
+    })
+
+    const room1Id = await findOrCreateRoom(db, {
+      name: 'Dev Seed Room 1',
+      description: 'Seeded fixture room for local/dev manual QA.',
+      tableCount: 3,
+    })
+
+    const room2Id = await findOrCreateRoom(db, {
+      name: 'Dev Seed Room 2',
+      description: 'Seeded fixture room for local/dev manual QA.',
+      tableCount: 2,
+    })
+
+    await findOrCreateTable(db, { roomId: room1Id, name: 'Dev Table 1', type: 'small' })
+    await findOrCreateTable(db, { roomId: room1Id, name: 'Dev Table 2', type: 'large' })
+    await findOrCreateTable(db, { roomId: room1Id, name: 'Dev Table 3', type: 'removable_top' })
+    await findOrCreateTable(db, { roomId: room2Id, name: 'Dev Table 4', type: 'small' })
+    await findOrCreateTable(db, { roomId: room2Id, name: 'Dev Table 5', type: 'removable_top' })
+
+    console.log('[seed] done — dev fixtures seeded successfully.')
+  } finally {
+    await pool.end()
+  }
+}
+
+main().catch((error) => {
+  console.error('[seed] failed:', error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/tests/unit/seed-guard.test.ts
+++ b/tests/unit/seed-guard.test.ts
@@ -1,0 +1,124 @@
+/**
+ * tests/scripts/seed-guard.test.ts — verify seed script guard logic
+ *
+ * Ensures the dev seed script refuses to run in production or without
+ * proper DEV_SEED_CONFIRM confirmation. This is critical for safety since
+ * the script would otherwise seed fixtures into a real production database.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+describe('seed script guard logic', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+  const originalConfirm = process.env.DEV_SEED_CONFIRM
+  const DEV_SEED_CONFIRM_VALUE = 'YES_SEED_NEON_DEV_DB'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv
+    process.env.DEV_SEED_CONFIRM = originalConfirm
+  })
+
+  it('should allow seed when NODE_ENV is development and DEV_SEED_CONFIRM is correct', () => {
+    process.env.NODE_ENV = 'development'
+    process.env.DEV_SEED_CONFIRM = DEV_SEED_CONFIRM_VALUE
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation()
+    const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    // Guard logic (inlined for test)
+    function assertDevSeedAllowed(): void {
+      if (process.env.NODE_ENV === 'production') {
+        console.error('[seed] Refusing to run: NODE_ENV=production')
+        process.exit(1)
+      }
+      if (process.env.DEV_SEED_CONFIRM !== DEV_SEED_CONFIRM_VALUE) {
+        console.error('[seed] Refusing to run: missing or incorrect DEV_SEED_CONFIRM')
+        process.exit(1)
+      }
+    }
+
+    expect(() => assertDevSeedAllowed()).not.toThrow()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    expect(processExitSpy).not.toHaveBeenCalled()
+  })
+
+  it('should refuse seed when NODE_ENV is production', () => {
+    process.env.NODE_ENV = 'production'
+    process.env.DEV_SEED_CONFIRM = DEV_SEED_CONFIRM_VALUE
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation()
+    const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    function assertDevSeedAllowed(): void {
+      if (process.env.NODE_ENV === 'production') {
+        console.error('[seed] Refusing to run: NODE_ENV=production')
+        process.exit(1)
+      }
+      if (process.env.DEV_SEED_CONFIRM !== DEV_SEED_CONFIRM_VALUE) {
+        console.error('[seed] Refusing to run: missing or incorrect DEV_SEED_CONFIRM')
+        process.exit(1)
+      }
+    }
+
+    expect(() => assertDevSeedAllowed()).toThrow('process.exit called')
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('NODE_ENV=production'))
+    expect(processExitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('should refuse seed when DEV_SEED_CONFIRM is missing', () => {
+    process.env.NODE_ENV = 'development'
+    process.env.DEV_SEED_CONFIRM = undefined
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation()
+    const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    function assertDevSeedAllowed(): void {
+      if (process.env.NODE_ENV === 'production') {
+        console.error('[seed] Refusing to run: NODE_ENV=production')
+        process.exit(1)
+      }
+      if (process.env.DEV_SEED_CONFIRM !== DEV_SEED_CONFIRM_VALUE) {
+        console.error('[seed] Refusing to run: missing or incorrect DEV_SEED_CONFIRM')
+        process.exit(1)
+      }
+    }
+
+    expect(() => assertDevSeedAllowed()).toThrow('process.exit called')
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('DEV_SEED_CONFIRM'))
+    expect(processExitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('should refuse seed when DEV_SEED_CONFIRM has wrong value', () => {
+    process.env.NODE_ENV = 'development'
+    process.env.DEV_SEED_CONFIRM = 'wrong_value'
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation()
+    const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    function assertDevSeedAllowed(): void {
+      if (process.env.NODE_ENV === 'production') {
+        console.error('[seed] Refusing to run: NODE_ENV=production')
+        process.exit(1)
+      }
+      if (process.env.DEV_SEED_CONFIRM !== DEV_SEED_CONFIRM_VALUE) {
+        console.error('[seed] Refusing to run: missing or incorrect DEV_SEED_CONFIRM')
+        process.exit(1)
+      }
+    }
+
+    expect(() => assertDevSeedAllowed()).toThrow('process.exit called')
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('DEV_SEED_CONFIRM'))
+    expect(processExitSpy).toHaveBeenCalledWith(1)
+  })
+})

--- a/tests/unit/seed-guard.test.ts
+++ b/tests/unit/seed-guard.test.ts
@@ -1,124 +1,111 @@
 /**
- * tests/scripts/seed-guard.test.ts — verify seed script guard logic
+ * tests/unit/seed-guard.test.ts — verify seed script guard logic
  *
- * Ensures the dev seed script refuses to run in production or without
- * proper DEV_SEED_CONFIRM confirmation. This is critical for safety since
- * the script would otherwise seed fixtures into a real production database.
+ * Proves the dev seed script's guard (in scripts/seed.ts) fires BEFORE any
+ * database connection is attempted. This is critical for safety since the
+ * script would otherwise seed fixtures into a wrong database.
+ *
+ * Rather than re-implementing guard logic inline, this test spawns the real
+ * `pnpm db:seed` process with controlled environment variables and an invalid
+ * POSTGRES_URL. For the "deny" cases (production, missing/wrong
+ * DEV_SEED_CONFIRM), the guard rejects and the process exits with code 1,
+ * outputting the guard's rejection message. For the "allowed" case, the guard
+ * passes but the subprocess fails trying to connect to the garbage URL,
+ * proving the guard ran first and the process got past it.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
 
 describe('seed script guard logic', () => {
-  const originalNodeEnv = process.env.NODE_ENV
-  const originalConfirm = process.env.DEV_SEED_CONFIRM
   const DEV_SEED_CONFIRM_VALUE = 'YES_SEED_NEON_DEV_DB'
+  const INVALID_POSTGRES_URL = 'postgres://invalid:invalid@localhost:1/nonexistent'
 
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  afterEach(() => {
-    process.env.NODE_ENV = originalNodeEnv
-    process.env.DEV_SEED_CONFIRM = originalConfirm
-  })
+  /**
+   * Spawn the real seed script as a subprocess with controlled environment.
+   * Returns { exitCode, stderr, stdout, success }.
+   */
+  function runSeedProcess(env: Record<string, string | undefined>): {
+    exitCode: number
+    stderr: string
+    stdout: string
+    success: boolean
+  } {
+    try {
+      const stdout = execFileSync('pnpm', ['db:seed'], {
+        cwd: path.resolve(__dirname, '../../'),
+        env: { ...process.env, ...env },
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      return { exitCode: 0, stdout, stderr: '', success: true }
+    } catch (error: any) {
+      const exitCode = error.status ?? 1
+      const stderr = error.stderr?.toString() ?? ''
+      const stdout = error.stdout?.toString() ?? ''
+      return { exitCode, stderr, stdout, success: false }
+    }
+  }
 
   it('should allow seed when NODE_ENV is development and DEV_SEED_CONFIRM is correct', () => {
-    process.env.NODE_ENV = 'development'
-    process.env.DEV_SEED_CONFIRM = DEV_SEED_CONFIRM_VALUE
-
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation()
-    const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit called')
+    const result = runSeedProcess({
+      NODE_ENV: 'development',
+      DEV_SEED_CONFIRM: DEV_SEED_CONFIRM_VALUE,
+      POSTGRES_URL: INVALID_POSTGRES_URL,
+      POSTGRES_URL_NON_POOLING: undefined,
     })
 
-    // Guard logic (inlined for test)
-    function assertDevSeedAllowed(): void {
-      if (process.env.NODE_ENV === 'production') {
-        console.error('[seed] Refusing to run: NODE_ENV=production')
-        process.exit(1)
-      }
-      if (process.env.DEV_SEED_CONFIRM !== DEV_SEED_CONFIRM_VALUE) {
-        console.error('[seed] Refusing to run: missing or incorrect DEV_SEED_CONFIRM')
-        process.exit(1)
-      }
-    }
+    // Subprocess should fail due to invalid DB, but NOT due to the guard.
+    // The guard should have passed, so we expect a DB-related error,
+    // not a guard rejection message.
+    expect(result.exitCode).toBe(1)
 
-    expect(() => assertDevSeedAllowed()).not.toThrow()
-    expect(consoleErrorSpy).not.toHaveBeenCalled()
-    expect(processExitSpy).not.toHaveBeenCalled()
+    // Assert the guard rejection message is NOT present.
+    // If the guard fired, we'd see "[seed] Refusing to run: NODE_ENV=production"
+    // or "[seed] Refusing to run: missing or incorrect DEV_SEED_CONFIRM"
+    expect(result.stderr).not.toMatch(/\[seed\] Refusing to run/)
+
+    // The failure should be DB-related (passed guard, failed on DB connection/query).
+    // This proves the guard ran and the process got PAST it to the seeding phase.
+    expect(result.stderr).toMatch(/\[seed\] failed|Failed query|Connection refused|getaddrinfo ENOTFOUND|ECONNREFUSED/)
   })
 
   it('should refuse seed when NODE_ENV is production', () => {
-    process.env.NODE_ENV = 'production'
-    process.env.DEV_SEED_CONFIRM = DEV_SEED_CONFIRM_VALUE
-
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation()
-    const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit called')
+    const result = runSeedProcess({
+      NODE_ENV: 'production',
+      DEV_SEED_CONFIRM: DEV_SEED_CONFIRM_VALUE,
+      POSTGRES_URL: INVALID_POSTGRES_URL,
+      POSTGRES_URL_NON_POOLING: undefined,
     })
 
-    function assertDevSeedAllowed(): void {
-      if (process.env.NODE_ENV === 'production') {
-        console.error('[seed] Refusing to run: NODE_ENV=production')
-        process.exit(1)
-      }
-      if (process.env.DEV_SEED_CONFIRM !== DEV_SEED_CONFIRM_VALUE) {
-        console.error('[seed] Refusing to run: missing or incorrect DEV_SEED_CONFIRM')
-        process.exit(1)
-      }
-    }
-
-    expect(() => assertDevSeedAllowed()).toThrow('process.exit called')
-    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('NODE_ENV=production'))
-    expect(processExitSpy).toHaveBeenCalledWith(1)
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toMatch(/NODE_ENV=production/)
+    expect(result.stderr).toMatch(/\[seed\] Refusing to run/)
   })
 
   it('should refuse seed when DEV_SEED_CONFIRM is missing', () => {
-    process.env.NODE_ENV = 'development'
-    process.env.DEV_SEED_CONFIRM = undefined
-
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation()
-    const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit called')
+    const result = runSeedProcess({
+      NODE_ENV: 'development',
+      DEV_SEED_CONFIRM: undefined,
+      POSTGRES_URL: INVALID_POSTGRES_URL,
+      POSTGRES_URL_NON_POOLING: undefined,
     })
 
-    function assertDevSeedAllowed(): void {
-      if (process.env.NODE_ENV === 'production') {
-        console.error('[seed] Refusing to run: NODE_ENV=production')
-        process.exit(1)
-      }
-      if (process.env.DEV_SEED_CONFIRM !== DEV_SEED_CONFIRM_VALUE) {
-        console.error('[seed] Refusing to run: missing or incorrect DEV_SEED_CONFIRM')
-        process.exit(1)
-      }
-    }
-
-    expect(() => assertDevSeedAllowed()).toThrow('process.exit called')
-    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('DEV_SEED_CONFIRM'))
-    expect(processExitSpy).toHaveBeenCalledWith(1)
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toMatch(/missing or incorrect DEV_SEED_CONFIRM/)
+    expect(result.stderr).toMatch(/\[seed\] Refusing to run/)
   })
 
   it('should refuse seed when DEV_SEED_CONFIRM has wrong value', () => {
-    process.env.NODE_ENV = 'development'
-    process.env.DEV_SEED_CONFIRM = 'wrong_value'
-
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation()
-    const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit called')
+    const result = runSeedProcess({
+      NODE_ENV: 'development',
+      DEV_SEED_CONFIRM: 'wrong_value',
+      POSTGRES_URL: INVALID_POSTGRES_URL,
+      POSTGRES_URL_NON_POOLING: undefined,
     })
 
-    function assertDevSeedAllowed(): void {
-      if (process.env.NODE_ENV === 'production') {
-        console.error('[seed] Refusing to run: NODE_ENV=production')
-        process.exit(1)
-      }
-      if (process.env.DEV_SEED_CONFIRM !== DEV_SEED_CONFIRM_VALUE) {
-        console.error('[seed] Refusing to run: missing or incorrect DEV_SEED_CONFIRM')
-        process.exit(1)
-      }
-    }
-
-    expect(() => assertDevSeedAllowed()).toThrow('process.exit called')
-    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('DEV_SEED_CONFIRM'))
-    expect(processExitSpy).toHaveBeenCalledWith(1)
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toMatch(/missing or incorrect DEV_SEED_CONFIRM/)
+    expect(result.stderr).toMatch(/\[seed\] Refusing to run/)
   })
 })


### PR DESCRIPTION
## Summary

- Adds `scripts/seed.ts`, a Drizzle/Neon-native dev seed script (run via `pnpm db:seed`) that bootstraps a minimal, idempotent fixture set — one admin profile, three member profiles, two rooms, and a handful of tables — directly against the Neon-native `profiles`/`rooms`/`tables` schema in `lib/db/schema`.
- This replaces the cancelled KIM-420 data-migration approach. There is no data migration from Supabase involved — this is a fresh dev-only seed intended for manual testing (e.g. admin image upload) once the app targets Neon.
- The script is a standalone module: it opens its own local `pg.Pool` + `drizzle-orm/node-postgres` client and does not touch `lib/db/index.ts` (still Supabase-backed) or `lib/authjs/db.ts`.
- Guard: refuses to run unless `NODE_ENV !== 'production'` **and** the `DEV_SEED_CONFIRM` env var is set to the exact expected value. This guard runs before any DB connection is opened — no bypass path.
- Adds `tsx` as an explicit devDependency (it was already a transitive dependency via vite/vitest, so the lockfile diff is minimal) and the `db:seed` script.
- Documents `DEV_SEED_CONFIRM` (name only, no values) in `.env.example`, and adds a "Dev seed on Neon" usage section to `README.md`, including the seeded dev-only (non-production) credentials.
- Adds `tests/unit/seed-guard.test.ts` covering the guard's refuse/allow paths.

## Important notes for reviewers

- **The seed script has never been run against a real database as part of this change.** It must be run by a human, locally, against their own configured Neon dev database, after setting `DEV_SEED_CONFIRM` themselves.
- Known out-of-scope gap: Auth.js is not yet wired into any page/layout/middleware (see `lib/authjs/config.ts`), so logging in against these seeded credentials through `/api/authjs/*` does not by itself grant access to admin UI pages — that gating still runs through the legacy Supabase-session path. This is expected and tracked separately; it is not a bug in this seed script.
- Security review completed (KIM-432): no CRITICAL/HIGH findings. Confirmed the `NODE_ENV`/`DEV_SEED_CONFIRM` guard has no bypass path, no real/production secrets or `POSTGRES_URL*` values are hardcoded or logged, bcryptjs is used correctly for the seeded `passwordHash`, all Drizzle queries use the query builder (no injection surface), and `lib/db/index.ts`, `lib/authjs/db.ts`, `lib/db/schema/*`, `supabase/migrations/`, `supabase/seed.sql` are untouched.

Refs: Linear KIM-432

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 1151 passed, 21 skipped, 0 failed (includes `tests/unit/seed-guard.test.ts`)
- [x] `pnpm build` — succeeds
- [ ] User manually runs `DEV_SEED_CONFIRM=<value> pnpm db:seed` against their own Neon dev database and verifies seeded admin/member logins and rooms/tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)