### PR TITLE
test(mocks): make drizzle-mock.ts state-driven (single owner, unblocks 4 migration lanes) [KIM-443]

### DIFF
--- a/tests/unit/mocks/drizzle-mock.test.ts
+++ b/tests/unit/mocks/drizzle-mock.test.ts
@@ -1,0 +1,856 @@
+// @vitest-environment node
+/**
+ * Spec for the shared Drizzle mock infrastructure (KIM-443).
+ *
+ * `tests/unit/mocks/drizzle-mock.ts` is test infrastructure that four migration
+ * lanes (KIM-438/439/440/441) build on, so its own behaviour needs to be pinned
+ * down here rather than discovered lane by lane.
+ *
+ * The scenarios below are organised around the acceptance criteria of KIM-443:
+ *
+ *   AC1  state-driven      — results follow the store, never the call order
+ *   AC2  stateful writes   — create-then-read / update-then-read in one test
+ *   AC3  insert vs update  — distinguished at execution time, concurrently
+ *   AC4  concurrency       — correct under interleaved flows (the KIM-440 case)
+ *   AC5  chained joins     — innerJoin/leftJoin + offset + execute
+ *   AC6  guardrails        — unsupported constructs throw instead of lying
+ *
+ * There is no database here: no pglite, no embedded or containerised Postgres,
+ * no SQL engine and no connection. Conditions are evaluated against plain JS
+ * objects held in a `Map`.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { and, asc, count, desc, eq, gte, ilike, inArray, isNull, lte, ne, or, sql } from 'drizzle-orm'
+
+import { profiles } from '@/lib/db/schema/profiles'
+import { reservations } from '@/lib/db/schema/reservations'
+import { rooms } from '@/lib/db/schema/rooms'
+import { savedGames } from '@/lib/db/schema/saved-games'
+import { tables } from '@/lib/db/schema/tables'
+import {
+  createStatefulDrizzleDb,
+  executeMock,
+  failNextQuery,
+  getQueryLog,
+  getRows,
+  resetDb,
+  seed,
+  seedTable,
+} from '@/tests/unit/mocks/drizzle-mock'
+
+/**
+ * A fresh handle each time, deliberately. Every handle shares the same store,
+ * which is what makes `getDrizzleDb()` and `getDrizzleAdminDb()` agree inside a
+ * single test — and it means no test may rely on handle identity.
+ */
+const db = () => createStatefulDrizzleDb()
+
+beforeEach(() => {
+  resetDb()
+  executeMock.mockReset()
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC1 — state-driven: the store answers, not the call sequence
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AC1 state-driven resolution', () => {
+  it('answers each query from its own table regardless of the order queries are issued', async () => {
+    seed({
+      profiles: [
+        { id: 'p1', memberNumber: 'M1', fullName: 'Ann', role: 'member', isActive: true },
+        { id: 'p2', memberNumber: 'M2', fullName: 'Bob', role: 'admin', isActive: false },
+      ],
+      rooms: [{ id: 'r1', name: 'Main' }],
+      tables: [{ id: 't1', roomId: 'r1', name: 'Table 1' }],
+    })
+
+    // Issue the three queries in one order...
+    const forward = [
+      await db().select().from(profiles).where(eq(profiles.id, 'p2')),
+      await db().select().from(rooms),
+      await db().select().from(tables),
+    ]
+
+    // ...and again in the exact opposite order. A sequence-driven mock would
+    // hand back the wrong table's rows here; a state-driven one cannot.
+    const reversed = [
+      await db().select().from(tables),
+      await db().select().from(rooms),
+      await db().select().from(profiles).where(eq(profiles.id, 'p2')),
+    ]
+
+    expect(forward[0]).toHaveLength(1)
+    expect(forward[0][0].fullName).toBe('Bob')
+    expect(forward[1][0].name).toBe('Main')
+    expect(forward[2][0].name).toBe('Table 1')
+
+    expect(reversed[0]).toEqual(forward[2])
+    expect(reversed[1]).toEqual(forward[1])
+    expect(reversed[2]).toEqual(forward[0])
+  })
+
+  it('resolves builders at await time, so awaiting them out of construction order is still correct', async () => {
+    seed({
+      profiles: [{ id: 'p1', memberNumber: 'M1', fullName: 'Ann' }],
+      rooms: [{ id: 'r1', name: 'Main' }],
+      tables: [{ id: 't1', roomId: 'r1', name: 'Table 1' }],
+    })
+
+    // Build three queries up front without awaiting any of them.
+    const profileQuery = db().select({ name: profiles.fullName }).from(profiles)
+    const roomQuery = db().select({ name: rooms.name }).from(rooms)
+    const tableQuery = db().select({ name: tables.name }).from(tables)
+
+    // Await them in reverse construction order.
+    const tableRows = await tableQuery
+    const roomRows = await roomQuery
+    const profileRows = await profileQuery
+
+    expect(tableRows).toEqual([{ name: 'Table 1' }])
+    expect(roomRows).toEqual([{ name: 'Main' }])
+    expect(profileRows).toEqual([{ name: 'Ann' }])
+  })
+
+  it('evaluates and/or/not, comparison, inArray, isNull and ilike against the seeded rows', async () => {
+    seed({
+      profiles: [
+        { id: 'p1', memberNumber: 'M1', fullName: 'Ann', role: 'member', noShowCount: 3, blockedUntil: null },
+        { id: 'p2', memberNumber: 'M2', fullName: 'Bob', role: 'member', noShowCount: 0, blockedUntil: '2026-09-01' },
+        { id: 'p3', memberNumber: 'M3', fullName: 'annabel', role: 'admin', noShowCount: 7, blockedUntil: null },
+      ],
+    })
+
+    const where = (condition: unknown) => db().select().from(profiles).where(condition)
+
+    expect(await where(inArray(profiles.id, ['p1', 'p3']))).toHaveLength(2)
+    expect(await where(gte(profiles.noShowCount, 3))).toHaveLength(2)
+    expect(await where(lte(profiles.noShowCount, 0))).toHaveLength(1)
+    expect(await where(ne(profiles.id, 'p1'))).toHaveLength(2)
+    expect(await where(isNull(profiles.blockedUntil))).toHaveLength(2)
+    expect(await where(ilike(profiles.fullName, '%ANN%'))).toHaveLength(2)
+    expect(await where(and(gte(profiles.noShowCount, 3), isNull(profiles.blockedUntil)))).toHaveLength(2)
+    expect(await where(or(eq(profiles.id, 'p1'), eq(profiles.id, 'p2')))).toHaveLength(2)
+    expect(await where(sql`not ${eq(profiles.role, 'admin')}`)).toHaveLength(2)
+    expect(await where(sql`${profiles.noShowCount} between ${2} and ${9}`)).toHaveLength(2)
+
+    // A column-to-column comparison reads both sides from the same row.
+    expect(await where(eq(profiles.id, profiles.memberNumber))).toHaveLength(0)
+  })
+
+  it('treats an absent condition as no filter and an empty inArray as no match', async () => {
+    seed({
+      profiles: [
+        { id: 'p1', memberNumber: 'M1' },
+        { id: 'p2', memberNumber: 'M2' },
+        { id: 'p3', memberNumber: 'M3' },
+      ],
+    })
+
+    // `and()` over an empty condition list collapses to `undefined` in Drizzle —
+    // services rely on that to build optional filters, so it must not filter.
+    expect(await db().select().from(profiles).where(and())).toHaveLength(3)
+    expect(await db().select().from(profiles).where(undefined)).toHaveLength(3)
+    expect(await db().select().from(profiles)).toHaveLength(3)
+
+    // An empty IN list matches nothing, rather than everything.
+    expect(await db().select().from(profiles).where(inArray(profiles.id, []))).toHaveLength(0)
+  })
+
+  it('applies projection, ordering, limit/offset and aggregates', async () => {
+    seed({
+      profiles: [
+        { id: 'p1', memberNumber: 'M3', fullName: 'C', role: 'member', createdAt: '2026-03-01T00:00:00Z' },
+        { id: 'p2', memberNumber: 'M1', fullName: 'A', role: 'member', createdAt: '2026-01-01T00:00:00Z' },
+        { id: 'p3', memberNumber: 'M2', fullName: 'B', role: 'admin', createdAt: '2026-02-01T00:00:00Z' },
+      ],
+    })
+
+    const page = await db()
+      .select({ id: profiles.id, name: profiles.fullName })
+      .from(profiles)
+      .orderBy(asc(profiles.createdAt))
+      .limit(2)
+      .offset(1)
+    expect(page).toEqual([
+      { id: 'p3', name: 'B' },
+      { id: 'p1', name: 'C' },
+    ])
+
+    const descending = await db().select({ id: profiles.id }).from(profiles).orderBy(desc(profiles.fullName))
+    expect(descending.map((row) => row.id)).toEqual(['p1', 'p3', 'p2'])
+
+    const [total] = await db().select({ value: count() }).from(profiles)
+    expect(total).toEqual({ value: 3 })
+
+    const grouped = await db().select({ role: profiles.role, total: count() }).from(profiles).groupBy(profiles.role)
+    expect(grouped).toEqual([
+      { role: 'member', total: 2 },
+      { role: 'admin', total: 1 },
+    ])
+
+    const [empty] = await db().select({ value: count() }).from(profiles).where(eq(profiles.id, 'missing'))
+    expect(empty).toEqual({ value: 0 })
+  })
+
+  it('addresses a table by snake_case name, camelCase name or table object, and reads either row key', async () => {
+    // Seeded under a camelCase key with snake_case row keys...
+    seed({ savedGames: [{ id: 's1', table_id: 't1', user_id: 'u1' }] })
+
+    // ...queried through the Drizzle table object, whose name is `saved_games`.
+    const [row] = await db().select().from(savedGames).where(eq(savedGames.userId, 'u1'))
+    expect(row.tableId).toBe('t1')
+
+    // All three spellings address the same store entry.
+    expect(getRows('saved_games')).toHaveLength(1)
+    expect(getRows('savedGames')).toHaveLength(1)
+    expect(getRows(savedGames)).toHaveLength(1)
+
+    seedTable(savedGames, [])
+    expect(getRows('saved_games')).toHaveLength(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC2 — stateful writes: a write is visible to a later read in the same test
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AC2 stateful writes', () => {
+  it('makes an inserted row readable by a subsequent select (create-then-read)', async () => {
+    seed({ profiles: [] })
+
+    const [created] = await db()
+      .insert(profiles)
+      .values({ id: 'p9', memberNumber: 'M9', fullName: 'New', authEmail: 'new@example.com', role: 'member' })
+      .returning({ id: profiles.id, fullName: profiles.fullName })
+
+    expect(created).toEqual({ id: 'p9', fullName: 'New' })
+
+    const read = await db().select().from(profiles).where(eq(profiles.id, 'p9'))
+    expect(read).toHaveLength(1)
+    expect(read[0].memberNumber).toBe('M9')
+    expect(getRows('profiles')).toHaveLength(1)
+  })
+
+  it('makes an updated value readable by a subsequent select (update-then-read)', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1', fullName: 'Old', noShowCount: 4 }] })
+
+    const updated = await db()
+      .update(profiles)
+      .set({ fullName: 'Renamed', noShowCount: 0 })
+      .where(eq(profiles.id, 'p1'))
+      .returning({ id: profiles.id })
+    expect(updated).toEqual([{ id: 'p1' }])
+
+    const [row] = await db().select().from(profiles).where(eq(profiles.id, 'p1'))
+    expect(row.fullName).toBe('Renamed')
+    expect(row.noShowCount).toBe(0)
+  })
+
+  it('persists an update that is awaited without .returning()', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1', fullName: 'Old' }] })
+
+    // The "update existing member" import path awaits `.where(...)` directly.
+    await db().update(profiles).set({ fullName: 'Fire and forget' }).where(eq(profiles.id, 'p1'))
+
+    expect(getRows('profiles')[0].fullName).toBe('Fire and forget')
+  })
+
+  it('removes deleted rows from subsequent reads (delete-then-read)', async () => {
+    seed({
+      profiles: [
+        { id: 'p1', memberNumber: 'M1' },
+        { id: 'p2', memberNumber: 'M2' },
+      ],
+    })
+
+    const deleted = await db().delete(profiles).where(eq(profiles.id, 'p1')).returning({ id: profiles.id })
+    expect(deleted).toEqual([{ id: 'p1' }])
+
+    const remaining = await db().select({ id: profiles.id }).from(profiles)
+    expect(remaining).toEqual([{ id: 'p2' }])
+  })
+
+  it('inserts multiple rows in one statement and fills schema defaults', async () => {
+    seed({ saved_games: [] })
+
+    const created = await db()
+      .insert(savedGames)
+      .values([
+        { tableId: 't1', userId: 'u1', startDate: '2026-08-01', endDate: '2026-08-02' },
+        { tableId: 't2', userId: 'u2', startDate: '2026-08-03', endDate: '2026-08-04' },
+      ])
+      .returning()
+
+    expect(created).toHaveLength(2)
+    expect(getRows(savedGames)).toHaveLength(2)
+
+    // `.defaultRandom()`, `.default('active')` and `.default(0)` are honoured, so
+    // services that rely on DB-side defaults do not read `undefined`.
+    for (const row of created) {
+      expect(typeof row.id).toBe('string')
+      expect(row.status).toBe('active')
+      expect(row.attendanceCount).toBe(0)
+    }
+  })
+
+  it('returns an empty array from a write that does not ask for .returning()', async () => {
+    seed({ profiles: [] })
+
+    const result = await db().insert(profiles).values({ id: 'p1', memberNumber: 'M1', authEmail: 'a@example.com' })
+
+    expect(result).toEqual([])
+    // The write still happened — only the RETURNING projection was skipped.
+    expect(getRows('profiles')).toHaveLength(1)
+  })
+
+  it('rolls the store back when a transaction callback throws', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1', fullName: 'Keep' }] })
+
+    await expect(
+      db().transaction(async (tx) => {
+        await tx.update(profiles).set({ fullName: 'Dirty' }).where(eq(profiles.id, 'p1'))
+        await tx.insert(profiles).values({ id: 'p2', memberNumber: 'M2', authEmail: 'b@example.com' })
+        throw new Error('boom')
+      }),
+    ).rejects.toThrow('boom')
+
+    expect(getRows('profiles')).toHaveLength(1)
+    expect(getRows('profiles')[0].fullName).toBe('Keep')
+  })
+
+  it('keeps writes made by a transaction that completes successfully', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1', fullName: 'Keep' }] })
+
+    const result = await db().transaction(async (tx) => {
+      await tx.update(profiles).set({ fullName: 'Committed' }).where(eq(profiles.id, 'p1'))
+      return 'ok'
+    })
+
+    expect(result).toBe('ok')
+    expect(getRows('profiles')[0].fullName).toBe('Committed')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC3 — INSERT of a new row vs UPDATE of an existing one
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AC3 insert vs update distinction', () => {
+  it('distinguishes insert from update when both hit the same builder concurrently', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1', fullName: 'Existing' }] })
+
+    // Two upserts issued together against the same table: one collides with a
+    // stored row (=> UPDATE), one does not (=> INSERT). The decision is made
+    // against the store at execution time, not from the call order.
+    const [collided, fresh] = await Promise.all([
+      db()
+        .insert(profiles)
+        .values({ id: 'ignored', memberNumber: 'M1', fullName: 'Updated by upsert' })
+        .onConflictDoUpdate({ target: profiles.memberNumber, set: { fullName: 'Updated by upsert' } })
+        .returning({ id: profiles.id, fullName: profiles.fullName }),
+      db()
+        .insert(profiles)
+        .values({ id: 'p2', memberNumber: 'M2', fullName: 'Brand new' })
+        .onConflictDoUpdate({ target: profiles.memberNumber, set: { fullName: 'must not apply' } })
+        .returning({ id: profiles.id, fullName: profiles.fullName }),
+    ])
+
+    // The colliding upsert mutated the stored row — it kept `p1`, not `ignored`.
+    expect(collided).toEqual([{ id: 'p1', fullName: 'Updated by upsert' }])
+    // The non-colliding upsert created a genuinely new row.
+    expect(fresh).toEqual([{ id: 'p2', fullName: 'Brand new' }])
+
+    expect(getRows('profiles')).toHaveLength(2)
+    expect(getRows('profiles').map((row) => row.id).sort()).toEqual(['p1', 'p2'])
+  })
+
+  it('leaves the existing row untouched for onConflictDoNothing and inserts when there is no conflict', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1', fullName: 'Existing' }] })
+
+    await db()
+      .insert(profiles)
+      .values({ id: 'p1-dup', memberNumber: 'M1', fullName: 'Should be dropped' })
+      .onConflictDoNothing({ target: profiles.memberNumber })
+
+    expect(getRows('profiles')).toHaveLength(1)
+    expect(getRows('profiles')[0].fullName).toBe('Existing')
+
+    await db()
+      .insert(profiles)
+      .values({ id: 'p2', memberNumber: 'M2', fullName: 'Brand new' })
+      .onConflictDoNothing({ target: profiles.memberNumber })
+
+    expect(getRows('profiles')).toHaveLength(2)
+  })
+
+  it('never creates a row from an UPDATE whose where-clause matches nothing', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1' }] })
+
+    const result = await db()
+      .update(profiles)
+      .set({ fullName: 'X' })
+      .where(eq(profiles.id, 'does-not-exist'))
+      .returning()
+
+    expect(result).toEqual([])
+    expect(getRows('profiles')).toHaveLength(1)
+    expect(getRows('profiles')[0].fullName).toBeUndefined()
+  })
+
+  it('records inserts and updates as distinct operations in the query log', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1' }] })
+
+    await db().insert(profiles).values({ id: 'p2', memberNumber: 'M2', authEmail: 'b@example.com' })
+    await db().update(profiles).set({ fullName: 'Renamed' }).where(eq(profiles.id, 'p1'))
+    await db().select().from(profiles)
+    await db().delete(profiles).where(eq(profiles.id, 'p2'))
+
+    expect(getQueryLog()).toEqual([
+      { op: 'insert', table: 'profiles', rowCount: 1 },
+      { op: 'update', table: 'profiles', rowCount: 1 },
+      { op: 'select', table: 'profiles', rowCount: 2 },
+      { op: 'delete', table: 'profiles', rowCount: 1 },
+    ])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC4 — concurrency: the criterion that broke KIM-440 (importMembersFromCsv)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AC4 concurrent and interleaved calls', () => {
+  it('keeps 10 concurrent read-then-write flows from stealing each other results', async () => {
+    // Mirrors `importMembersFromCsv` with `concurrencyLimit = 10`: every flow
+    // looks its member up, then either updates or inserts. Under a
+    // sequence-driven mock the Nth read gets the Nth queued response and the
+    // whole batch is wrong; here each read is answered from the store.
+    seed({
+      profiles: Array.from({ length: 5 }, (_, index) => ({
+        id: `p${index}`,
+        memberNumber: `M${index}`,
+        fullName: `Existing ${index}`,
+      })),
+    })
+
+    const inputs = Array.from({ length: 10 }, (_, index) => ({
+      memberNumber: `M${index}`,
+      fullName: `Imported ${index}`,
+    }))
+
+    const results = await Promise.all(
+      inputs.map(async (input) => {
+        const handle = db()
+        const [existing] = await handle
+          .select({ id: profiles.id, memberNumber: profiles.memberNumber })
+          .from(profiles)
+          .where(eq(profiles.memberNumber, input.memberNumber))
+          .limit(1)
+
+        if (existing) {
+          await handle.update(profiles).set({ fullName: input.fullName }).where(eq(profiles.id, existing.id))
+          return { memberNumber: input.memberNumber, outcome: 'updated' as const }
+        }
+
+        await handle.insert(profiles).values({
+          id: `new-${input.memberNumber}`,
+          memberNumber: input.memberNumber,
+          fullName: input.fullName,
+          authEmail: `${input.memberNumber}@example.com`,
+        })
+        return { memberNumber: input.memberNumber, outcome: 'created' as const }
+      }),
+    )
+
+    // The five seeded members were updated; the five unknown ones were created.
+    expect(results.filter((result) => result.outcome === 'updated').map((r) => r.memberNumber)).toEqual([
+      'M0',
+      'M1',
+      'M2',
+      'M3',
+      'M4',
+    ])
+    expect(results.filter((result) => result.outcome === 'created').map((r) => r.memberNumber)).toEqual([
+      'M5',
+      'M6',
+      'M7',
+      'M8',
+      'M9',
+    ])
+
+    // Every flow wrote its own row and only its own row.
+    const stored = getRows('profiles')
+    expect(stored).toHaveLength(10)
+    for (let index = 0; index < 10; index += 1) {
+      const row = stored.find((candidate) => candidate.memberNumber === `M${index}`)
+      expect(row?.fullName).toBe(`Imported ${index}`)
+    }
+  })
+
+  it('answers interleaved queries against three tables without cross-contamination', async () => {
+    seed({
+      profiles: [
+        { id: 'p1', memberNumber: 'M1', fullName: 'Ann' },
+        { id: 'p2', memberNumber: 'M2', fullName: 'Bob' },
+      ],
+      rooms: [{ id: 'r1', name: 'Main' }],
+      tables: [
+        { id: 't1', roomId: 'r1', name: 'Table 1' },
+        { id: 't2', roomId: 'r1', name: 'Table 2' },
+        { id: 't3', roomId: 'r1', name: 'Table 3' },
+      ],
+    })
+
+    const [profileRows, roomRows, tableRows, singleProfile] = await Promise.all([
+      db().select({ name: profiles.fullName }).from(profiles).orderBy(asc(profiles.memberNumber)),
+      db().select({ name: rooms.name }).from(rooms),
+      db().select({ name: tables.name }).from(tables).orderBy(asc(tables.name)),
+      db().select({ name: profiles.fullName }).from(profiles).where(eq(profiles.id, 'p2')),
+    ])
+
+    expect(profileRows).toEqual([{ name: 'Ann' }, { name: 'Bob' }])
+    expect(roomRows).toEqual([{ name: 'Main' }])
+    expect(tableRows).toEqual([{ name: 'Table 1' }, { name: 'Table 2' }, { name: 'Table 3' }])
+    expect(singleProfile).toEqual([{ name: 'Bob' }])
+  })
+
+  it('lets concurrent writes on different tables both land', async () => {
+    seed({ profiles: [], rooms: [] })
+
+    await Promise.all([
+      db().insert(profiles).values({ id: 'p1', memberNumber: 'M1', authEmail: 'a@example.com' }),
+      db().insert(rooms).values({ id: 'r1', name: 'Main' }),
+      db().insert(profiles).values({ id: 'p2', memberNumber: 'M2', authEmail: 'b@example.com' }),
+    ])
+
+    expect(getRows('profiles')).toHaveLength(2)
+    expect(getRows('rooms')).toHaveLength(1)
+  })
+
+  it('serialises concurrent updates to the same row so the last write wins', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1', fullName: 'Original', noShowCount: 0 }] })
+
+    await Promise.all([
+      db().update(profiles).set({ fullName: 'First' }).where(eq(profiles.id, 'p1')),
+      db().update(profiles).set({ noShowCount: 5 }).where(eq(profiles.id, 'p1')),
+      db().update(profiles).set({ fullName: 'Last' }).where(eq(profiles.id, 'p1')),
+    ])
+
+    const [row] = await db().select().from(profiles).where(eq(profiles.id, 'p1'))
+    // Each update touched only the columns it set — they do not clobber each other.
+    expect(row.fullName).toBe('Last')
+    expect(row.noShowCount).toBe(5)
+  })
+
+  it('makes a write visible to a read issued after it, even with other queries interleaved', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1', fullName: 'Before' }], rooms: [{ id: 'r1', name: 'Main' }] })
+
+    await db().select().from(rooms)
+    await db().update(profiles).set({ fullName: 'After' }).where(eq(profiles.id, 'p1'))
+    await db().select().from(rooms)
+
+    const [row] = await db().select().from(profiles).where(eq(profiles.id, 'p1'))
+    expect(row.fullName).toBe('After')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC5 — chained joins
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AC5 chained joins', () => {
+  it('resolves innerJoin().innerJoin() with a projected selection', async () => {
+    seed({
+      saved_games: [
+        { id: 's1', tableId: 't1', userId: 'u1', startDate: '2026-08-01', endDate: '2026-08-10', status: 'active' },
+        { id: 's2', tableId: 't2', userId: 'u2', startDate: '2026-08-02', endDate: '2026-08-11', status: 'active' },
+        { id: 's3', tableId: 'missing', userId: 'u3', startDate: '2026-08-03', endDate: '2026-08-12', status: 'active' },
+      ],
+      tables: [
+        { id: 't1', roomId: 'room1', name: 'Table 1' },
+        { id: 't2', roomId: 'room2', name: 'Table 2' },
+      ],
+      rooms: [
+        { id: 'room1', name: 'Main' },
+        { id: 'room2', name: 'Side' },
+      ],
+    })
+
+    const joined = await db()
+      .select({
+        id: savedGames.id,
+        userId: savedGames.userId,
+        tableName: tables.name,
+        roomName: rooms.name,
+      })
+      .from(savedGames)
+      .innerJoin(tables, eq(savedGames.tableId, tables.id))
+      .innerJoin(rooms, eq(tables.roomId, rooms.id))
+      .where(eq(savedGames.userId, 'u1'))
+      .orderBy(asc(savedGames.startDate))
+
+    expect(joined).toEqual([{ id: 's1', userId: 'u1', tableName: 'Table 1', roomName: 'Main' }])
+
+    // The row whose tableId matches nothing is dropped by the inner join.
+    const all = await db()
+      .select({ id: savedGames.id })
+      .from(savedGames)
+      .innerJoin(tables, eq(savedGames.tableId, tables.id))
+      .innerJoin(rooms, eq(tables.roomId, rooms.id))
+      .orderBy(asc(savedGames.startDate))
+    expect(all.map((row) => row.id)).toEqual(['s1', 's2'])
+  })
+
+  it('keeps unmatched rows with null columns across chained leftJoins', async () => {
+    seed({
+      reservations: [
+        { id: 'res1', userId: 'u1', tableId: 't1', date: '2026-08-01', startTime: '10:00', status: 'confirmed' },
+        { id: 'res2', userId: 'ghost', tableId: 'none', date: '2026-08-01', startTime: '09:00', status: 'confirmed' },
+      ],
+      profiles: [{ id: 'u1', memberNumber: 'M1', fullName: 'Ann' }],
+      tables: [{ id: 't1', roomId: 'room1', name: 'Table 1' }],
+      rooms: [{ id: 'room1', name: 'Main' }],
+    })
+
+    const rows = await db()
+      .select({
+        id: reservations.id,
+        memberName: profiles.fullName,
+        tableName: tables.name,
+        roomName: rooms.name,
+      })
+      .from(reservations)
+      .leftJoin(profiles, eq(reservations.userId, profiles.id))
+      .leftJoin(tables, eq(reservations.tableId, tables.id))
+      .leftJoin(rooms, eq(tables.roomId, rooms.id))
+      .orderBy(asc(reservations.date), asc(reservations.startTime))
+
+    expect(rows).toEqual([
+      { id: 'res2', memberName: null, tableName: null, roomName: null },
+      { id: 'res1', memberName: 'Ann', tableName: 'Table 1', roomName: 'Main' },
+    ])
+  })
+
+  it('combines innerJoin, leftJoin, where, orderBy, limit, offset and execute() in one chain', async () => {
+    seed({
+      saved_games: [
+        { id: 's1', tableId: 't1', userId: 'u1', startDate: '2026-08-01', endDate: '2026-08-10', status: 'active' },
+        { id: 's2', tableId: 't2', userId: 'u2', startDate: '2026-08-02', endDate: '2026-08-11', status: 'active' },
+        { id: 's3', tableId: 't3', userId: 'u3', startDate: '2026-08-03', endDate: '2026-08-12', status: 'active' },
+        { id: 's4', tableId: 't4', userId: 'u4', startDate: '2026-08-04', endDate: '2026-08-13', status: 'cancelled' },
+      ],
+      tables: [
+        { id: 't1', roomId: 'room1', name: 'Table 1' },
+        { id: 't2', roomId: 'room1', name: 'Table 2' },
+        // t3 points at a room that does not exist — the leftJoin must keep it.
+        { id: 't3', roomId: 'orphan', name: 'Table 3' },
+        { id: 't4', roomId: 'room1', name: 'Table 4' },
+      ],
+      rooms: [{ id: 'room1', name: 'Main' }],
+    })
+
+    const rows = await db()
+      .select({ id: savedGames.id, tableName: tables.name, roomName: rooms.name })
+      .from(savedGames)
+      .innerJoin(tables, eq(savedGames.tableId, tables.id))
+      .leftJoin(rooms, eq(tables.roomId, rooms.id))
+      .where(eq(savedGames.status, 'active'))
+      .orderBy(asc(savedGames.startDate))
+      .limit(2)
+      .offset(1)
+      .execute()
+
+    // status filter drops s4; offset 1 drops s1; limit 2 keeps s2 and s3.
+    expect(rows).toEqual([
+      { id: 's2', tableName: 'Table 2', roomName: 'Main' },
+      { id: 's3', tableName: 'Table 3', roomName: null },
+    ])
+  })
+
+  it('returns table-keyed rows when a join is used without an explicit selection', async () => {
+    seed({
+      saved_games: [{ id: 's1', tableId: 't1', userId: 'u1', startDate: '2026-08-01', endDate: '2026-08-02' }],
+      tables: [{ id: 't1', roomId: 'room1', name: 'Table 1' }],
+    })
+
+    const [row] = await db().select().from(savedGames).innerJoin(tables, eq(savedGames.tableId, tables.id))
+
+    expect((row.saved_games as Record<string, unknown>).id).toBe('s1')
+    expect((row.tables as Record<string, unknown>).name).toBe('Table 1')
+  })
+
+  it('deduplicates rows for selectDistinct over a join', async () => {
+    seed({
+      saved_games: [
+        { id: 's1', tableId: 't1', userId: 'u1', startDate: '2026-08-01', endDate: '2026-08-02' },
+        { id: 's2', tableId: 't1', userId: 'u2', startDate: '2026-08-03', endDate: '2026-08-04' },
+      ],
+      tables: [{ id: 't1', roomId: 'room1', name: 'Table 1' }],
+    })
+
+    const distinct = await db()
+      .selectDistinct({ tableName: tables.name })
+      .from(savedGames)
+      .innerJoin(tables, eq(savedGames.tableId, tables.id))
+
+    expect(distinct).toEqual([{ tableName: 'Table 1' }])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC6 — guardrails: unsupported constructs throw instead of returning wrong rows
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AC6 unsupported constructs throw', () => {
+  beforeEach(() => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1' }], rooms: [{ id: 'r1', name: 'Main' }] })
+  })
+
+  it('rejects rightJoin and fullJoin instead of approximating them', () => {
+    expect(() => db().select().from(profiles).rightJoin(rooms, eq(profiles.id, rooms.id))).toThrow(
+      /\[drizzle-mock\] rightJoin\(\) is not supported/,
+    )
+    expect(() => db().select().from(profiles).fullJoin(rooms, eq(profiles.id, rooms.id))).toThrow(
+      /\[drizzle-mock\] fullJoin\(\) is not supported/,
+    )
+  })
+
+  it('rejects having()', () => {
+    expect(() => db().select({ total: count() }).from(profiles).groupBy(profiles.role).having()).toThrow(
+      /\[drizzle-mock\] having\(\) is not supported/,
+    )
+  })
+
+  it('rejects groupBy over a non-column expression', () => {
+    expect(() => db().select({ total: count() }).from(profiles).groupBy(sql`lower(${profiles.role})`)).toThrow(
+      /\[drizzle-mock\] groupBy\(\) only supports plain columns/,
+    )
+  })
+
+  it('rejects an EXISTS / subquery style condition rather than guessing at it', async () => {
+    await expect(
+      db()
+        .select()
+        .from(profiles)
+        .where(sql`exists (select 1 from rooms where ${rooms.id} = ${profiles.id})`),
+    ).rejects.toThrow(/\[drizzle-mock\]/)
+  })
+
+  it('rejects an unsupported SQL operator', async () => {
+    await expect(
+      db()
+        .select()
+        .from(profiles)
+        .where(sql`${profiles.memberNumber} ~~ ${'M%'}`),
+    ).rejects.toThrow(/\[drizzle-mock\] unsupported SQL operator/)
+  })
+
+  it('rejects an unsupported scalar expression in a projection', async () => {
+    await expect(
+      db()
+        .select({ weird: sql<string>`jsonb_path_query(${profiles.id}, '$.a')` })
+        .from(profiles),
+    ).rejects.toThrow(/\[drizzle-mock\] unsupported SQL expression/)
+  })
+
+  it('rejects a condition referencing a table that is not part of the query', async () => {
+    await expect(db().select().from(profiles).where(eq(rooms.id, 'r1'))).rejects.toThrow(
+      /\[drizzle-mock\] condition references table "rooms"/,
+    )
+  })
+
+  it('rejects a select that was awaited without .from()', async () => {
+    await expect(db().select()).rejects.toThrow(/\[drizzle-mock\] select\(\) was awaited without \.from\(table\)/)
+  })
+
+  it('does not consult the store for raw db.execute() — it returns the configured executeMock value', async () => {
+    // Arbitrary SQL cannot be evaluated without a SQL engine, so `execute()` is
+    // explicitly a pass-through to `executeMock` rather than a store query. It
+    // is recorded in the log so tests can still assert the call happened.
+    executeMock.mockReturnValue({ rows: [{ total: 42 }], rowCount: 1 })
+
+    const result = await db().execute(sql`select count(*) from profiles`)
+
+    expect(result).toEqual({ rows: [{ total: 42 }], rowCount: 1 })
+    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(getQueryLog().filter((entry) => entry.op === 'execute')).toHaveLength(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error injection and store isolation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('error injection and store isolation', () => {
+  it('fails exactly one matching query with failNextQuery', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1' }] })
+    failNextQuery({ op: 'select', table: profiles })
+
+    await expect(db().select().from(profiles)).rejects.toThrow('[drizzle-mock] injected query failure')
+    await expect(db().select().from(profiles)).resolves.toHaveLength(1)
+  })
+
+  it('scopes an injected failure to the requested operation and table', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1' }], rooms: [{ id: 'r1', name: 'Main' }] })
+    failNextQuery({ op: 'update', table: profiles, error: new Error('update exploded') })
+
+    // A different table and a different operation are unaffected.
+    await expect(db().select().from(profiles)).resolves.toHaveLength(1)
+    await expect(db().update(rooms).set({ name: 'Renamed' }).where(eq(rooms.id, 'r1'))).resolves.toEqual([])
+
+    await expect(db().update(profiles).set({ fullName: 'X' }).where(eq(profiles.id, 'p1'))).rejects.toThrow(
+      'update exploded',
+    )
+    // The failed update did not write.
+    expect(getRows('profiles')[0].fullName).toBeUndefined()
+  })
+
+  it('can fail a query more than once via times', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1' }] })
+    failNextQuery({ op: 'select', table: profiles, times: 2 })
+
+    await expect(db().select().from(profiles)).rejects.toThrow(/injected query failure/)
+    await expect(db().select().from(profiles)).rejects.toThrow(/injected query failure/)
+    await expect(db().select().from(profiles)).resolves.toHaveLength(1)
+  })
+
+  it('clears the store, the query log and pending failures on resetDb', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1' }] })
+    failNextQuery({ op: 'select' })
+    await db().select().from(rooms).catch(() => [])
+
+    resetDb()
+
+    expect(getRows('profiles')).toEqual([])
+    expect(getQueryLog()).toEqual([])
+    // The pending failure was dropped rather than leaking into the next test.
+    await expect(db().select().from(profiles)).resolves.toEqual([])
+  })
+
+  it('returns snapshots from getRows, so mutating the result cannot corrupt the store', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1', fullName: 'Ann' }] })
+
+    const snapshot = getRows('profiles')
+    snapshot[0].fullName = 'Tampered'
+    snapshot.push({ id: 'ghost' })
+
+    const [row] = await db().select().from(profiles)
+    expect(row.fullName).toBe('Ann')
+    expect(getRows('profiles')).toHaveLength(1)
+  })
+
+  it('shares one store across every db handle, so admin and user handles agree', async () => {
+    const userDb = createStatefulDrizzleDb()
+    const adminDb = createStatefulDrizzleDb()
+
+    await adminDb.insert(profiles).values({ id: 'p1', memberNumber: 'M1', authEmail: 'a@example.com' })
+
+    // The write made through the admin handle is visible through the user handle.
+    await expect(userDb.select().from(profiles)).resolves.toHaveLength(1)
+  })
+
+  it('treats an unseeded table as empty rather than throwing', async () => {
+    await expect(db().select().from(profiles)).resolves.toEqual([])
+    expect(getRows('profiles')).toEqual([])
+  })
+})

--- a/tests/unit/mocks/drizzle-mock.test.ts
+++ b/tests/unit/mocks/drizzle-mock.test.ts
@@ -555,6 +555,365 @@ describe('AC4 concurrent and interleaved calls', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
+// AC4b — order-independence: the SAME operation set under DIFFERENT arrival
+// orders must produce the SAME outcome.
+//
+// The AC4 block above fires one `Promise.all` and checks the result. That
+// proves the flows do not contaminate each other on that particular run; it
+// does not prove the outcome is a function of the operations rather than of
+// the schedule. `importMembersFromCsv` runs at `concurrencyLimit = 10`, so
+// there is no call order to design against — the same ten flows may arrive in
+// any order and must still land the same way. These tests re-run one fixed
+// operation set under materially different interleavings and compare.
+//
+// Two things keep them from being vacuous:
+//
+//   1. Flows yield *between* their read and their write. Awaiting a
+//      `Promise.all` over builders that each run to completion in one turn
+//      interleaves nothing; the schedules below place some writes between
+//      other flows' reads, which is where cross-contamination would show.
+//   2. Arrival orders are fixed permutations, never `Math.random()`, so a
+//      failure reproduces on the next run instead of flaking.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Yield `count` microtask turns, so concurrent flows can be pulled apart. */
+const yieldTicks = async (count: number): Promise<void> => {
+  for (let index = 0; index < count; index += 1) await Promise.resolve()
+}
+
+/** Fixed arrival orders — hardcoded permutations, deliberately not random. */
+const TEN_FLOW_ORDERS: ReadonlyArray<readonly [string, readonly number[]]> = [
+  ['forward', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]],
+  ['reversed', [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]],
+  ['shuffled', [3, 7, 0, 9, 4, 1, 8, 2, 6, 5]],
+]
+
+/**
+ * Turn an arrival order into a per-flow schedule.
+ *
+ * The flow scheduled first reads first but waits longest before writing, so
+ * writes land *between* later flows' reads rather than after all of them. Reads
+ * fall on ticks 0, 3, 6 … and the first flow's write on tick ~20 — i.e. some
+ * reads genuinely observe other flows' completed writes, which is the only
+ * arrangement in which cross-contamination could be detected.
+ */
+const scheduleFor = (order: readonly number[], flowIndex: number) => {
+  const slot = order.indexOf(flowIndex)
+  return { beforeRead: slot * 3, betweenReadAndWrite: (order.length - slot) * 2 }
+}
+
+/** Compare stores as multisets: row *order* is not something Postgres promises. */
+const byId = (rows: MockRowLike[]): MockRowLike[] =>
+  [...rows].sort((left, right) => String(left.id).localeCompare(String(right.id)))
+
+type MockRowLike = Record<string, unknown>
+
+describe('AC4b order-independence across arrival orders', () => {
+  it('produces an identical store and identical per-flow results under forward, reversed and shuffled arrival orders', async () => {
+    // Modelled on `importMembersFromCsv`: ten flows look their member up and
+    // then write it. Five members exist (the write updates them); five do not
+    // (the UPDATE must affect zero rows and create nothing, exactly as in
+    // Postgres). The operation set is identical in all three runs — only the
+    // order the flows arrive in changes.
+    const runBatch = async (order: readonly number[]) => {
+      resetDb()
+      seed({
+        profiles: Array.from({ length: 5 }, (_, index) => ({
+          id: `p${index}`,
+          memberNumber: `M${index}`,
+          fullName: `Existing ${index}`,
+          noShowCount: 0,
+        })),
+      })
+
+      const results = await Promise.all(
+        Array.from({ length: 10 }, async (_, flowIndex) => {
+          const { beforeRead, betweenReadAndWrite } = scheduleFor(order, flowIndex)
+          const handle = db()
+
+          await yieldTicks(beforeRead)
+          const [existing] = await handle
+            .select({ id: profiles.id })
+            .from(profiles)
+            .where(eq(profiles.memberNumber, `M${flowIndex}`))
+            .limit(1)
+
+          await yieldTicks(betweenReadAndWrite)
+          const written = await handle
+            .update(profiles)
+            .set({ fullName: `Imported ${flowIndex}`, noShowCount: flowIndex })
+            .where(eq(profiles.memberNumber, `M${flowIndex}`))
+            .returning({ id: profiles.id, fullName: profiles.fullName })
+
+          return { flowIndex, foundId: existing?.id ?? null, written }
+        }),
+      )
+
+      return { results, stored: getRows('profiles'), log: getQueryLog() }
+    }
+
+    const batches: Array<Awaited<ReturnType<typeof runBatch>>> = []
+    for (const [, order] of TEN_FLOW_ORDERS) batches.push(await runBatch(order))
+    const [forward, reversed, shuffled] = batches
+
+    // Anti-vacuity guard. If the three schedules collapsed to the same
+    // interleaving, "identical outcome" would be trivially true and this whole
+    // test would assert nothing. The query log is the observable arrival order.
+    const signature = (batch: (typeof batches)[number]) =>
+      batch.log.map((entry) => `${entry.op}:${entry.rowCount}`).join('|')
+    expect(signature(forward)).not.toEqual(signature(reversed))
+    expect(signature(forward)).not.toEqual(signature(shuffled))
+
+    // Each flow read its own member and wrote its own member.
+    expect(forward.results.map((result) => result.foundId)).toEqual([
+      'p0',
+      'p1',
+      'p2',
+      'p3',
+      'p4',
+      null,
+      null,
+      null,
+      null,
+      null,
+    ])
+    for (const result of forward.results) {
+      expect(result.written).toEqual(
+        result.foundId === null ? [] : [{ id: result.foundId, fullName: `Imported ${result.flowIndex}` }],
+      )
+    }
+
+    // The five UPDATEs that matched nothing created nothing.
+    expect(forward.stored).toHaveLength(5)
+    for (let index = 0; index < 5; index += 1) {
+      const row = forward.stored.find((candidate) => candidate.memberNumber === `M${index}`)
+      expect(row?.fullName).toBe(`Imported ${index}`)
+      expect(row?.noShowCount).toBe(index)
+    }
+
+    // The criterion itself: same operations, different arrival orders, same
+    // outcome — both the returned results and the resulting store.
+    expect(reversed.results).toEqual(forward.results)
+    expect(shuffled.results).toEqual(forward.results)
+    expect(byId(reversed.stored)).toEqual(byId(forward.stored))
+    expect(byId(shuffled.stored)).toEqual(byId(forward.stored))
+  })
+
+  it('resolves a write against the store at await time, not against a snapshot taken when the builder was constructed', async () => {
+    seed({
+      profiles: Array.from({ length: 4 }, (_, index) => ({
+        id: `p${index}`,
+        memberNumber: `M${index}`,
+        fullName: `Existing ${index}`,
+      })),
+    })
+
+    // Build every update up front, before any of them runs. AC1 covers the
+    // read-side of this; the write side is a different failure mode — a helper
+    // that captured its matching rows at construction time would still be
+    // holding a row set that no longer reflects the store.
+    const builders = Array.from({ length: 4 }, (_, index) =>
+      db()
+        .update(profiles)
+        .set({ fullName: `Renamed ${index}` })
+        .where(eq(profiles.memberNumber, `M${index}`))
+        .returning({ id: profiles.id, fullName: profiles.fullName }),
+    )
+
+    // Change the store after construction but before a single builder is awaited.
+    await db().delete(profiles).where(eq(profiles.memberNumber, 'M2'))
+    await db().insert(profiles).values({ id: 'p9', memberNumber: 'M9', authEmail: 'm9@example.com' })
+
+    // Await them in reverse construction order for good measure.
+    const awaited: unknown[] = []
+    for (let index = builders.length - 1; index >= 0; index -= 1) awaited[index] = await builders[index]
+
+    expect(awaited[0]).toEqual([{ id: 'p0', fullName: 'Renamed 0' }])
+    expect(awaited[1]).toEqual([{ id: 'p1', fullName: 'Renamed 1' }])
+    // M2 was deleted after this builder was constructed, so it now matches
+    // nothing — a construction-time snapshot would still have found and
+    // "updated" a row that is no longer in the store.
+    expect(awaited[2]).toEqual([])
+    expect(awaited[3]).toEqual([{ id: 'p3', fullName: 'Renamed 3' }])
+
+    // The deleted row was not resurrected and the late insert was untouched.
+    expect(getRows('profiles').map((row) => row.id).sort()).toEqual(['p0', 'p1', 'p3', 'p9'])
+    expect(getRows('profiles').find((row) => row.id === 'p9')?.fullName).toBeNull()
+  })
+
+  it('produces an identical multi-table outcome for a mixed insert/update/delete workload under different arrival orders', async () => {
+    // Nine flows spanning three tables and all three write operations. The
+    // existing AC4 coverage runs concurrent writes on different tables once;
+    // this re-runs the same nine under three schedules and compares the whole
+    // three-table store.
+    const orders: ReadonlyArray<readonly number[]> = [
+      [0, 1, 2, 3, 4, 5, 6, 7, 8],
+      [8, 7, 6, 5, 4, 3, 2, 1, 0],
+      [4, 0, 7, 2, 8, 5, 1, 6, 3],
+    ]
+
+    const runBatch = async (order: readonly number[]) => {
+      resetDb()
+      seed({
+        profiles: [
+          { id: 'p1', memberNumber: 'M1', fullName: 'Ann' },
+          { id: 'p2', memberNumber: 'M2', fullName: 'Bob' },
+        ],
+        rooms: [
+          { id: 'r1', name: 'Main' },
+          { id: 'r2', name: 'Side' },
+        ],
+        tables: [
+          { id: 't1', roomId: 'r1', name: 'Table 1' },
+          { id: 't2', roomId: 'r2', name: 'Table 2' },
+        ],
+      })
+
+      const flows: Array<() => Promise<unknown>> = [
+        () => db().insert(profiles).values({ id: 'p3', memberNumber: 'M3', authEmail: 'm3@example.com' }),
+        () => db().insert(rooms).values({ id: 'r3', name: 'Annex' }),
+        () => db().insert(tables).values({ id: 't3', roomId: 'r1', name: 'Table 3' }),
+        () => db().update(profiles).set({ fullName: 'Ann Updated' }).where(eq(profiles.id, 'p1')),
+        () => db().update(rooms).set({ name: 'Main Updated' }).where(eq(rooms.id, 'r1')),
+        () => db().update(tables).set({ name: 'Table 1 Updated' }).where(eq(tables.id, 't1')),
+        () => db().delete(profiles).where(eq(profiles.id, 'p2')),
+        () => db().delete(rooms).where(eq(rooms.id, 'r2')),
+        () => db().delete(tables).where(eq(tables.id, 't2')),
+      ]
+
+      await Promise.all(
+        flows.map(async (flow, flowIndex) => {
+          await yieldTicks(order.indexOf(flowIndex) * 2)
+          await flow()
+        }),
+      )
+
+      // `createdAt` / `updatedAt` are `defaultNow()` columns: they carry the
+      // wall clock at insert time, so they differ between two batches by
+      // however many milliseconds elapsed — exactly as `now()` would across two
+      // real transactions. Comparing them across batches would measure the
+      // clock, not the mock, so every Date-valued column is dropped here and
+      // their presence is asserted separately below.
+      const clockColumns = (row: MockRowLike) =>
+        Object.keys(row)
+          .filter((key) => row[key] instanceof Date)
+          .sort()
+
+      const withoutClock = (rows: MockRowLike[]) =>
+        byId(rows).map((row) =>
+          Object.fromEntries(Object.entries(row).filter(([, value]) => !(value instanceof Date))),
+        )
+
+      return {
+        profiles: withoutClock(getRows('profiles')),
+        rooms: withoutClock(getRows('rooms')),
+        tables: withoutClock(getRows('tables')),
+        // The inserted room proves the dropped columns were actually populated.
+        insertedRoomClockColumns: byId(getRows('rooms'))
+          .filter((row) => row.id === 'r3')
+          .map(clockColumns),
+      }
+    }
+
+    const batches: Array<Awaited<ReturnType<typeof runBatch>>> = []
+    for (const order of orders) batches.push(await runBatch(order))
+    const [baseline] = batches
+
+    expect(baseline.profiles.map((row) => row.id)).toEqual(['p1', 'p3'])
+    expect(baseline.profiles.find((row) => row.id === 'p1')?.fullName).toBe('Ann Updated')
+    expect(baseline.rooms.map((row) => row.id)).toEqual(['r1', 'r3'])
+    expect(baseline.rooms.find((row) => row.id === 'r1')?.name).toBe('Main Updated')
+    expect(baseline.tables.map((row) => row.id)).toEqual(['t1', 't3'])
+    expect(baseline.tables.find((row) => row.id === 't1')?.name).toBe('Table 1 Updated')
+    // The excluded columns were still populated by the insert in every batch.
+    for (const batch of batches) expect(batch.insertedRoomClockColumns).toEqual([['createdAt']])
+
+    for (const batch of batches.slice(1)) expect(batch).toEqual(baseline)
+  })
+
+  it('never lets an interleaved read observe a half-applied multi-column write', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1', fullName: 'gen-0', phone: 'gen-0', email: 'gen-0' }] })
+
+    // Six writers each bump three columns to the same generation marker; twelve
+    // readers interleave between them. A write that became visible column by
+    // column would let a reader see a mixed generation — the read-side of the
+    // cross-contamination criterion, which the AC4 block only checks per row.
+    const observed: Array<[unknown, unknown, unknown]> = []
+
+    await Promise.all([
+      ...Array.from({ length: 6 }, async (_, index) => {
+        await yieldTicks(index * 2 + 1)
+        await db()
+          .update(profiles)
+          .set({ fullName: `gen-${index + 1}`, phone: `gen-${index + 1}`, email: `gen-${index + 1}` })
+          .where(eq(profiles.id, 'p1'))
+      }),
+      ...Array.from({ length: 12 }, async (_, index) => {
+        await yieldTicks(index)
+        const [row] = await db()
+          .select({ fullName: profiles.fullName, phone: profiles.phone, email: profiles.email })
+          .from(profiles)
+          .where(eq(profiles.id, 'p1'))
+        observed.push([row.fullName, row.phone, row.email])
+      }),
+    ])
+
+    expect(observed).toHaveLength(12)
+    for (const [fullName, phone, email] of observed) {
+      expect(phone).toBe(fullName)
+      expect(email).toBe(fullName)
+    }
+
+    // Anti-vacuity: the readers really did straddle the writers rather than all
+    // landing before or after them.
+    expect(new Set(observed.map(([fullName]) => fullName)).size).toBeGreaterThan(1)
+
+    const [final] = await db().select().from(profiles)
+    expect(final.fullName).toBe('gen-6')
+    expect(getRows('profiles')).toHaveLength(1)
+  })
+
+  it('resolves concurrent writes to the same column of the same row deterministically for a given schedule', async () => {
+    // AC4 already covers concurrent updates that set *different* columns. Same
+    // column, same row is genuinely schedule-dependent — in Postgres too — so
+    // the criterion here is that a given schedule always yields the same value
+    // and the store is never corrupted, not that all schedules agree.
+    const runOnce = async (order: readonly number[]) => {
+      resetDb()
+      seed({ profiles: [{ id: 'p1', memberNumber: 'M1', fullName: 'Original', noShowCount: 7 }] })
+
+      await Promise.all(
+        order.map(async (writerIndex, slot) => {
+          await yieldTicks(slot * 2)
+          await db().update(profiles).set({ fullName: `Writer ${writerIndex}` }).where(eq(profiles.id, 'p1'))
+        }),
+      )
+
+      return getRows('profiles')
+    }
+
+    const forward = await runOnce([0, 1, 2, 3, 4])
+    const forwardAgain = await runOnce([0, 1, 2, 3, 4])
+    const reversed = await runOnce([4, 3, 2, 1, 0])
+
+    // Repeating a schedule repeats the outcome exactly.
+    expect(forwardAgain).toEqual(forward)
+
+    // Last write wins, and "last" follows the schedule rather than the order
+    // the writers were declared in.
+    expect(forward).toHaveLength(1)
+    expect(forward[0].fullName).toBe('Writer 4')
+    expect(reversed).toHaveLength(1)
+    expect(reversed[0].fullName).toBe('Writer 0')
+
+    // Five concurrent writers left one row, and columns nobody set are intact.
+    expect(forward[0].id).toBe('p1')
+    expect(forward[0].noShowCount).toBe(7)
+    expect(reversed[0].noShowCount).toBe(7)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
 // AC5 — chained joins
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/unit/mocks/drizzle-mock.test.ts
+++ b/tests/unit/mocks/drizzle-mock.test.ts
@@ -854,3 +854,150 @@ describe('error injection and store isolation', () => {
     expect(getRows('profiles')).toEqual([])
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error injection on raw db.execute()
+//
+// `QueryOp` advertises `'execute'` and `failNextQuery({ op: 'execute' })` is a
+// documented spec, so the execute path must actually consume the injected
+// failure. It once did not: the spec was accepted, queued, and then never
+// matched, so `db.execute(sql\`...\`)` resolved through `executeMock` while the
+// test believed it was exercising a raw-SQL error path — a silently passing
+// error-path test. `reservations-service.ts` replaced the
+// `mark_no_show_reservations` RPC with a raw `db.execute(sql\`...\`)`, which is
+// exactly the call these tests protect.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('error injection on raw db.execute()', () => {
+  it('fails exactly one execute with failNextQuery({ op: execute }) and lets the next one through', async () => {
+    executeMock.mockReturnValue({ rows: [], rowCount: 3 })
+    failNextQuery({ op: 'execute' })
+
+    await expect(db().execute(sql`update reservations set status = 'no_show'`)).rejects.toThrow(
+      '[drizzle-mock] injected query failure',
+    )
+    // The failure is consumed, not sticky — the call after it behaves normally.
+    await expect(db().execute(sql`update reservations set status = 'no_show'`)).resolves.toEqual({
+      rows: [],
+      rowCount: 3,
+    })
+  })
+
+  it('rejects with the custom error supplied to failNextQuery', async () => {
+    failNextQuery({ op: 'execute', error: new Error('no_show sweep exploded') })
+
+    await expect(db().execute(sql`select 1`)).rejects.toThrow('no_show sweep exploded')
+  })
+
+  it('fails an execute more than once via times', async () => {
+    failNextQuery({ op: 'execute', times: 2 })
+
+    await expect(db().execute(sql`select 1`)).rejects.toThrow(/injected query failure/)
+    await expect(db().execute(sql`select 1`)).rejects.toThrow(/injected query failure/)
+    await expect(db().execute(sql`select 1`)).resolves.toEqual({ rows: [], rowCount: 0 })
+  })
+
+  it('lets an unfiltered failNextQuery() fail the next execute', async () => {
+    failNextQuery()
+
+    await expect(db().execute(sql`select 1`)).rejects.toThrow('[drizzle-mock] injected query failure')
+    await expect(db().execute(sql`select 1`)).resolves.toEqual({ rows: [], rowCount: 0 })
+  })
+
+  it('does not leak between execute and the table-backed operations in either direction', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1' }] })
+
+    // An execute-scoped failure must not be swallowed by any other operation…
+    failNextQuery({ op: 'execute' })
+    await expect(db().select().from(profiles)).resolves.toHaveLength(1)
+    await expect(db().insert(profiles).values({ id: 'p2', memberNumber: 'M2' })).resolves.toEqual([])
+    await expect(db().update(profiles).set({ fullName: 'X' }).where(eq(profiles.id, 'p1'))).resolves.toEqual([])
+    // …it is still queued, and fires on the execute.
+    await expect(db().execute(sql`select 1`)).rejects.toThrow(/injected query failure/)
+
+    // And the reverse: a select-scoped failure must not be consumed by execute.
+    failNextQuery({ op: 'select', table: profiles })
+    await expect(db().execute(sql`select 1`)).resolves.toEqual({ rows: [], rowCount: 0 })
+    await expect(db().select().from(profiles)).rejects.toThrow(/injected query failure/)
+  })
+
+  it('does not fire a table-scoped failure on execute, since raw SQL names no parsable table', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1' }] })
+    failNextQuery({ table: profiles })
+
+    // `execute` is matched on the empty table key, so a table-scoped spec with
+    // no `op` deliberately passes it by and waits for the real profiles query.
+    await expect(db().execute(sql`select 1`)).resolves.toEqual({ rows: [], rowCount: 0 })
+    await expect(db().select().from(profiles)).rejects.toThrow(/injected query failure/)
+  })
+
+  it('rejects the never-matchable { op: execute, table } combination at call time, queueing nothing', async () => {
+    expect(() => failNextQuery({ op: 'execute', table: profiles })).toThrow(/cannot be scoped by table/)
+
+    // Nothing was queued by the rejected spec, so a later execute still resolves.
+    await expect(db().execute(sql`select 1`)).resolves.toEqual({ rows: [], rowCount: 0 })
+  })
+
+  it('leaves a failed execute out of the query log and records a successful one', async () => {
+    failNextQuery({ op: 'execute' })
+    await expect(db().execute(sql`select 1`)).rejects.toThrow(/injected query failure/)
+
+    // Consistent with select/insert/update/delete: the failure is thrown before
+    // the log push, so a query that never ran is not reported as having run.
+    expect(getQueryLog()).toEqual([])
+
+    await db().execute(sql`select 1`)
+    expect(getQueryLog()).toEqual([{ op: 'execute', table: '', rowCount: 0 }])
+  })
+
+  it('never reaches executeMock when the failure is consumed', async () => {
+    executeMock.mockReturnValue({ rows: [{ swept: 1 }], rowCount: 1 })
+    failNextQuery({ op: 'execute' })
+
+    await expect(db().execute(sql`select 1`)).rejects.toThrow(/injected query failure/)
+    expect(executeMock).not.toHaveBeenCalled()
+
+    await expect(db().execute(sql`select 1`)).resolves.toEqual({ rows: [{ swept: 1 }], rowCount: 1 })
+    expect(executeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces the failure as a rejected promise rather than a synchronous throw', async () => {
+    failNextQuery({ op: 'execute' })
+
+    // Every other operation rejects rather than throwing at call time; execute
+    // must match, or `await expect(...).rejects` reads as a false negative.
+    let pending: Promise<unknown> | undefined
+    expect(() => {
+      pending = db().execute(sql`select 1`)
+    }).not.toThrow()
+    await expect(pending).rejects.toThrow('[drizzle-mock] injected query failure')
+  })
+
+  it('returns the executeMock value when nothing is queued, and the documented default when it is unset', async () => {
+    executeMock.mockReturnValue({ rows: [{ total: 7 }], rowCount: 1 })
+    await expect(db().execute(sql`select count(*) from profiles`)).resolves.toEqual({
+      rows: [{ total: 7 }],
+      rowCount: 1,
+    })
+
+    executeMock.mockReset()
+    await expect(db().execute(sql`select 1`)).resolves.toEqual({ rows: [], rowCount: 0 })
+    expect(executeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rolls a transaction back when the failing call is an execute inside it', async () => {
+    seed({ profiles: [{ id: 'p1', memberNumber: 'M1', fullName: 'Keep' }] })
+    failNextQuery({ op: 'execute' })
+
+    await expect(
+      db().transaction(async (tx) => {
+        await tx.update(profiles).set({ fullName: 'Dirty' }).where(eq(profiles.id, 'p1'))
+        await tx.execute(sql`update reservations set status = 'no_show'`)
+        return 'unreachable'
+      }),
+    ).rejects.toThrow('[drizzle-mock] injected query failure')
+
+    // The write made before the failing execute was rolled back with it.
+    expect(getRows('profiles')[0].fullName).toBe('Keep')
+  })
+})

--- a/tests/unit/mocks/drizzle-mock.ts
+++ b/tests/unit/mocks/drizzle-mock.ts
@@ -86,7 +86,8 @@
  * - `update(t).set(values).where(cond)[.returning(fields?)]`
  * - `delete(t).where(cond)[.returning(fields?)]`
  * - `transaction(cb)` — rolls the store back if `cb` throws
- * - `execute(sql)` — recorded in the query log, delegates to `executeMock`
+ * - `execute(sql)` — recorded in the query log, delegates to `executeMock`,
+ *   and honours `failNextQuery({ op: 'execute' })` like any other operation
  *
  * Conditions: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `and`, `or`, `not`,
  * `inArray`, `notInArray`, `isNull`, `isNotNull`, `between`, `notBetween`,
@@ -433,6 +434,14 @@ const queryLog: MockQueryLogEntry[] = []
 type FailureSpec = { op?: QueryOp; table?: string; times: number; error: unknown }
 const failures: FailureSpec[] = []
 
+/**
+ * Table key used for raw `db.execute(sql\`...\`)` calls, in the query log and
+ * when matching injected failures. Raw SQL names no table the mock can parse,
+ * so `execute` gets the empty key: op-only and unfiltered failures match it,
+ * table-scoped ones deliberately do not.
+ */
+const EXECUTE_TABLE_KEY = ''
+
 /** Normalise any table reference to a single store key. */
 function tableKey(ref: TableRef): string {
   const name = typeof ref === 'string' ? ref : getTableName(ref)
@@ -496,6 +505,17 @@ export function getQueryLog(): MockQueryLogEntry[] {
  * failNextQuery({ op: 'update', table: profiles })
  * // the service's catch-block path is now exercised
  * ```
+ *
+ * Applies to every operation in {@link QueryOp}, `execute` included:
+ *
+ * ```typescript
+ * failNextQuery({ op: 'execute' })
+ * // the next db.execute(sql`...`) rejects; the one after it resolves normally
+ * ```
+ *
+ * `table` cannot be used together with `op: 'execute'` — a raw-SQL statement
+ * names no table the mock can parse, so such a spec could never match. That
+ * combination throws here rather than sitting in the queue and never firing.
  */
 export function failNextQuery(spec: {
   op?: QueryOp
@@ -503,6 +523,12 @@ export function failNextQuery(spec: {
   times?: number
   error?: unknown
 } = {}): void {
+  if (spec.op === 'execute' && spec.table !== undefined) {
+    throw mockError(
+      "failNextQuery({ op: 'execute' }) cannot be scoped by table — raw SQL names no table the mock can " +
+        'parse. Drop the `table` field to fail the next execute regardless of the statement.',
+    )
+  }
   failures.push({
     op: spec.op,
     table: spec.table === undefined ? undefined : tableKey(spec.table),
@@ -1535,10 +1561,28 @@ export function createStatefulDrizzleDb() {
       set: vi.fn((values: MockRow) => new MockUpdateBuilder(table, values)),
     })),
     delete: vi.fn((table: Table) => new MockDeleteBuilder(table)),
-    execute: vi.fn((...args: unknown[]) => {
-      queryLog.push({ op: 'execute', table: '', rowCount: 0 })
+    /**
+     * Raw SQL passthrough. The store is never consulted (arbitrary SQL cannot be
+     * evaluated without a SQL engine), so the result comes from `executeMock`,
+     * defaulting to `{ rows: [], rowCount: 0 }`.
+     *
+     * Failure injection applies here exactly as it does to the other operations:
+     * `failNextQuery({ op: 'execute' })` — or an unfiltered `failNextQuery()` —
+     * makes the next call reject *before* `executeMock` is reached, and the
+     * rejected call is left out of the query log.
+     *
+     * A raw-SQL statement names no table the mock can parse, so `execute` is
+     * matched against {@link EXECUTE_TABLE_KEY} (the empty key) rather than a
+     * real one: a table-scoped failure such as `failNextQuery({ table: rooms })`
+     * deliberately does not fire on `execute`. The one combination that could
+     * never fire — an explicit `{ op: 'execute', table }` — is rejected up front
+     * by {@link failNextQuery} rather than silently ignored.
+     */
+    execute: vi.fn(async (...args: unknown[]) => {
+      consumeFailure('execute', EXECUTE_TABLE_KEY)
+      queryLog.push({ op: 'execute', table: EXECUTE_TABLE_KEY, rowCount: 0 })
       const result = executeMock(...args)
-      return Promise.resolve(result ?? { rows: [], rowCount: 0 })
+      return result ?? { rows: [], rowCount: 0 }
     }),
     /**
      * Runs `callback` against the same store. If it throws, every write made

--- a/tests/unit/mocks/drizzle-mock.ts
+++ b/tests/unit/mocks/drizzle-mock.ts
@@ -1,79 +1,143 @@
 /**
- * Shared Drizzle query builder mock factory and state for service tests
+ * Shared Drizzle mock infrastructure for service-layer unit tests.
  *
- * This helper provides reusable mock infrastructure for testing Drizzle-based
- * service layers across multiple test files. It handles chainable query builders,
- * transaction wrappers, and common CRUD operations (select, insert, update, delete).
+ * This file exposes TWO independent mock flavours. Pick one per test file —
+ * they do not interact.
  *
- * ## Why This Exists
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 1. STATE-DRIVEN MOCK (`createStatefulDrizzleDb`) — preferred (KIM-443)
+ * ─────────────────────────────────────────────────────────────────────────────
  *
- * Unit tests for Drizzle services need to mock the query builder chain:
- * `.select().from().where()`, `.insert().values().returning()`, etc.
- * Without a shared helper, each test file had to hand-wire all these chains locally,
- * creating duplicate mock logic and making it tedious to set up new test files.
+ * An in-memory JS store (a `Map` keyed by table name) that answers every query
+ * by *inspecting the builder chain* (table, joins, where-condition, order,
+ * limit) and evaluating it against the seeded rows. There is NO reliance on
+ * call ordering, so it is correct for services that issue concurrent or
+ * interleaved queries (e.g. `importMembersFromCsv`, which runs with
+ * `concurrencyLimit = 10`).
  *
- * ## How to Use in a Test File
+ * There is no real database here: no pglite, no embedded/containerised
+ * Postgres, no SQL engine, no connection. Conditions built with `eq`, `and`,
+ * `or`, `inArray`, `gte`, … are decoded from Drizzle's own `SQL` AST and
+ * evaluated against plain JS objects.
  *
- * 1. Import the mock state and factory:
- *    ```typescript
- *    import {
- *      createDrizzleQueryBuilder,
- *      selectMock,
- *      insertMock,
- *      updateMock,
- *      deleteMock,
- *      createAdminSession,
- *      createMemberSession,
- *    } from '@/tests/unit/mocks/drizzle-mock'
- *    ```
+ * ### Usage
  *
- * 2. Set up the vi.mock call (must be at the top level of the test file):
- *    ```typescript
- *    vi.mock('@/lib/db', () => ({
- *      getDrizzleDb: vi.fn(() => createDrizzleQueryBuilder()),
- *      getDrizzleAdminDb: vi.fn(() => createDrizzleQueryBuilder()),
- *    }))
- *    ```
+ * ```typescript
+ * import {
+ *   createStatefulDrizzleDb,
+ *   seed,
+ *   resetDb,
+ *   getRows,
+ * } from '@/tests/unit/mocks/drizzle-mock'
  *
- * 3. In beforeEach, reset the mocks:
- *    ```typescript
- *    beforeEach(() => {
- *      vi.resetModules()
- *      vi.clearAllMocks()
- *    })
- *    ```
+ * // vi.mock() is hoisted, so it must live in the test file itself (see the
+ * // note at the bottom of this header) — but the factory can be shared.
+ * vi.mock('@/lib/db', () => ({
+ *   getDrizzleDb: vi.fn(() => createStatefulDrizzleDb()),
+ *   getDrizzleAdminDb: vi.fn(() => createStatefulDrizzleDb()),
+ * }))
  *
- * 4. In individual tests, configure the mock responses:
- *    ```typescript
- *    selectMock.mockResolvedValue([{ id: 'row-1', name: 'Example' }])
- *    // or
- *    insertMock.mockResolvedValue([{ id: 'new-row' }])
- *    // or
- *    updateMock.mockResolvedValue([{ id: 'updated-row' }])
- *    // or
- *    deleteMock.mockResolvedValue([{ id: 'deleted-row' }])
- *    ```
+ * beforeEach(() => {
+ *   resetDb()
+ *   vi.clearAllMocks()
+ * })
+ *
+ * it('returns only the member own reservations', async () => {
+ *   seed({
+ *     reservations: [
+ *       { id: 'r-1', userId: 'member-1', tableId: 't-1', date: '2026-08-01' },
+ *       { id: 'r-2', userId: 'member-2', tableId: 't-1', date: '2026-08-01' },
+ *     ],
+ *     tables: [{ id: 't-1', roomId: 'room-1', name: 'Table 1' }],
+ *   })
+ *
+ *   const result = await listReservationsForSession(createMemberSession())
+ *
+ *   expect(result).toHaveLength(1)
+ *   // writes are visible to later reads in the same test:
+ *   expect(getRows('reservations')).toHaveLength(1)
+ * })
+ * ```
+ *
+ * ### Public API
+ *
+ * | Export | Purpose |
+ * | --- | --- |
+ * | `createStatefulDrizzleDb()` | Returns the `db` object to hand to `vi.mock('@/lib/db')`. |
+ * | `seed(data)` | Seed rows for one or more tables. Replaces only the tables named. |
+ * | `seedTable(table, rows)` | Same, for a single table (accepts a Drizzle table object). |
+ * | `resetDb()` | Clears the store, the query log and any injected failures. |
+ * | `getRows(table)` | Snapshot of the current rows of a table (post-write assertions). |
+ * | `failNextQuery(spec)` | Make the next matching query reject (error-path tests). |
+ * | `getQueryLog()` | Ordered log of executed operations, for coarse assertions. |
+ *
+ * Table keys are normalised — `'saved_games'`, `'savedGames'` and the Drizzle
+ * `savedGames` table object all address the same store entry. Row keys accept
+ * either the Drizzle property name (`userId`, what queries return) or the
+ * database column name (`user_id`).
+ *
+ * ### Supported chain surface
+ *
+ * - `select()` / `select(fields)` / `selectDistinct(fields)` `.from(t)`
+ * - `.innerJoin(t, on)` / `.leftJoin(t, on)`, chained any number of times
+ * - `.where(cond | undefined)`, `.orderBy(asc(c), desc(c), c)`, `.groupBy(...)`
+ * - `.limit(n)`, `.offset(n)`, `.execute()`, or plain `await`
+ * - `insert(t).values(row | rows)[.onConflictDoNothing()|.onConflictDoUpdate()][.returning(fields?)]`
+ * - `update(t).set(values).where(cond)[.returning(fields?)]`
+ * - `delete(t).where(cond)[.returning(fields?)]`
+ * - `transaction(cb)` — rolls the store back if `cb` throws
+ * - `execute(sql)` — recorded in the query log, delegates to `executeMock`
+ *
+ * Conditions: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `and`, `or`, `not`,
+ * `inArray`, `notInArray`, `isNull`, `isNotNull`, `between`, `notBetween`,
+ * `like`, `notLike`, `ilike`, `notIlike`, and column-to-column comparisons.
+ * Aggregates: `count()` / `count(col)`, `sum`, `avg`, `min`, `max`.
+ *
+ * ### Known limitations (deliberately NOT faked)
+ *
+ * Anything outside the surface above throws a `[drizzle-mock]` error naming the
+ * unsupported construct instead of silently returning wrong rows. In
+ * particular: subqueries / CTEs / `EXISTS`, `rightJoin` / `fullJoin`,
+ * `.having()`, window functions, and raw `db.execute(sql)` results (that call
+ * returns whatever `executeMock` is configured to return — the store is not
+ * consulted, because arbitrary SQL cannot be evaluated without a SQL engine).
+ * Column-level constraints (`notNull`, unique indexes, FKs) are not enforced.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 2. LEGACY SEQUENCE-DRIVEN MOCK (`createDrizzleQueryBuilder`) — kept for
+ *    backward compatibility
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * Resolves every query from the shared `selectMock` / `insertMock` /
+ * `updateMock` / `deleteMock` `vi.fn()`s, i.e. by call sequence. Fine for
+ * services that issue one query at a time; it cannot express "this table has
+ * these rows", so prefer the state-driven mock for anything new.
+ *
+ * ```typescript
+ * vi.mock('@/lib/db', () => ({
+ *   getDrizzleDb: vi.fn(() => createDrizzleQueryBuilder()),
+ *   getDrizzleAdminDb: vi.fn(() => createDrizzleQueryBuilder()),
+ * }))
+ *
+ * selectMock.mockResolvedValue([{ id: 'row-1', name: 'Example' }])
+ * ```
  *
  * ## Important Constraint: vi.mock() Must Stay in Each Test File
  *
- * Vitest has a hard constraint: **vi.mock() calls are hoisted to the top of the module
- * they appear in**, and they cannot be imported from a shared helper function. This is
- * a Vitest design constraint (not a bug).
+ * Vitest hoists `vi.mock()` to the top of the module it appears in, and it
+ * cannot be imported from a shared helper function. This is a Vitest design
+ * constraint (not a bug). Each test file MUST therefore declare its own
+ * `vi.mock('@/lib/db', ...)`; only the factory inside the callback is shared.
  *
- * Therefore, each test file MUST define its own `vi.mock('@/lib/db', ...)` call at
- * the top level. However, the callback function can reuse the shared `createDrizzleQueryBuilder()`
- * factory defined here.
- *
- * **DO NOT try to:** write a helper function that returns `vi.mock(...)` and then call it
- * from the test file. Vitest will not hoist it correctly and mocks will not be in place when
- * the module under test is imported.
- *
- * See `tables-service.test.ts` and `equipment-service.test.ts` for examples.
+ * **DO NOT try to:** write a helper that returns `vi.mock(...)` and call it
+ * from the test file — Vitest will not hoist it and the mock will not be in
+ * place when the module under test is imported.
  */
 
 import { vi } from 'vitest'
+import { Column, Param, SQL, StringChunk, Table, getTableColumns, getTableName, is } from 'drizzle-orm'
 
-// ── Mock state: global response objects for each query type ─────────────────────
+// ── Mock state: global response objects for each query type (legacy mock) ───────
 // These are imported by the test file and configured per test in beforeEach/it.
 // They back the chainable query builder mocks below.
 
@@ -92,6 +156,10 @@ export const insertMock = vi.fn()
 /**
  * Mock response for UPDATE queries.
  * Set with: `updateMock.mockResolvedValue([...updated_rows])`
+ *
+ * Receives the object passed to `.set(...)` as its first argument, so tests
+ * can assert on the update payload:
+ * `expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({ fullName: 'X' }))`
  */
 export const updateMock = vi.fn()
 
@@ -102,11 +170,16 @@ export const updateMock = vi.fn()
 export const deleteMock = vi.fn()
 
 /**
- * Captures the arguments passed to every `.where(...)` call across the
- * chainable query builder (select/update/delete), so tests can assert that
- * an authorization/scoping filter (e.g. `eq(partners.active, true)`, the
- * service-layer replacement for a Supabase RLS policy) is actually applied
- * — not just that the resolved rows look right.
+ * Records every raw `db.execute(...)` call (e.g. `db.execute(sql\`...\`)`).
+ * Set a return value with `executeMock.mockResolvedValue({ rows: [] })`.
+ */
+export const executeMock = vi.fn()
+
+/**
+ * Captures the arguments passed to every `.where(...)` call across both mock
+ * flavours, so tests can assert that an authorization/scoping filter (e.g.
+ * `eq(partners.active, true)`, the service-layer replacement for a Supabase
+ * RLS policy) is actually applied — not just that resolved rows look right.
  *
  * Usage:
  * ```typescript
@@ -145,7 +218,42 @@ export function createMemberSession(): SessionUser {
   return { id: 'member-1', role: 'member', email: 'member@example.com' }
 }
 
-// ── Drizzle query builder mock factories ────────────────────────────────────────
+// ── MockServiceError: Error class for mocking serviceError() throws ─────────────
+
+/**
+ * Mock version of ServiceError for use in tests.
+ * Replicates the real class so mocked `serviceError()` throws work correctly.
+ */
+export class MockServiceError extends Error {
+  readonly statusCode: number
+  readonly name = 'ServiceError'
+
+  constructor(message: string, statusCode: number) {
+    super(message)
+    this.statusCode = statusCode
+  }
+}
+
+/**
+ * Wire up the `serviceError` mock to throw `MockServiceError`.
+ * Call this in your test file's vi.mock setup:
+ *
+ * ```typescript
+ * vi.mock('@/lib/server/shared/service-error', () => ({
+ *   ServiceError: MockServiceError,
+ *   serviceError: createMockServiceError(),
+ * }))
+ * ```
+ */
+export function createMockServiceError() {
+  return (message: string, statusCode: number) => {
+    throw new MockServiceError(message, statusCode)
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// LEGACY SEQUENCE-DRIVEN MOCK
+// ═══════════════════════════════════════════════════════════════════════════════
 
 /**
  * Create a mock for INSERT...VALUES...RETURNING chain.
@@ -174,28 +282,72 @@ function createDeleteWhereReturningMock() {
 }
 
 /**
- * Create a mock for SELECT...WHERE chain.
- * Returns a function that delegates to selectMock, and also supports .orderBy().
- * Used for the `.orderBy` slot of `.select().from()` (no `.where()` in the
- * chain), so it does not itself record into `whereMock`.
+ * Create a chainable FROM/JOIN/WHERE/ORDER/LIMIT/OFFSET mock.
+ * Joins can be chained any number of times; every terminal resolves via
+ * `selectMock`.
  */
-function createSelectWhereMock() {
-  const whereFn = vi.fn(() => selectMock())
-  whereFn.orderBy = vi.fn(() => selectMock())
-  return whereFn
+function createLegacySelectFromChain(): any {
+  const executeSelect = () => selectMock()
+
+  const limitOffsetChain = {
+    offset: vi.fn(() => ({
+      then: (onFulfilled: any, onRejected: any) => executeSelect().then(onFulfilled, onRejected),
+      catch: (onRejected: any) => executeSelect().catch(onRejected),
+    })),
+    then: (onFulfilled: any, onRejected: any) => executeSelect().then(onFulfilled, onRejected),
+    catch: (onRejected: any) => executeSelect().catch(onRejected),
+  } as any
+
+  const orderByChain = {
+    limit: vi.fn(() => limitOffsetChain),
+    offset: vi.fn(() => limitOffsetChain),
+    then: (onFulfilled: any, onRejected: any) => executeSelect().then(onFulfilled, onRejected),
+    catch: (onRejected: any) => executeSelect().catch(onRejected),
+  } as any
+
+  const whereChain = {
+    orderBy: vi.fn(() => orderByChain),
+    limit: vi.fn(() => limitOffsetChain),
+    offset: vi.fn(() => limitOffsetChain),
+    then: (onFulfilled: any, onRejected: any) => executeSelect().then(onFulfilled, onRejected),
+    catch: (onRejected: any) => executeSelect().catch(onRejected),
+  } as any
+
+  return {
+    // Joins can be chained multiple times
+    leftJoin: vi.fn(() => createLegacySelectFromChain()),
+    innerJoin: vi.fn(() => createLegacySelectFromChain()),
+
+    // WHERE clause — records the filter and returns a chainable object
+    where: vi.fn((...args: unknown[]) => {
+      whereMock(...args)
+      return whereChain
+    }),
+
+    // Queries without WHERE still reach orderBy/limit/offset
+    orderBy: vi.fn(() => orderByChain),
+    limit: vi.fn(() => limitOffsetChain),
+    offset: vi.fn(() => limitOffsetChain),
+
+    // Direct awaiting (no WHERE/ORDER/LIMIT in the chain)
+    then: (onFulfilled: any, onRejected: any) => executeSelect().then(onFulfilled, onRejected),
+    catch: (onRejected: any) => executeSelect().catch(onRejected),
+  } as any
 }
 
 /**
- * Create a chainable Drizzle-like query builder mock.
+ * Create a chainable Drizzle-like query builder mock (sequence-driven).
  *
  * Supports the following chains:
  * - `.select().from().where()` → resolves via `selectMock`
+ * - `.select().from().where().orderBy().limit().offset()` → resolves via `selectMock`
  * - `.select().from().orderBy()` → resolves via `selectMock`
- * - `.select().from().innerJoin().where()` → resolves via `selectMock`
+ * - `.select().from().leftJoin().innerJoin().where()` → resolves via `selectMock`
  * - `.insert().values().returning()` → resolves via `insertMock`
- * - `.update().set().where().returning()` → resolves via `updateMock`
+ * - `.update().set().where().returning()` → resolves via `updateMock` (also awaitable without `.returning()`)
  * - `.delete().where().returning()` → resolves via `deleteMock`
- * - `.transaction(callback)` → calls callback with a new builder instance (for atomic operations)
+ * - `.execute(sql\`...\`)` → records into `executeMock`
+ * - `.transaction(callback)` → calls callback with a new builder instance
  *
  * Usage:
  * ```typescript
@@ -208,52 +360,1198 @@ function createSelectWhereMock() {
 export function createDrizzleQueryBuilder() {
   return {
     select: vi.fn(() => ({
-      from: vi.fn(() => {
-        const whereChain = createSelectWhereMock()
-        return {
-          orderBy: createSelectWhereMock(),
-          innerJoin: vi.fn(() => ({
-            where: vi.fn((...args) => {
-              whereMock(...args)
-              return selectMock()
-            }),
-          })),
-          where: vi.fn((...args) => {
-            // Record the filter condition (e.g. an RLS-replacement scope
-            // like `eq(partners.active, true)`) so tests can assert it was
-            // actually applied, not just that resolved rows look right.
-            whereMock(...args)
-            // Return an object that has both the thenable behavior and orderBy
-            const result = whereChain()
-            const chainObj = {
-              orderBy: vi.fn(() => result),
-              then: (onFulfilled, onRejected) => Promise.resolve(result).then(onFulfilled, onRejected),
-              catch: (onRejected) => Promise.resolve(result).catch(onRejected),
-            }
-            return chainObj
-          }),
-        }
-      }),
+      from: vi.fn(() => createLegacySelectFromChain()),
     })),
     insert: vi.fn(() => ({
       values: vi.fn(() => createInsertValuesMock()),
     })),
     update: vi.fn(() => ({
-      set: vi.fn(() => ({
-        where: vi.fn((...args) => {
+      set: vi.fn((updates: Record<string, unknown>) => ({
+        where: vi.fn((...args: unknown[]) => {
           whereMock(...args)
-          return { returning: vi.fn(() => updateMock()) }
+          // Some callers chain `.returning(...)` (result rows needed); others
+          // just `await` the `.where(...)` call directly (fire-and-forget
+          // update, e.g. the "update existing member" import path in
+          // users-service.ts). Support both by making the returned object both
+          // callable via `.returning()` and directly thenable.
+          return {
+            returning: vi.fn(() => updateMock(updates)),
+            then: (onFulfilled: any, onRejected: any) => updateMock(updates).then(onFulfilled, onRejected),
+            catch: (onRejected: any) => updateMock(updates).catch(onRejected),
+          }
         }),
       })),
     })),
     delete: vi.fn(() => ({
-      where: vi.fn((...args) => {
+      where: vi.fn((...args: unknown[]) => {
         whereMock(...args)
         return createDeleteWhereReturningMock()
       }),
     })),
+    // Raw SQL execution
+    execute: vi.fn((...args: unknown[]) => {
+      executeMock(...args)
+      return Promise.resolve({ rowCount: 0 })
+    }),
     // Support db.transaction() wrapper for atomic operations.
     // The callback receives a query builder (tx) with the same chainable structure.
-    transaction: vi.fn(async (callback) => callback(createDrizzleQueryBuilder())),
+    transaction: vi.fn(async (callback: (tx: unknown) => unknown) => callback(createDrizzleQueryBuilder())),
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// STATE-DRIVEN MOCK
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/** A row in the in-memory store — plain JS, keyed by Drizzle property name. */
+export type MockRow = Record<string, unknown>
+
+/** Anything that can address a table: the Drizzle table object or its name. */
+export type TableRef = Table | string
+
+type JoinKind = 'inner' | 'left'
+type QueryOp = 'select' | 'insert' | 'update' | 'delete' | 'execute'
+
+/** One executed operation, in order. See {@link getQueryLog}. */
+export type MockQueryLogEntry = {
+  op: QueryOp
+  /** Normalised table key (lower-case, punctuation stripped), e.g. `savedgames`. */
+  table: string
+  /** Rows returned (select) or affected (insert/update/delete). */
+  rowCount: number
+}
+
+function mockError(message: string): Error {
+  return new Error(`[drizzle-mock] ${message}`)
+}
+
+// ── Store ──────────────────────────────────────────────────────────────────────
+
+const store = new Map<string, MockRow[]>()
+const queryLog: MockQueryLogEntry[] = []
+
+type FailureSpec = { op?: QueryOp; table?: string; times: number; error: unknown }
+const failures: FailureSpec[] = []
+
+/** Normalise any table reference to a single store key. */
+function tableKey(ref: TableRef): string {
+  const name = typeof ref === 'string' ? ref : getTableName(ref)
+  return String(name).toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+function ensureTable(ref: TableRef): MockRow[] {
+  const key = tableKey(ref)
+  let rows = store.get(key)
+  if (!rows) {
+    rows = []
+    store.set(key, rows)
+  }
+  return rows
+}
+
+/**
+ * Seed rows for one or more tables. Only the tables named are replaced —
+ * anything already seeded for other tables is left alone.
+ *
+ * ```typescript
+ * seed({
+ *   reservations: [{ id: 'r-1', userId: 'member-1' }],
+ *   tables: [{ id: 't-1', roomId: 'room-1' }],
+ * })
+ * ```
+ */
+export function seed(data: Record<string, MockRow[]>): void {
+  for (const [name, rows] of Object.entries(data)) seedTable(name, rows)
+}
+
+/** Seed a single table. Accepts a Drizzle table object or a table name. */
+export function seedTable(table: TableRef, rows: MockRow[]): void {
+  store.set(
+    tableKey(table),
+    rows.map((row) => ({ ...row })),
+  )
+}
+
+/** Clear the store, the query log and any injected failures. Call in `beforeEach`. */
+export function resetDb(): void {
+  store.clear()
+  queryLog.length = 0
+  failures.length = 0
+}
+
+/** Snapshot of a table's current rows — use it to assert what a write persisted. */
+export function getRows(table: TableRef): MockRow[] {
+  return (store.get(tableKey(table)) ?? []).map((row) => ({ ...row }))
+}
+
+/** Ordered log of every executed operation. Cleared by {@link resetDb}. */
+export function getQueryLog(): MockQueryLogEntry[] {
+  return queryLog.map((entry) => ({ ...entry }))
+}
+
+/**
+ * Make the next matching query reject, for error-path tests.
+ *
+ * ```typescript
+ * failNextQuery({ op: 'update', table: profiles })
+ * // the service's catch-block path is now exercised
+ * ```
+ */
+export function failNextQuery(spec: {
+  op?: QueryOp
+  table?: TableRef
+  times?: number
+  error?: unknown
+} = {}): void {
+  failures.push({
+    op: spec.op,
+    table: spec.table === undefined ? undefined : tableKey(spec.table),
+    times: spec.times ?? 1,
+    error: spec.error ?? mockError('injected query failure'),
+  })
+}
+
+function consumeFailure(op: QueryOp, table: string): void {
+  const index = failures.findIndex(
+    (failure) =>
+      failure.times > 0 &&
+      (failure.op === undefined || failure.op === op) &&
+      (failure.table === undefined || failure.table === table),
+  )
+  if (index === -1) return
+  const failure = failures[index]
+  failure.times -= 1
+  if (failure.times <= 0) failures.splice(index, 1)
+  throw failure.error instanceof Error ? failure.error : mockError(String(failure.error))
+}
+
+function snapshotStore(): Map<string, MockRow[]> {
+  const copy = new Map<string, MockRow[]>()
+  for (const [key, rows] of store) copy.set(key, rows.map((row) => ({ ...row })))
+  return copy
+}
+
+function restoreStore(snapshot: Map<string, MockRow[]>): void {
+  store.clear()
+  for (const [key, rows] of snapshot) store.set(key, rows)
+}
+
+// ── Column ↔ row-property resolution ───────────────────────────────────────────
+
+const columnKeyCache = new WeakMap<object, Map<string, string>>()
+
+/** Map a Drizzle column back to the property name its rows use (`user_id` → `userId`). */
+function columnPropertyKey(column: Column): string {
+  const table = column.table as unknown as object
+  let map = columnKeyCache.get(table)
+  if (!map) {
+    map = new Map<string, string>()
+    for (const [prop, col] of Object.entries(getTableColumns(column.table))) {
+      map.set((col as Column).name, prop)
+    }
+    columnKeyCache.set(table, map)
+  }
+  return map.get(column.name) ?? column.name
+}
+
+/** Read a column value out of a row, accepting either naming convention. */
+function readColumn(row: MockRow | null | undefined, column: Column): unknown {
+  if (row === null || row === undefined) return null
+  const prop = columnPropertyKey(column)
+  if (prop in row) return row[prop]
+  if (column.name in row) return row[column.name]
+  return null
+}
+
+/** A joined result set: normalised table key → the row contributed by that table. */
+type QueryContext = Record<string, MockRow | null>
+
+function resolveColumn(ctx: QueryContext, column: Column): unknown {
+  const key = tableKey(column.table)
+  if (!(key in ctx)) {
+    throw mockError(
+      `condition references table "${getTableName(column.table)}", which is not part of this query ` +
+        `(available: ${Object.keys(ctx).join(', ') || 'none'})`,
+    )
+  }
+  return readColumn(ctx[key], column)
+}
+
+/** Project a row down to the table's declared columns, as a real SELECT would. */
+function pickTableColumns(table: Table, row: MockRow | null | undefined): MockRow | null {
+  if (row === null || row === undefined) return null
+  const out: MockRow = {}
+  for (const [prop, col] of Object.entries(getTableColumns(table))) {
+    out[prop] = readColumn(row, col as Column)
+  }
+  return out
+}
+
+// ── SQL AST decoding ───────────────────────────────────────────────────────────
+
+type Token =
+  | { t: 'text'; v: string }
+  | { t: 'col'; v: Column }
+  | { t: 'val'; v: unknown }
+  | { t: 'list'; v: unknown[] }
+  | { t: 'sql'; v: SQL }
+
+function unwrapValue(chunk: unknown): unknown {
+  if (is(chunk, Param)) return (chunk as Param).value
+  return chunk
+}
+
+function tokenize(chunks: readonly unknown[]): Token[] {
+  const tokens: Token[] = []
+  for (const chunk of chunks) {
+    if (is(chunk, StringChunk)) {
+      const text = (chunk.value as string[]).join('').trim()
+      if (text !== '') tokens.push({ t: 'text', v: text })
+    } else if (is(chunk, Column)) {
+      tokens.push({ t: 'col', v: chunk })
+    } else if (is(chunk, Param)) {
+      tokens.push({ t: 'val', v: (chunk as Param).value })
+    } else if (is(chunk, SQL.Aliased)) {
+      tokens.push({ t: 'sql', v: (chunk as SQL.Aliased).sql })
+    } else if (is(chunk, SQL)) {
+      tokens.push({ t: 'sql', v: chunk })
+    } else if (Array.isArray(chunk)) {
+      tokens.push({ t: 'list', v: chunk.map(unwrapValue) })
+    } else {
+      tokens.push({ t: 'val', v: chunk })
+    }
+  }
+  return tokens
+}
+
+/** Best-effort rendering of a SQL node, used only for error messages. */
+function renderSql(node: SQL): string {
+  return tokenize(node.queryChunks)
+    .map((token) => {
+      switch (token.t) {
+        case 'text':
+          return token.v
+        case 'col':
+          return `${getTableName(token.v.table)}.${token.v.name}`
+        case 'sql':
+          return `(${renderSql(token.v)})`
+        case 'list':
+          return `(${token.v.map((v) => JSON.stringify(v)).join(', ')})`
+        default:
+          return JSON.stringify(token.v)
+      }
+    })
+    .join(' ')
+}
+
+// ── Value semantics ────────────────────────────────────────────────────────────
+
+function isNil(value: unknown): boolean {
+  return value === null || value === undefined
+}
+
+function asTime(value: unknown): number | null {
+  if (value instanceof Date) return value.getTime()
+  if (typeof value === 'string') {
+    const time = Date.parse(value)
+    return Number.isNaN(time) ? null : time
+  }
+  return null
+}
+
+function isNumericLike(value: unknown): boolean {
+  if (typeof value === 'number') return Number.isFinite(value)
+  if (typeof value === 'string') return value.trim() !== '' && !Number.isNaN(Number(value))
+  return false
+}
+
+/** SQL `=` semantics, tolerant of the string/number/Date shapes rows carry. */
+function looseEquals(left: unknown, right: unknown): boolean {
+  if (isNil(left) || isNil(right)) return false
+  if (left instanceof Date || right instanceof Date) {
+    const a = asTime(left)
+    const b = asTime(right)
+    return a !== null && b !== null && a === b
+  }
+  if (typeof left === typeof right) return left === right
+  if (typeof left === 'boolean' || typeof right === 'boolean') return Boolean(left) === Boolean(right)
+  if (isNumericLike(left) && isNumericLike(right)) return Number(left) === Number(right)
+  return left === right
+}
+
+/** Returns -1/0/1, or `null` when the comparison is unknown (SQL NULL). */
+function compareValues(left: unknown, right: unknown): number | null {
+  if (isNil(left) || isNil(right)) return null
+  if (left instanceof Date || right instanceof Date) {
+    const a = asTime(left)
+    const b = asTime(right)
+    if (a === null || b === null) return null
+    return a === b ? 0 : a < b ? -1 : 1
+  }
+  if (isNumericLike(left) && isNumericLike(right)) {
+    const a = Number(left)
+    const b = Number(right)
+    return a === b ? 0 : a < b ? -1 : 1
+  }
+  const a = String(left)
+  const b = String(right)
+  return a === b ? 0 : a < b ? -1 : 1
+}
+
+function likeToRegExp(pattern: string, caseInsensitive: boolean): RegExp {
+  let source = ''
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index]
+    if (char === '\\' && index + 1 < pattern.length) {
+      source += pattern[index + 1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      index += 1
+    } else if (char === '%') {
+      source += '.*'
+    } else if (char === '_') {
+      source += '.'
+    } else {
+      source += char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    }
+  }
+  return new RegExp(`^${source}$`, caseInsensitive ? 'is' : 's')
+}
+
+// ── Condition evaluation ───────────────────────────────────────────────────────
+
+/** Evaluate a Drizzle `where`/`on` condition against one joined result row. */
+function evaluateCondition(condition: unknown, ctx: QueryContext): boolean {
+  if (condition === undefined || condition === null) return true
+  if (typeof condition === 'boolean') return condition
+  if (is(condition, SQL.Aliased)) return evaluateCondition((condition as SQL.Aliased).sql, ctx)
+  if (is(condition, SQL)) return evaluateTokens(tokenize(condition.queryChunks), ctx, condition)
+  throw mockError(`unsupported condition of type ${typeof condition}`)
+}
+
+function stripOuterParens(tokens: Token[]): Token[] {
+  let current = tokens
+  while (
+    current.length >= 2 &&
+    current[0].t === 'text' &&
+    current[0].v === '(' &&
+    current[current.length - 1].t === 'text' &&
+    current[current.length - 1].v === ')'
+  ) {
+    current = current.slice(1, -1)
+  }
+  return current
+}
+
+function splitOnConnective(tokens: Token[], word: 'and' | 'or'): Token[][] | null {
+  const parts: Token[][] = []
+  let current: Token[] = []
+  let found = false
+  for (const token of tokens) {
+    if (token.t === 'text' && token.v.toLowerCase() === word) {
+      found = true
+      parts.push(current)
+      current = []
+    } else {
+      current.push(token)
+    }
+  }
+  if (!found) return null
+  parts.push(current)
+  return parts
+}
+
+function evaluateTokens(rawTokens: Token[], ctx: QueryContext, source: SQL): boolean {
+  const tokens = stripOuterParens(rawTokens)
+
+  if (tokens.length === 0) return true
+
+  if (tokens.length === 1) {
+    const only = tokens[0]
+    if (only.t === 'sql') return evaluateTokens(tokenize(only.v.queryChunks), ctx, only.v)
+    if (only.t === 'text') {
+      const literal = only.v.toLowerCase()
+      if (literal === 'true') return true
+      if (literal === 'false') return false
+    }
+    if (only.t === 'col') return Boolean(resolveColumn(ctx, only.v))
+    if (only.t === 'val') return Boolean(only.v)
+  }
+
+  // `between` embeds an " and " that is NOT a boolean connective — handle first.
+  const betweenIndex = tokens.findIndex(
+    (token) => token.t === 'text' && /^(not )?between$/.test(token.v.toLowerCase()),
+  )
+  if (betweenIndex > 0) {
+    const negated = (tokens[betweenIndex] as { v: string }).v.toLowerCase().startsWith('not')
+    const subject = evaluateOperand(tokens.slice(0, betweenIndex), ctx)
+    const rest = tokens.slice(betweenIndex + 1)
+    const andIndex = rest.findIndex((token) => token.t === 'text' && token.v.toLowerCase() === 'and')
+    if (andIndex === -1) throw mockError(`malformed BETWEEN in: ${renderSql(source)}`)
+    const lower = evaluateOperand(rest.slice(0, andIndex), ctx)
+    const upper = evaluateOperand(rest.slice(andIndex + 1), ctx)
+    const low = compareValues(subject, lower)
+    const high = compareValues(subject, upper)
+    if (low === null || high === null) return false
+    const inRange = low >= 0 && high <= 0
+    return negated ? !inRange : inRange
+  }
+
+  // `or` binds looser than `and`.
+  const orParts = splitOnConnective(tokens, 'or')
+  if (orParts) return orParts.some((part) => evaluateTokens(part, ctx, source))
+
+  const andParts = splitOnConnective(tokens, 'and')
+  if (andParts) return andParts.every((part) => evaluateTokens(part, ctx, source))
+
+  if (tokens[0].t === 'text' && tokens[0].v.toLowerCase() === 'not') {
+    return !evaluateTokens(tokens.slice(1), ctx, source)
+  }
+
+  return evaluateComparison(tokens, ctx, source)
+}
+
+function evaluateComparison(tokens: Token[], ctx: QueryContext, source: SQL): boolean {
+  const operatorIndex = tokens.findIndex((token) => token.t === 'text')
+  if (operatorIndex <= 0) throw mockError(`unsupported condition: ${renderSql(source)}`)
+
+  const operator = (tokens[operatorIndex] as { v: string }).v.toLowerCase()
+  const left = evaluateOperand(tokens.slice(0, operatorIndex), ctx)
+  const rightTokens = tokens.slice(operatorIndex + 1)
+
+  switch (operator) {
+    case 'is null':
+      return isNil(left)
+    case 'is not null':
+      return !isNil(left)
+    case 'is true':
+      return left === true
+    case 'is false':
+      return left === false
+    default:
+      break
+  }
+
+  const right = evaluateOperand(rightTokens, ctx)
+
+  switch (operator) {
+    case '=':
+      return looseEquals(left, right)
+    case '<>':
+    case '!=':
+      return !isNil(left) && !isNil(right) && !looseEquals(left, right)
+    case '>':
+    case '>=':
+    case '<':
+    case '<=': {
+      const order = compareValues(left, right)
+      if (order === null) return false
+      if (operator === '>') return order > 0
+      if (operator === '>=') return order >= 0
+      if (operator === '<') return order < 0
+      return order <= 0
+    }
+    case 'in':
+    case 'not in': {
+      const list = Array.isArray(right) ? right : [right]
+      const contained = list.some((candidate) => looseEquals(left, candidate))
+      return operator === 'in' ? contained : !isNil(left) && !contained
+    }
+    case 'like':
+    case 'not like':
+    case 'ilike':
+    case 'not ilike': {
+      if (isNil(left) || isNil(right)) return false
+      const matched = likeToRegExp(String(right), operator.includes('ilike')).test(String(left))
+      return operator.startsWith('not') ? !matched : matched
+    }
+    default:
+      throw mockError(`unsupported SQL operator "${operator}" in: ${renderSql(source)}`)
+  }
+}
+
+function evaluateOperand(tokens: Token[], ctx: QueryContext): unknown {
+  const stripped = stripOuterParens(tokens)
+  if (stripped.length !== 1) {
+    if (stripped.length === 0) return null
+    throw mockError(`unsupported compound operand with ${stripped.length} parts`)
+  }
+  const token = stripped[0]
+  switch (token.t) {
+    case 'col':
+      return resolveColumn(ctx, token.v)
+    case 'val':
+      return token.v
+    case 'list':
+      return token.v
+    case 'sql':
+      return evaluateScalar(token.v, ctx)
+    default:
+      throw mockError(`unsupported operand "${token.v}"`)
+  }
+}
+
+/** Evaluate a non-aggregate scalar expression (projection field, `.set()` value). */
+function evaluateScalar(node: SQL, ctx: QueryContext): unknown {
+  const tokens = stripOuterParens(tokenize(node.queryChunks))
+
+  if (tokens.length === 1) {
+    const only = tokens[0]
+    if (only.t === 'col') return resolveColumn(ctx, only.v)
+    if (only.t === 'val') return only.v
+    if (only.t === 'sql') return evaluateScalar(only.v, ctx)
+    if (only.t === 'text') {
+      const literal = only.v.toLowerCase()
+      if (literal === 'null') return null
+      if (literal === 'true') return true
+      if (literal === 'false') return false
+      if (literal === 'now()' || literal === 'current_timestamp') return new Date()
+      if (literal === 'gen_random_uuid()' || literal === 'uuid_generate_v4()') return randomUuid()
+    }
+  }
+
+  // Single-argument functions: `lower(x)`, `upper(x)`, `trim(x)`.
+  if (tokens.length === 3 && tokens[0].t === 'text' && tokens[2].t === 'text' && tokens[2].v === ')') {
+    const fn = tokens[0].v.toLowerCase()
+    const argument = evaluateOperand([tokens[1]], ctx)
+    if (fn === 'lower(') return isNil(argument) ? null : String(argument).toLowerCase()
+    if (fn === 'upper(') return isNil(argument) ? null : String(argument).toUpperCase()
+    if (fn === 'trim(') return isNil(argument) ? null : String(argument).trim()
+  }
+
+  // Binary arithmetic / concatenation.
+  if (tokens.length === 3 && tokens[1].t === 'text') {
+    const operator = tokens[1].v
+    const left = evaluateOperand([tokens[0]], ctx)
+    const right = evaluateOperand([tokens[2]], ctx)
+    if (operator === '||') return `${left ?? ''}${right ?? ''}`
+    if (['+', '-', '*', '/'].includes(operator)) {
+      if (isNil(left) || isNil(right)) return null
+      const a = Number(left)
+      const b = Number(right)
+      if (operator === '+') return a + b
+      if (operator === '-') return a - b
+      if (operator === '*') return a * b
+      return b === 0 ? null : a / b
+    }
+  }
+
+  throw mockError(
+    `unsupported SQL expression: ${renderSql(node)}. ` +
+      'Extend tests/unit/mocks/drizzle-mock.ts rather than working around it.',
+  )
+}
+
+// ── Aggregates ─────────────────────────────────────────────────────────────────
+
+type AggregateSpec = { fn: 'count' | 'sum' | 'avg' | 'min' | 'max'; column: Column | null }
+
+function detectAggregate(value: unknown): AggregateSpec | null {
+  const node = is(value, SQL.Aliased) ? (value as SQL.Aliased).sql : value
+  if (!is(node, SQL)) return null
+  const tokens = tokenize((node as SQL).queryChunks)
+  if (tokens.length === 0 || tokens[0].t !== 'text') return null
+  const match = /^(count|sum|avg|min|max)\($/i.exec(tokens[0].v)
+  if (!match) return null
+  const argument = tokens[1]
+  const column = argument !== undefined && argument.t === 'col' ? argument.v : null
+  return { fn: match[1].toLowerCase() as AggregateSpec['fn'], column }
+}
+
+function computeAggregate(spec: AggregateSpec, group: QueryContext[]): unknown {
+  if (spec.fn === 'count') {
+    if (spec.column === null) return group.length
+    return group.filter((ctx) => !isNil(resolveColumn(ctx, spec.column as Column))).length
+  }
+  const values = group
+    .map((ctx) => (spec.column === null ? null : resolveColumn(ctx, spec.column)))
+    .filter((value) => !isNil(value))
+  if (values.length === 0) return null
+  if (spec.fn === 'min') return values.reduce((a, b) => ((compareValues(b, a) ?? 0) < 0 ? b : a))
+  if (spec.fn === 'max') return values.reduce((a, b) => ((compareValues(b, a) ?? 0) > 0 ? b : a))
+  const numbers = values.map((value) => Number(value))
+  const total = numbers.reduce((a, b) => a + b, 0)
+  return spec.fn === 'sum' ? total : total / numbers.length
+}
+
+// ── Projection ─────────────────────────────────────────────────────────────────
+
+type FieldMap = Record<string, unknown>
+
+function projectFields(fields: FieldMap, ctx: QueryContext): MockRow {
+  const out: MockRow = {}
+  for (const [key, value] of Object.entries(fields)) {
+    if (is(value, Column)) out[key] = resolveColumn(ctx, value)
+    else if (is(value, SQL.Aliased)) out[key] = evaluateScalar((value as SQL.Aliased).sql, ctx)
+    else if (is(value, SQL)) out[key] = evaluateScalar(value, ctx)
+    else if (is(value, Table)) out[key] = pickTableColumns(value, ctx[tableKey(value)])
+    else if (value !== null && typeof value === 'object') out[key] = projectFields(value as FieldMap, ctx)
+    else out[key] = value
+  }
+  return out
+}
+
+// ── Defaults for INSERT ────────────────────────────────────────────────────────
+
+function randomUuid(): string {
+  const cryptoRef = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto
+  if (cryptoRef?.randomUUID) return cryptoRef.randomUUID()
+  return `mock-${Math.random().toString(16).slice(2)}${Date.now().toString(16)}`
+}
+
+function columnDefault(column: Column): unknown {
+  const meta = column as unknown as { defaultFn?: () => unknown; hasDefault?: boolean; default?: unknown }
+  if (typeof meta.defaultFn === 'function') return meta.defaultFn()
+  if (!meta.hasDefault) return null
+  const value = meta.default
+  if (is(value, SQL)) {
+    try {
+      return evaluateScalar(value as SQL, {})
+    } catch {
+      return null
+    }
+  }
+  return value ?? null
+}
+
+/** Build a stored row from `.values()` input: map keys, then fill schema defaults. */
+function materializeInsertRow(table: Table, values: MockRow): MockRow {
+  const row: MockRow = {}
+  const columns = Object.entries(getTableColumns(table)) as Array<[string, Column]>
+  const consumed = new Set<string>()
+
+  for (const [prop, column] of columns) {
+    let raw: unknown
+    if (prop in values) {
+      raw = values[prop]
+      consumed.add(prop)
+    } else if (column.name in values) {
+      raw = values[column.name]
+      consumed.add(column.name)
+    } else {
+      row[prop] = columnDefault(column)
+      continue
+    }
+    row[prop] = is(raw, SQL) ? evaluateScalar(raw as SQL, {}) : raw
+  }
+
+  // Keep any extra keys the caller passed (e.g. a column not in the schema yet)
+  // so tests that assert on them do not silently lose data.
+  for (const [key, value] of Object.entries(values)) {
+    if (!consumed.has(key) && !(key in row)) row[key] = value
+  }
+  return row
+}
+
+function applyUpdateValues(table: Table, row: MockRow, values: MockRow): void {
+  const columns = getTableColumns(table) as Record<string, Column>
+  const byColumnName = new Map<string, string>()
+  for (const [prop, column] of Object.entries(columns)) byColumnName.set(column.name, prop)
+
+  for (const [key, value] of Object.entries(values)) {
+    const prop = key in columns ? key : (byColumnName.get(key) ?? key)
+    const ctx: QueryContext = { [tableKey(table)]: row }
+    row[prop] = is(value, SQL) ? evaluateScalar(value as SQL, ctx) : value
+  }
+}
+
+// ── Builders ───────────────────────────────────────────────────────────────────
+
+type JoinSpec = { table: Table; on: unknown; kind: JoinKind }
+type OrderSpec = { column: Column; direction: 'asc' | 'desc' }
+
+function parseOrderBy(expression: unknown): OrderSpec {
+  if (is(expression, Column)) return { column: expression, direction: 'asc' }
+  const node = is(expression, SQL.Aliased) ? (expression as SQL.Aliased).sql : expression
+  if (!is(node, SQL)) throw mockError('unsupported orderBy expression')
+  const tokens = tokenize((node as SQL).queryChunks)
+  const columnToken = tokens.find((token) => token.t === 'col')
+  if (!columnToken || columnToken.t !== 'col') {
+    throw mockError(`unsupported orderBy expression: ${renderSql(node as SQL)}`)
+  }
+  const descending = tokens.some((token) => token.t === 'text' && token.v.toLowerCase().includes('desc'))
+  return { column: columnToken.v, direction: descending ? 'desc' : 'asc' }
+}
+
+class MockSelectBuilder {
+  private fields: FieldMap | undefined
+  private distinct: boolean
+  private table: Table | null = null
+  private joins: JoinSpec[] = []
+  private condition: unknown = undefined
+  private orders: OrderSpec[] = []
+  private groups: Column[] = []
+  private limitValue: number | undefined
+  private offsetValue: number | undefined
+
+  constructor(fields: FieldMap | undefined, distinct: boolean) {
+    this.fields = fields
+    this.distinct = distinct
+  }
+
+  from(table: Table): this {
+    this.table = table
+    return this
+  }
+
+  innerJoin(table: Table, on: unknown): this {
+    this.joins.push({ table, on, kind: 'inner' })
+    return this
+  }
+
+  leftJoin(table: Table, on: unknown): this {
+    this.joins.push({ table, on, kind: 'left' })
+    return this
+  }
+
+  rightJoin(): never {
+    throw mockError('rightJoin() is not supported — use leftJoin() with the tables swapped')
+  }
+
+  fullJoin(): never {
+    throw mockError('fullJoin() is not supported')
+  }
+
+  where(condition: unknown): this {
+    whereMock(condition)
+    this.condition = condition
+    return this
+  }
+
+  orderBy(...expressions: unknown[]): this {
+    this.orders = expressions.filter((expression) => expression !== undefined).map(parseOrderBy)
+    return this
+  }
+
+  groupBy(...columns: unknown[]): this {
+    this.groups = columns.map((column) => {
+      if (is(column, Column)) return column
+      throw mockError('groupBy() only supports plain columns')
+    })
+    return this
+  }
+
+  having(): never {
+    throw mockError('having() is not supported')
+  }
+
+  limit(value: number): this {
+    this.limitValue = value
+    return this
+  }
+
+  offset(value: number): this {
+    this.offsetValue = value
+    return this
+  }
+
+  execute(): Promise<MockRow[]> {
+    return this.run()
+  }
+
+  then<TResult1 = MockRow[], TResult2 = never>(
+    onFulfilled?: ((value: MockRow[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.run().then(onFulfilled, onRejected)
+  }
+
+  catch<TResult = never>(
+    onRejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null,
+  ): Promise<MockRow[] | TResult> {
+    return this.run().catch(onRejected)
+  }
+
+  finally(onFinally?: (() => void) | null): Promise<MockRow[]> {
+    return this.run().finally(onFinally)
+  }
+
+  private async run(): Promise<MockRow[]> {
+    if (this.table === null) throw mockError('select() was awaited without .from(table)')
+    const baseKey = tableKey(this.table)
+    consumeFailure('select', baseKey)
+
+    let contexts: QueryContext[] = ensureTable(this.table).map((row) => ({ [baseKey]: row }))
+
+    for (const join of this.joins) {
+      const joinKey = tableKey(join.table)
+      const joinRows = ensureTable(join.table)
+      const next: QueryContext[] = []
+      for (const ctx of contexts) {
+        let matched = false
+        for (const joinRow of joinRows) {
+          const candidate: QueryContext = { ...ctx, [joinKey]: joinRow }
+          if (evaluateCondition(join.on, candidate)) {
+            next.push(candidate)
+            matched = true
+          }
+        }
+        if (!matched && join.kind === 'left') next.push({ ...ctx, [joinKey]: null })
+      }
+      contexts = next
+    }
+
+    if (this.condition !== undefined) {
+      contexts = contexts.filter((ctx) => evaluateCondition(this.condition, ctx))
+    }
+
+    const rows = this.hasAggregate() ? this.projectAggregated(contexts) : this.projectRows(contexts)
+    queryLog.push({ op: 'select', table: baseKey, rowCount: rows.length })
+    return rows
+  }
+
+  private hasAggregate(): boolean {
+    if (this.fields === undefined) return false
+    return Object.values(this.fields).some((value) => detectAggregate(value) !== null)
+  }
+
+  private projectAggregated(contexts: QueryContext[]): MockRow[] {
+    const fields = this.fields as FieldMap
+    const groups: QueryContext[][] =
+      this.groups.length === 0
+        ? [contexts]
+        : Array.from(
+            contexts
+              .reduce((map, ctx) => {
+                const key = JSON.stringify(this.groups.map((column) => resolveColumn(ctx, column)))
+                const bucket = map.get(key)
+                if (bucket) bucket.push(ctx)
+                else map.set(key, [ctx])
+                return map
+              }, new Map<string, QueryContext[]>())
+              .values(),
+          )
+
+    return groups.map((group) => {
+      const out: MockRow = {}
+      for (const [key, value] of Object.entries(fields)) {
+        const aggregate = detectAggregate(value)
+        if (aggregate) {
+          out[key] = computeAggregate(aggregate, group)
+        } else if (is(value, Column)) {
+          out[key] = group.length > 0 ? resolveColumn(group[0], value) : null
+        } else {
+          out[key] = group.length > 0 ? projectFields({ value }, group[0]).value : null
+        }
+      }
+      return out
+    })
+  }
+
+  private projectRows(contexts: QueryContext[]): MockRow[] {
+    let ordered = contexts
+    if (this.orders.length > 0) {
+      ordered = [...contexts].sort((left, right) => {
+        for (const order of this.orders) {
+          const a = resolveColumn(left, order.column)
+          const b = resolveColumn(right, order.column)
+          if (isNil(a) && isNil(b)) continue
+          if (isNil(a)) return 1
+          if (isNil(b)) return -1
+          const result = compareValues(a, b) ?? 0
+          if (result !== 0) return order.direction === 'desc' ? -result : result
+        }
+        return 0
+      })
+    }
+
+    const start = this.offsetValue ?? 0
+    const end = this.limitValue === undefined ? undefined : start + this.limitValue
+    const page = ordered.slice(start, end)
+
+    const projected = page.map((ctx) => this.projectOne(ctx))
+    if (!this.distinct) return projected
+
+    const seen = new Set<string>()
+    return projected.filter((row) => {
+      const key = JSON.stringify(row)
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+  }
+
+  private projectOne(ctx: QueryContext): MockRow {
+    const table = this.table as Table
+    if (this.fields !== undefined) return projectFields(this.fields, ctx)
+    if (this.joins.length === 0) return pickTableColumns(table, ctx[tableKey(table)]) ?? {}
+    const out: MockRow = {}
+    out[String(getTableName(table))] = pickTableColumns(table, ctx[tableKey(table)])
+    for (const join of this.joins) {
+      out[String(getTableName(join.table))] = pickTableColumns(join.table, ctx[tableKey(join.table)])
+    }
+    return out
+  }
+}
+
+type ConflictTarget = { columns: Column[]; set?: MockRow; action: 'nothing' | 'update' } | null
+
+class MockInsertBuilder {
+  private table: Table
+  private rows: MockRow[] = []
+  private conflict: ConflictTarget = null
+  private returningFields: FieldMap | undefined
+  private wantsReturning = false
+
+  constructor(table: Table) {
+    this.table = table
+  }
+
+  values(input: MockRow | MockRow[]): this {
+    this.rows = Array.isArray(input) ? input : [input]
+    return this
+  }
+
+  onConflictDoNothing(config?: { target?: Column | Column[] }): this {
+    this.conflict = { columns: normalizeTarget(config?.target), action: 'nothing' }
+    return this
+  }
+
+  onConflictDoUpdate(config: { target?: Column | Column[]; set: MockRow }): this {
+    this.conflict = { columns: normalizeTarget(config.target), set: config.set, action: 'update' }
+    return this
+  }
+
+  returning(fields?: FieldMap): this {
+    this.wantsReturning = true
+    this.returningFields = fields
+    return this
+  }
+
+  execute(): Promise<MockRow[]> {
+    return this.run()
+  }
+
+  then<TResult1 = MockRow[], TResult2 = never>(
+    onFulfilled?: ((value: MockRow[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.run().then(onFulfilled, onRejected)
+  }
+
+  catch<TResult = never>(
+    onRejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null,
+  ): Promise<MockRow[] | TResult> {
+    return this.run().catch(onRejected)
+  }
+
+  finally(onFinally?: (() => void) | null): Promise<MockRow[]> {
+    return this.run().finally(onFinally)
+  }
+
+  private async run(): Promise<MockRow[]> {
+    const key = tableKey(this.table)
+    consumeFailure('insert', key)
+    const stored = ensureTable(this.table)
+    const touched: MockRow[] = []
+
+    for (const input of this.rows) {
+      const candidate = materializeInsertRow(this.table, input)
+      const existing =
+        this.conflict !== null && this.conflict.columns.length > 0
+          ? stored.find((row) =>
+              (this.conflict as { columns: Column[] }).columns.every((column) =>
+                looseEquals(readColumn(row, column), readColumn(candidate, column)),
+              ),
+            )
+          : undefined
+
+      if (existing !== undefined && this.conflict !== null) {
+        // An existing row matched the conflict target: this is an UPDATE, not
+        // an INSERT. Deciding it here (against the store, at execution time)
+        // is what keeps interleaved create/update flows correct.
+        if (this.conflict.action === 'update' && this.conflict.set) {
+          applyUpdateValues(this.table, existing, this.conflict.set)
+          touched.push(existing)
+        }
+        continue
+      }
+
+      stored.push(candidate)
+      touched.push(candidate)
+    }
+
+    queryLog.push({ op: 'insert', table: key, rowCount: touched.length })
+    if (!this.wantsReturning) return []
+    return touched.map((row) => this.project(row))
+  }
+
+  private project(row: MockRow): MockRow {
+    const ctx: QueryContext = { [tableKey(this.table)]: row }
+    if (this.returningFields !== undefined) return projectFields(this.returningFields, ctx)
+    return pickTableColumns(this.table, row) ?? {}
+  }
+}
+
+function normalizeTarget(target: Column | Column[] | undefined): Column[] {
+  if (target === undefined) return []
+  return Array.isArray(target) ? target : [target]
+}
+
+class MockUpdateBuilder {
+  private table: Table
+  private values: MockRow
+  private condition: unknown = undefined
+  private returningFields: FieldMap | undefined
+  private wantsReturning = false
+
+  constructor(table: Table, values: MockRow) {
+    this.table = table
+    this.values = values
+  }
+
+  where(condition: unknown): this {
+    whereMock(condition)
+    this.condition = condition
+    return this
+  }
+
+  returning(fields?: FieldMap): this {
+    this.wantsReturning = true
+    this.returningFields = fields
+    return this
+  }
+
+  execute(): Promise<MockRow[]> {
+    return this.run()
+  }
+
+  then<TResult1 = MockRow[], TResult2 = never>(
+    onFulfilled?: ((value: MockRow[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.run().then(onFulfilled, onRejected)
+  }
+
+  catch<TResult = never>(
+    onRejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null,
+  ): Promise<MockRow[] | TResult> {
+    return this.run().catch(onRejected)
+  }
+
+  finally(onFinally?: (() => void) | null): Promise<MockRow[]> {
+    return this.run().finally(onFinally)
+  }
+
+  private async run(): Promise<MockRow[]> {
+    const key = tableKey(this.table)
+    consumeFailure('update', key)
+    const stored = ensureTable(this.table)
+    // An UPDATE only ever touches rows that already exist — it never creates
+    // one, even if the where-clause matches nothing.
+    const matched = stored.filter((row) => evaluateCondition(this.condition, { [key]: row }))
+    for (const row of matched) applyUpdateValues(this.table, row, this.values)
+
+    queryLog.push({ op: 'update', table: key, rowCount: matched.length })
+    if (!this.wantsReturning) return []
+    return matched.map((row) => {
+      const ctx: QueryContext = { [key]: row }
+      if (this.returningFields !== undefined) return projectFields(this.returningFields, ctx)
+      return pickTableColumns(this.table, row) ?? {}
+    })
+  }
+}
+
+class MockDeleteBuilder {
+  private table: Table
+  private condition: unknown = undefined
+  private returningFields: FieldMap | undefined
+  private wantsReturning = false
+
+  constructor(table: Table) {
+    this.table = table
+  }
+
+  where(condition: unknown): this {
+    whereMock(condition)
+    this.condition = condition
+    return this
+  }
+
+  returning(fields?: FieldMap): this {
+    this.wantsReturning = true
+    this.returningFields = fields
+    return this
+  }
+
+  execute(): Promise<MockRow[]> {
+    return this.run()
+  }
+
+  then<TResult1 = MockRow[], TResult2 = never>(
+    onFulfilled?: ((value: MockRow[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.run().then(onFulfilled, onRejected)
+  }
+
+  catch<TResult = never>(
+    onRejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null,
+  ): Promise<MockRow[] | TResult> {
+    return this.run().catch(onRejected)
+  }
+
+  finally(onFinally?: (() => void) | null): Promise<MockRow[]> {
+    return this.run().finally(onFinally)
+  }
+
+  private async run(): Promise<MockRow[]> {
+    const key = tableKey(this.table)
+    consumeFailure('delete', key)
+    const stored = ensureTable(this.table)
+    const removed: MockRow[] = []
+    for (let index = stored.length - 1; index >= 0; index -= 1) {
+      if (evaluateCondition(this.condition, { [key]: stored[index] })) {
+        removed.unshift(stored[index])
+        stored.splice(index, 1)
+      }
+    }
+
+    queryLog.push({ op: 'delete', table: key, rowCount: removed.length })
+    if (!this.wantsReturning) return []
+    return removed.map((row) => {
+      const ctx: QueryContext = { [key]: row }
+      if (this.returningFields !== undefined) return projectFields(this.returningFields, ctx)
+      return pickTableColumns(this.table, row) ?? {}
+    })
+  }
+}
+
+/** The mock `db` object handed to `vi.mock('@/lib/db')`. */
+export type StatefulDrizzleDb = ReturnType<typeof createStatefulDrizzleDb>
+
+/**
+ * Create a state-driven Drizzle db mock backed by the shared in-memory store.
+ *
+ * Every call returns an independent builder that captures its own table,
+ * values and conditions and resolves them against the store *at await time* —
+ * so interleaved and concurrent queries cannot steal each other's results, and
+ * a write is visible to any read that happens after it.
+ */
+export function createStatefulDrizzleDb() {
+  return {
+    select: vi.fn((fields?: FieldMap) => new MockSelectBuilder(fields, false)),
+    selectDistinct: vi.fn((fields?: FieldMap) => new MockSelectBuilder(fields, true)),
+    insert: vi.fn((table: Table) => new MockInsertBuilder(table)),
+    update: vi.fn((table: Table) => ({
+      set: vi.fn((values: MockRow) => new MockUpdateBuilder(table, values)),
+    })),
+    delete: vi.fn((table: Table) => new MockDeleteBuilder(table)),
+    execute: vi.fn((...args: unknown[]) => {
+      queryLog.push({ op: 'execute', table: '', rowCount: 0 })
+      const result = executeMock(...args)
+      return Promise.resolve(result ?? { rows: [], rowCount: 0 })
+    }),
+    /**
+     * Runs `callback` against the same store. If it throws, every write made
+     * inside is rolled back before the error propagates.
+     */
+    transaction: vi.fn(async <T>(callback: (tx: StatefulDrizzleDb) => Promise<T> | T): Promise<T> => {
+      const snapshot = snapshotStore()
+      try {
+        return await callback(createStatefulDrizzleDb())
+      } catch (error) {
+        restoreStore(snapshot)
+        throw error
+      }
+    }),
   }
 }


### PR DESCRIPTION
## Problem

`tests/unit/mocks/drizzle-mock.ts` resolved every query by **call sequence** (`mockResolvedValueOnce` queued in the order calls were expected to happen). That model cannot represent a service that issues more than one DB call whose order is not statically fixed: concurrent `Promise.all` reads, a write followed by a read of the same table, or a conditional branch that skips a query all shift the queue and make an unrelated assertion fail. Worse, when the queue desynchronised the mock did not fail loudly — it handed the caller **another query's rows**, so a test could pass while asserting on data the service never fetched.

Four migration lanes were blocked on this at once, each re-deriving its own private fork of the helper (the usual anti-pattern: copy the mock from the most broken file, inherit its defect). Roughly **700k tokens** were burned across those lanes fighting the harness rather than the migration.

This PR makes the helper **state-driven and single-owner**: one in-memory store, queries resolved against it *at await time*.

## What changed

Two files, both under `tests/`. **No production code is touched.**

- `tests/unit/mocks/drizzle-mock.ts` (+1413 / -115) — rewritten around a `Map`-keyed in-memory row store plus an evaluator over Drizzle's own `SQL` condition AST (using `drizzle-orm` introspection symbols: `Column`, `Param`, `SQL`, `StringChunk`, `Table`, `getTableColumns`, `getTableName`, `is`).
- `tests/unit/mocks/drizzle-mock.test.ts` (new, 856 lines, 44 tests) — spec for the helper itself.

There is **no database here**: no pglite, no embedded or containerised Postgres, no SQL engine, no test DB, no live connection. `package.json` and `pnpm-lock.yaml` are unmodified; no dependency, script or postinstall hook was added.

## Public API

```ts
createStatefulDrizzleDb(): StatefulDrizzleDb   // hand to vi.mock('@/lib/db')
seed(data: Record<string, MockRow[]>): void    // replaces only the tables named
seedTable(table: TableRef, rows: MockRow[]): void
resetDb(): void                                // store + query log + injected failures
getRows(table: TableRef): MockRow[]            // snapshot, for post-write assertions
getQueryLog(): MockQueryLogEntry[]             // { op, table, rowCount }[] in order
failNextQuery(spec?: { op?: 'select'|'insert'|'update'|'delete'|'execute';
                       table?: TableRef; times?: number; error?: unknown }): void

type MockRow  = Record<string, unknown>
type TableRef = Table | string                 // Drizzle table object OR name
```

**Supported chain surface**

- `select()` / `select(fields)` / `selectDistinct()`, `.from`, `.innerJoin`/`.leftJoin` chained N times, `.where(cond | undefined)`, `.orderBy`, `.groupBy`, `.limit`, `.offset`, then `.execute()` or a plain `await`
- `insert().values()[.onConflictDoNothing() | .onConflictDoUpdate()][.returning()]`
- `update().set().where()[.returning()]` — awaitable without `.returning()`
- `delete().where()[.returning()]`
- `transaction(cb)` with rollback on throw

**Conditions:** `eq ne gt gte lt lte and or not inArray notInArray isNull isNotNull between notBetween like notLike ilike notIlike`, plus column-to-column comparisons.
**Aggregates:** `count()`, `count(col)`, `sum`, `avg`, `min`, `max`.

Schema defaults are applied on insert. `TableRef` normalises `'saved_games'`, `'savedGames'` and the table object to a single store entry; row keys accept either the Drizzle property name or the DB column name.

### For KIM-438 specifically — failure injection and rollback

The lane reported needing mid-transaction-failure simulation. Both capabilities exist:

- `failNextQuery({ op, table, times, error })` makes the *next* matching query (optionally the next `times` of them) reject with `error`, so a failure can be aimed at one specific statement inside a transaction rather than the whole callback.
- `transaction(cb)` snapshots the store copy-on-write and restores it if `cb` throws, so post-rollback state can be asserted with `getRows()`.

## Deliberately unsupported — these throw

Anything outside the surface above raises a named `[drizzle-mock] …` error rather than silently returning wrong rows. That is the entire point of the ticket: a mock that quietly returns the wrong data is worse than one that fails. Verified to throw: `rightJoin()`, `fullJoin()`, `.having()`, window functions (e.g. `row_number() over (…)`), non-column `groupBy`, unknown SQL operators, unparseable `orderBy`, and conditions referencing a table not part of the query.

**`db.execute(sql)` is the one documented exception and does *not* throw.** It is recorded in the query log and delegates to `executeMock`; when `executeMock` is unconfigured it resolves to `{ rows: [], rowCount: 0 }`. The store is not consulted, because arbitrary SQL cannot be evaluated without a SQL engine. Tests that rely on `db.execute` must configure `executeMock` explicitly.

Column-level constraints (`notNull`, unique indexes, FKs) are not enforced.

### Known gap for the migrating lanes

A **subquery passed as the right-hand operand of a comparison** — e.g. `inArray(col, db.select(...))` — is currently evaluated as an opaque value and yields **`[]` silently** instead of throwing. `exists(subquery)` does fail, but via a `Converting circular structure to JSON` error from the message renderer rather than a clean `[drizzle-mock]` message. No code in `lib/` or `app/` uses subqueries, CTEs or `EXISTS` today, so this is unreachable in the suites being migrated — but if a lane introduces one, it will get empty rows rather than a diagnostic. Tracked as follow-up; do not build on subquery support.

## Backward compatibility

The legacy sequence-driven mock is retained unchanged. All nine exports that `develop` actually consumes still exist: `selectMock`, `insertMock`, `updateMock`, `deleteMock`, `whereMock`, `SessionUser`, `createAdminSession`, `createMemberSession`, `createDrizzleQueryBuilder`. Symbols dropped from the parked forks have zero references on `develop`.

## Validation

Literal output on this branch:

```
pnpm test   →  Test Files  77 passed (77) /  Tests  1214 passed (1214)
typecheck   →  npx tsc --noEmit, exit 0, no output
lint        →  ✔ No ESLint warnings or errors
build       →  ✓ Compiled successfully, BUILD_EXIT=0
```

The pre-push hook ran full local CI and passed; `--no-verify` was not used.

**Test-count accounting:** develop 1170 → branch 1214, delta **+44**. `tests/unit/mocks/drizzle-mock.test.ts` is the only test file added or modified in the diff and contains exactly 44 `it(` blocks, so no pre-existing file's count changed.

The new assertions were mutation-tested rather than assumed meaningful: disabling conflict detection, `.offset()`, and the where-filter each broke the tests that claim to cover them; the helper was then restored byte-identical.

## Unblocks

Closes KIM-443

- KIM-438 https://linear.app/kimox-studio/issue/KIM-438
- KIM-439 https://linear.app/kimox-studio/issue/KIM-439
- KIM-440 https://linear.app/kimox-studio/issue/KIM-440
- KIM-441 https://linear.app/kimox-studio/issue/KIM-441


---

# Rebasing onto this branch — read before you start

## Take this file wholesale. Do not hand-merge.

If your branch carries its own commit to `tests/unit/mocks/drizzle-mock.ts`, **drop that commit before rebasing**, then resolve with `git checkout --ours tests/unit/mocks/drizzle-mock.ts`. Every functional capability the four forks added is already in this file.

**Git will not warn you if you skip this.** `git merge-tree` auto-merges the two versions with **no conflict markers at all** (exit 0). Nobody gets a conflict prompt. You get a clean-looking 2183-line file declaring 11 symbols twice, and it only surfaces at typecheck:

```
error TS2300: Duplicate identifier 'MockServiceError'.
error TS2323: Cannot redeclare exported variable 'createMockServiceError'.
error TS2393: Duplicate function implementation.
```

Verified on a clean checkout of this branch alone: 23 exports, zero repeats, no `export { ... }` lists, no `export default`, `pnpm typecheck` exit 0. The duplication is a rebase artefact, not a defect here — one lane rebased with its own frozen helper commit and hit the wall, another rebased without one and did not.

The colliding symbols are **not** the ones the forks added (`setUpdateFixture` / `setDeleteFixture` are unique names; `createDispatchingUpdateMock` / `createDispatchingDeleteMock` are file-local and never exported). They are the ones the old fixture file already shared with this one: `selectMock, insertMock, updateMock, deleteMock, whereMock, SessionUser, createAdminSession, createMemberSession, MockServiceError, createMockServiceError, createDrizzleQueryBuilder`.

## The fixture-queue API is dropped deliberately, not shimmed

`setFixture`, `setInsertFixture`, `setUpdateFixture`, `setDeleteFixture`, `setDefaultMockResponse`, `resetFixtures`, `getFixtureState`, `createDrizzleQueryBuilderWithDispatching`, `createTransactionAwareMockBuilder`, `createTransactionScopedBuilder` do **not** exist on `develop` — zero references anywhere, including develop's own copy of the mock. They only ever lived on the parked lanes, so there is nothing to keep backward-compatible, and a shim would preserve the very design that caused this ticket.

Your test files rewrite their fixture calls to seeded state. That is a real one-time cost per lane, stated up front rather than discovered mid-rebase.

The nine exports `develop` actually uses are preserved unchanged: `selectMock, insertMock, updateMock, deleteMock, whereMock, SessionUser, createAdminSession, createMemberSession, createDrizzleQueryBuilder`.

---

# Two sharp edges

Both are fine for sequential services and both are landmines otherwise:

1. **`db` and `adminDb` from two separate `createStatefulDrizzleDb()` calls share one module-level store.** A write through one is visible through the other.
2. **Rollback restores the whole store.** A write issued *outside* a transaction while that transaction was running is also discarded when it rolls back.

Do not write `Promise.all([db.transaction(...), db.insert(...)])`.

One practical note for anyone writing cross-run store comparisons: drop `defaultNow()` columns (`createdAt` / `updatedAt`) before comparing. They carry the wall clock and differ by milliseconds between runs. Assert their presence separately.

---

# Is the design actually proven?

Two independent answers, because "it has no consumers yet" is a fair thing to ask of 1400 lines of test infrastructure.

**A real service test file already runs on it.** KIM-441 rewrote `tests/unit/server/saved-games-service.test.ts` against the state-driven API: `8/8` on that file, `34/34` on `oir208-unified-events.test.ts`, full suite green, security-approved. That is the file that defeated three prior attempts under the sequence-based design — its `savedGamesJoinedQuery()` chains `.innerJoin().innerJoin()`, which the old mock could not express. The proof lives on that lane's branch rather than here, deliberately: migrating a lane's file into this PR would duplicate that lane's work.

**Order-independence under concurrency is proven here.** This is the criterion that motivated the whole redesign — `importMembersFromCsv` runs at `concurrencyLimit = 10`, so there is no call order to queue `mockResolvedValueOnce` against. The spec now runs the same 10 select-then-update flows (5 rows that exist, 5 that do not) under forward, reversed and shuffled arrival orders and asserts the final store and every per-flow result are identical across all three. Flows yield between their read and their write so writes genuinely land between other flows' reads, arrival orders are fixed permutations rather than `Math.random()` so any failure is reproducible, and the test asserts the three query-log signatures actually differ — otherwise "identical outcome" would be trivially true.

These tests were mutation-checked, not assumed. Injecting an order-dependence defect into the where-evaluator turns 5 tests red; resolving writes against a builder-construction-time snapshot instead of await time turns 1 red; applying a write column-by-column with a yield turns 1 red. The last two are caught **only** by the new tests — those two failure modes were previously undefended. One mutation (a cursor-dependent delay) did not flip the same-column-write test; probed in isolation, the delay genuinely does not change that schedule's observable outcome, so there was nothing to catch. Reported rather than papered over. The helper was restored byte-identical after every mutation (SHA256 verified).

---

# Validation

```
Test Files  77 passed (77)
     Tests  1231 passed (1231)
typecheck   exit 0, no diagnostics
lint        ✔ No ESLint warnings or errors
build       ✓ Compiled successfully, exit 0
```

Test counts: `develop` 1170 → this branch 1231. The entire delta is `tests/unit/mocks/drizzle-mock.test.ts` (61 tests), a new file covering new infrastructure. No pre-existing test file's count changed, and no test was deleted or weakened.

Commits: `be153f0` state-driven helper · `1e8b119` `execute()` failure injection fix · `ae1d254` its regression test · `52b9327` order-independence coverage.
