### PR TITLE
chore: encode agent working agreements in CLAUDE.md (KIM-437)

### DIFF
--- a/.claude/agent-progress.md
+++ b/.claude/agent-progress.md
@@ -1662,3 +1662,8 @@ No blocking issues. No modifications needed. Code is ready for security-reviewer
 - Validation: pnpm typecheck ✅, pnpm lint ✅ (no warnings), pnpm test — full suite green (see validation summary below), pnpm build ✅.
 - Pushed --force-with-lease to origin/docs/migration-status-update.
 - ✅ Complete — PR #175 rebased cleanly onto origin/develop, all conflicts resolved, 9 additional stale references from newer develop PRs fixed, full validation green.
+
+#### [KIM-437] software-engineer — Add agent working agreements to CLAUDE.md
+- [12:06] Started
+- [12:07] Strengthened test-file-ownership rule; added product-manager single-instance reinforcement; added new "Agent Working Agreements" section (Reporting Standards, Test Integrity, Shared Working Directory, Stopping and Escalating, Tooling)
+- [12:07] ✅ Complete — 34 lines added / 1 removed in CLAUDE.md, all 11 rules covered

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ The user may write prompts in any language; replies to the user are in their lan
 - All privilege checks (ownership + role) must live in the **service layer**, never in route handlers
 - i18n keys must maintain full parity between `en.json` and `es.json`
 - Test files must be excluded from `tsconfig.app.json`
-- Test files are owned exclusively by `qa-engineer` — `software-engineer` must never create or modify test files
+- **Test files are owned exclusively by `qa-engineer` — `software-engineer` must NEVER create, edit, or delete test files, under any framing (e.g. "fixing" a failure). Doing so and reporting completion anyway is a false completion.**
 - Every read of `reservations` / `saved_games` for a `member` session MUST filter `WHERE user_id = session.id`; member-scoped reads must also pass through `assertMemberRowsScoped()` (from `lib/server/data-scoping.ts`) as defense-in-depth after the DB fetch and before mapping rows to the public shape (admins exempt).
 
 ---
@@ -124,6 +124,8 @@ For **every issue** — regardless of size or scope:
 
 This is the standard workflow — no exceptions.
 
+Only one product-manager may run per session — never spawn a second one to "help" or parallelize; the existing one already owns Linear/branch/task coordination for the whole session.
+
 **CRITICAL RULE:** Product-manager NEVER spawns software-engineer, qa-engineer, or security-reviewer directly. Product-manager ALWAYS spawns team-lead to orchestrate the pipeline. Team-lead then manages: impl → qa → security → PR. This preserves agent isolation: product-manager = coordinator, team-lead = orchestrator, impl agents = workers.
 
 ---
@@ -143,3 +145,33 @@ This is the standard workflow — no exceptions.
 4. User verifies in Supabase dashboard
 
 Agent prepares + validates. User applies.
+
+---
+
+## Agent Working Agreements
+
+### Reporting Standards
+
+- A failing test may be called "pre-existing" only after being run on `develop` and confirmed failing there; otherwise report it as "failing on this branch, cause not established."
+- Never report validation (typecheck/lint/build/tests) as passing without actually running it — no "assumed to pass," no fabricated timestamps, no silently-skipped steps presented as done.
+- Reports state the command run and its literal output, not a conclusion — e.g. "`Tests 1166 passed (1166)`," not "suite green."
+- "Done" is a number matched against a defined bar, not an adjective — "infrastructure ready," "pattern established," "84% passing," "non-blocking edge cases" are not completion.
+
+### Test Integrity
+
+- Test count per file must never decrease vs `develop` — compare with `grep -cE "^\s*(it|test)\("` against develop and report both numbers; any drop requires each removed test justified by name. Exception: removing a tautological test (e.g. `expect(true).toBe(true)`) removes zero coverage by definition — still name it and say why.
+- Tests never make real database calls — no live connection, no test DB, no containerized/embedded Postgres. Mocks only; improve the mock rather than making the dependency real.
+
+### Shared Working Directory
+
+- The shared checkout is read-only to every agent, with exactly one exception: appending to `.claude/agent-progress.md` via `>>` or equivalent that cannot replace the file — never read-modify-write it. To run code from another branch, create a throwaway worktree and install dependencies there, never in the shared checkout.
+
+### Stopping and Escalating
+
+- Reporting a blocker costs nothing; a false completion costs hours. A correctly-reported blocker must not be disbelieved or punished because a different agent fabricated something similar earlier.
+- Not acceptable as "completion": silently handing remaining work to another agent, describing a stopping point as a result (e.g. "reverted to baseline"), self-approving with a red suite under any framing, or citing a repo rule that doesn't exist to justify stopping.
+
+### Tooling
+
+- When an agent regresses repeatedly on a large file, the tool it needs likely doesn't exist yet — build that tool as its own bounded task, separately from applying it.
+- One shared helper/mock, extended when it falls short — never re-derived per file (copying a pattern from the most broken file inherits its defect).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,8 @@ Agent prepares + validates. User applies.
 ### Shared Working Directory
 
 - The shared checkout is read-only to every agent, with exactly one exception: appending to `.claude/agent-progress.md` via `>>` or equivalent that cannot replace the file — never read-modify-write it. To run code from another branch, create a throwaway worktree and install dependencies there, never in the shared checkout.
+- Worktree cleanup removes only the agent's own worktree, by absolute path: `git worktree remove /absolute/path/to/own-worktree` then `git worktree prune`. Never `rm -rf` the parent worktrees directory — in a multi-pipeline session that destroys other agents' active work.
+- Commit early and often on the worktree's branch. Uncommitted work exists in exactly one place and survives nothing — committing after each meaningful step is cheap insurance against losing hours of work.
 
 ### Stopping and Escalating
 


### PR DESCRIPTION
## Summary

Adds a new "Agent Working Agreements" section to `CLAUDE.md` plus two strengthened existing rules, encoding standards that were previously only enforced ad hoc:

- **Reporting Standards** — failing tests may only be called "pre-existing" after confirming on `develop`; validation results must reflect actual command output, not assumptions; "done" is a measured bar, not an adjective.
- **Test Integrity** — test count per file must never silently decrease vs `develop`; tests must never make real database calls (mocks only).
- **Shared Working Directory** — the shared checkout is read-only to every agent except for append-only writes to `.claude/agent-progress.md`; running code from another branch requires a throwaway worktree.
- **Stopping and Escalating** — reporting a blocker is always acceptable; silently handing off work, self-approving a red suite, or citing a nonexistent rule to justify stopping is not.
- **Tooling** — repeated regressions on a large file signal a missing tool, not a workflow problem; shared mocks/helpers should be extended, not re-derived per file.

Also strengthens two existing rules for clarity:
- Test-file-ownership rule (`software-engineer` must never create/edit/delete test files, under any framing).
- Reinforces the single-product-manager-per-session constraint already implied by the existing workflow.

Docs-only change — no code or test files touched.

Refs KIM-437.

## Test plan
- [x] Confirmed diff touches only `CLAUDE.md` (plus the standard append-only agent-progress log entry)
- [x] No secrets/credentials in diff
- [x] Content is terse, imperative, English-only, ~34 lines (well under budget)
- [x] No contradictions with existing rules in the file