### PR TITLE
feat(auth): replace Auth.js runtime with Clerk (KIM-451)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,21 +18,17 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=sb_publishable_xxxxxxxxxxxxxxxx
 SUPABASE_SECRET_DEFAULT_KEY=sb_secret_xxxxxxxxxxxxxxxx
 
 # ============================================================
-# AUTH.JS (NextAuth v5) — transitional scaffolding scheduled for removal
-# KIM-451 replaces Auth.js with Clerk. Keep this legacy route disabled.
+# CLERK
+# Dashboard: dashboard.clerk.com → Configure → API keys
 # ============================================================
 
-# Keeps `/api/authjs/*` returning 404 until explicitly set to "true". This is
-# a safety gate, not a launch switch. Leave it false in every environment;
-# KIM-451 removes the route instead of activating it.
-AUTH_JS_ENABLED=false
+# Publishable key — safe to expose in the browser
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 
-# Secret used to sign/encrypt Auth.js JWTs and cookies. Generate with:
-# openssl rand -base64 32
-AUTH_SECRET=your-random-auth-secret
+# Secret key — SERVER ONLY, never expose to the browser
+CLERK_SECRET_KEY=
 
-# Target Postgres (Neon / Vercel Postgres) connection string, used by the
-# Auth.js Credentials provider to look up `profiles.password_hash`.
+# Target Postgres (Neon / Vercel Postgres) connection string.
 # Pooled connection string (e.g. Vercel Postgres "POSTGRES_URL").
 POSTGRES_URL=
 

--- a/app/api/auth/activate/route.ts
+++ b/app/api/auth/activate/route.ts
@@ -25,21 +25,16 @@ export async function POST(request: NextRequest) {
     const requestBody = typeof body === 'object' && body !== null
       ? body as Record<string, unknown>
       : {}
-    // activateAccount() now establishes the post-activation Auth.js session
-    // itself (see lib/server/auth/auth-service.ts) — no client/cookie
-    // plumbing needed here.
+    // KIM-451 retires server-side session establishment from this route.
+    // Activation still returns the updated profile so the client can
+    // redirect the member into the Clerk-driven login flow.
     const result = await activateAccount({
       token: requestBody.token,
       password: requestBody.password,
     })
 
-    if (result.signInFailed) {
-      return NextResponse.json({
-        message: 'Account activated, but automatic sign-in failed. Please sign in with your member number and new password.',
-        statusCode: 500,
-      }, { status: 500 })
-    }
-
+    // Keep this compatibility branch until activation/recovery UI no longer
+    // expects the legacy result shape during the auth migration.
     return NextResponse.json(result.user)
   } catch (error) {
     return toServiceErrorResponse(error)

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { enforceMutationSecurity, enforceRateLimit, RATE_LIMIT_POLICIES } from '@/lib/server/shared/security'
-import { login } from '@/lib/server/auth/auth-service'
-import { toServiceErrorResponse } from '@/lib/server/shared/http-error'
 
 export async function POST(request: NextRequest) {
   const securityError = enforceMutationSecurity(request)
@@ -10,15 +8,8 @@ export async function POST(request: NextRequest) {
   const rateLimitError = await enforceRateLimit(request, RATE_LIMIT_POLICIES.authLogin)
   if (rateLimitError) return rateLimitError
 
-  try {
-    const body = await request.json()
-    const user = await login(body)
-    // Auth.js's `signIn()` (called inside `login()`) sets the session cookie
-    // itself via `next/headers`, which attaches directly to this Route
-    // Handler's response — no manual cookie propagation needed here, unlike
-    // the previous Supabase route-handler client this replaced.
-    return NextResponse.json(user)
-  } catch (error) {
-    return toServiceErrorResponse(error)
-  }
+  return NextResponse.json(
+    { message: 'Interactive login is handled by Clerk on the client', statusCode: 410 },
+    { status: 410 },
+  )
 }

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { enforceMutationSecurity, enforceRateLimit, RATE_LIMIT_POLICIES } from '@/lib/server/shared/security'
-import { logoutWithClient } from '@/lib/server/auth/auth-service'
-import { toServiceErrorResponse } from '@/lib/server/shared/http-error'
 
 export async function POST(request: NextRequest) {
   const securityError = enforceMutationSecurity(request)
@@ -10,13 +8,8 @@ export async function POST(request: NextRequest) {
   const rateLimitError = await enforceRateLimit(request, RATE_LIMIT_POLICIES.authLogout)
   if (rateLimitError) return rateLimitError
 
-  try {
-    // Auth.js's `signOut()` (called inside `logoutWithClient()`) clears the
-    // session cookie itself via `next/headers`, attaching directly to this
-    // Route Handler's response — no client/cookie plumbing needed here.
-    const body = await logoutWithClient()
-    return NextResponse.json(body)
-  } catch (error) {
-    return toServiceErrorResponse(error)
-  }
+  return NextResponse.json(
+    { message: 'Interactive logout is handled by Clerk on the client', statusCode: 410 },
+    { status: 410 },
+  )
 }

--- a/app/api/auth/recover/route.ts
+++ b/app/api/auth/recover/route.ts
@@ -25,21 +25,16 @@ export async function POST(request: NextRequest) {
     const requestBody = typeof body === 'object' && body !== null
       ? body as Record<string, unknown>
       : {}
-    // recoverAccount() now establishes the post-recovery Auth.js session
-    // itself (see lib/server/auth/auth-service.ts) — no client/cookie
-    // plumbing needed here.
+    // KIM-451 retires server-side session establishment from this route.
+    // Password recovery still returns the updated profile so the client can
+    // redirect the member into the Clerk-driven login flow.
     const result = await recoverAccount({
       token: requestBody.token,
       password: requestBody.password,
     })
 
-    if (result.signInFailed) {
-      return NextResponse.json({
-        message: 'Password updated, but automatic sign-in failed. Please sign in with your member number and new password.',
-        statusCode: 500,
-      }, { status: 500 })
-    }
-
+    // Keep this compatibility branch until activation/recovery UI no longer
+    // expects the legacy result shape during the auth migration.
     return NextResponse.json(result.user)
   } catch (error) {
     return toServiceErrorResponse(error)

--- a/app/api/authjs/[...nextauth]/route.ts
+++ b/app/api/authjs/[...nextauth]/route.ts
@@ -1,38 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { handlers } from '@/lib/authjs/auth'
 
 /**
- * Auth.js (NextAuth v5) route handler — F1 scaffolding only (KIM-416).
+ * Permanent tombstone for the retired Auth.js endpoint.
  *
- * Deliberately mounted at `/api/authjs/*`, distinct from `/api/auth/*`
- * which is reserved for the existing, live Supabase Auth (GoTrue) flow.
- * Nothing in the app links to or calls this route yet — it is inert until
- * KIM-451 removes the transitional Auth.js runtime in favor of Clerk.
- *
- * Forced to the Node.js runtime because the Credentials provider talks to
- * Postgres via `pg`, which is not Edge-compatible.
- *
- * Guarded behind `AUTH_JS_ENABLED` so this endpoint 404s by default even if
- * `AUTH_SECRET`/`POSTGRES_URL` are already present in an environment ahead of
- * removal — it must not become a publicly reachable, unrate-limited
- * password-guessing surface.
+ * Keep the path unreachable even if stale environments still define
+ * AUTH_JS_ENABLED. Removing this route entirely would allow a future catch-all
+ * route to claim the old authentication URL accidentally.
  */
-export const runtime = 'nodejs'
-
-function isAuthJsEnabled(): boolean {
-  return process.env.AUTH_JS_ENABLED === 'true'
+export async function GET(_request: NextRequest) {
+  return new NextResponse(null, { status: 404 })
 }
 
-export async function GET(request: NextRequest) {
-  if (!isAuthJsEnabled()) {
-    return new NextResponse(null, { status: 404 })
-  }
-  return handlers.GET(request)
-}
-
-export async function POST(request: NextRequest) {
-  if (!isAuthJsEnabled()) {
-    return new NextResponse(null, { status: 404 })
-  }
-  return handlers.POST(request)
+export async function POST(_request: NextRequest) {
+  return new NextResponse(null, { status: 404 })
 }

--- a/components/auth/activation-form.tsx
+++ b/components/auth/activation-form.tsx
@@ -64,8 +64,7 @@ export function ActivationForm({ locale, token }: ActivationFormProps) {
         token,
         password: data.password,
       })
-      router.push(`/${locale}/rooms`)
-      router.refresh()
+      router.push(`/${locale}/login`)
     } catch (error) {
       const message = error instanceof Error
         ? error.message

--- a/components/auth/recovery-form.tsx
+++ b/components/auth/recovery-form.tsx
@@ -64,8 +64,7 @@ export function RecoveryForm({ locale, token }: RecoveryFormProps) {
         token,
         password: data.password,
       })
-      router.push(`/${locale}/rooms`)
-      router.refresh()
+      router.push(`/${locale}/login`)
     } catch (error) {
       const message = error instanceof Error
         ? error.message

--- a/lib/auth/auth-context.tsx
+++ b/lib/auth/auth-context.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import { useAuth as useClerkAuth, useClerk, useSignIn } from '@clerk/nextjs'
+import { createContext, useCallback, useContext, useState, useEffect } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import type { User } from '@/lib/types'
 import { apiClient } from '@/lib/api/client'
@@ -20,6 +21,9 @@ const AuthContext = createContext<AuthContextValue | null>(null)
 export function AuthProvider({ children, initialUser }: { children: React.ReactNode; initialUser?: User | null }) {
   const [user, setUser] = useState<User | null>(initialUser ?? null)
   const [isLoading, setIsLoading] = useState(initialUser === undefined)
+  const clerk = useClerk()
+  const { isLoaded: isClerkLoaded, userId } = useClerkAuth()
+  const { signIn, fetchStatus: signInFetchStatus } = useSignIn()
   const router = useRouter()
   const pathname = usePathname()
 
@@ -29,24 +33,56 @@ export function AuthProvider({ children, initialUser }: { children: React.ReactN
     try {
       const data = await apiClient.get<User>(endpoints.auth.me)
       setUser(data)
-    } catch { setUser(null) }
-    finally { setIsLoading(false) }
+      return data
+    } catch {
+      setUser(null)
+      return null
+    } finally {
+      setIsLoading(false)
+    }
   }, [])
 
   useEffect(() => {
-    if (initialUser !== undefined) return
+    if (initialUser !== undefined || !isClerkLoaded) return
+    if (!userId) {
+      setUser(null)
+      setIsLoading(false)
+      return
+    }
     checkAuth()
-  }, [checkAuth, initialUser])
+  }, [checkAuth, initialUser, isClerkLoaded, userId])
 
   const login = async (identifier: string, password: string) => {
-    const data = await apiClient.post<User>(endpoints.auth.login, { identifier, password })
-    setUser(data)
+    if (!signIn || signInFetchStatus === 'fetching') {
+      throw new Error('Clerk sign-in is not ready')
+    }
+
+    const { error } = await signIn.password({
+      identifier: `${identifier.trim()}@members.alea.internal`,
+      password,
+    })
+
+    if (error || signIn.status !== 'complete') {
+      throw new Error('Invalid credentials')
+    }
+
+    const { error: finalizeError } = await signIn.finalize()
+    if (finalizeError) {
+      throw new Error('Invalid credentials')
+    }
+    const mappedUser = await checkAuth()
+    if (!mappedUser) {
+      await clerk.signOut()
+      throw new Error('Invalid credentials')
+    }
   }
+
   const logout = async () => {
-    await apiClient.post(endpoints.auth.logout)
+    await clerk.signOut()
     setUser(null)
     router.push(`/${locale}/login`)
   }
+
   const register = async (memberNumber: string, password: string) => {
     const data = await apiClient.post<User>(endpoints.auth.register, { memberNumber, password })
     setUser(data)

--- a/lib/providers.tsx
+++ b/lib/providers.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ClerkProvider } from '@clerk/nextjs'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useState } from 'react'
 
@@ -17,6 +18,8 @@ export function Providers({ children }: { children: React.ReactNode }) {
   )
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <ClerkProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </ClerkProvider>
   )
 }

--- a/lib/server/auth/auth-service.ts
+++ b/lib/server/auth/auth-service.ts
@@ -3,9 +3,6 @@ import type { SessionUser } from '@/lib/server/auth/auth'
 import { createHash, randomBytes } from 'node:crypto'
 import bcrypt from 'bcryptjs'
 import { and, eq, gt, isNull } from 'drizzle-orm'
-import { AuthError } from 'next-auth'
-import { signIn as authJsSignIn, signOut as authJsSignOut } from '@/lib/authjs/auth'
-import { verifyCredentials } from '@/lib/authjs/credentials-user'
 import { getDatabaseNow } from '@/lib/server/shared/database-time'
 import { serviceError } from '@/lib/server/shared/service-error'
 import { getAdminDb, getDrizzleAdminDb, getDrizzleDb } from '@/lib/db'
@@ -32,15 +29,8 @@ const PASSWORD_HASH_COST = 10
  * only changes the password on the legacy Supabase Auth (GoTrue) seam
  * (`getAdminDb()` / `NEXT_PUBLIC_SUPABASE_URL`), a physically different
  * database from the one `POSTGRES_URL` points at (see `lib/db/index.ts`).
- * `verifyCredentials()`
- * (`lib/authjs/credentials-user.ts`) authenticates exclusively against the
- * Drizzle/Neon row, so without this write every Auth.js login attempt after
- * activation/recovery would fail against a null or stale hash (KIM-433
- * Codex-review fix).
- *
- * Resolves `true` only when the hash is durably visible to
- * `verifyCredentials()` afterward — not merely when no exception was
- * thrown. Drizzle's `.update()` over node-postgres does NOT throw when the
+ * Resolves `true` only when the hash is durably persisted — not merely when
+ * no exception was thrown. Drizzle's `.update()` over node-postgres does NOT throw when the
  * `WHERE` clause matches zero rows (e.g. no Neon row exists yet for this
  * `profileId` during the transition); it just
  * resolves with nothing updated. `.returning({ id: profiles.id })` lets us
@@ -52,8 +42,7 @@ const PASSWORD_HASH_COST = 10
  *
  * For activation, this single Drizzle update persists both the password hash
  * and active-status fields. Callers roll back the single-use token when it
- * fails, so Neon never exposes an active profile without the credential
- * `verifyCredentials()` reads.
+ * fails, so Neon never exposes an active profile without its credential.
  */
 async function persistDrizzlePasswordHash(
   profileId: string,
@@ -123,65 +112,6 @@ type AuthClient = {
       error: { message: string } | null
     }>
     signOut: () => Promise<{ error: { message: string } | null }>
-  }
-}
-
-/**
- * Establishes an Auth.js session for the given credentials, via the same
- * Credentials provider `lib/authjs/config.ts` registers (which delegates to
- * `lib/authjs/credentials-user.ts#verifyCredentials`). Used by `login()`,
- * and by `activateAccount()`/`recoverAccount()` after their custom
- * token/password logic finishes, to issue the post-activation /
- * post-recovery session that Supabase Auth's `signInWithPassword` used to
- * issue there.
- *
- * IMPORTANT (KIM-433): this function deliberately does NOT attempt to read
- * back which identity got authenticated by calling `auth()` immediately
- * after `signIn()` resolves. That pattern cannot work reliably in a Route
- * Handler: `signIn()` (`node_modules/next-auth/lib/actions.js`) writes the
- * new session cookie via the request's *mutable* cookie jar
- * (`await cookies()`), while zero-arg `auth()`
- * (`node_modules/next-auth/lib/index.js`) resolves the session from
- * `headers()` — a frozen snapshot of the *incoming* request headers taken
- * at the start of the request. Nothing re-derives that snapshot from a
- * cookie write that happens later in the same request. In the common case
- * (no pre-existing Auth.js session cookie on the request), that readback
- * always resolved to `null`, which incorrectly rejected logins that had, in
- * fact, just succeeded — and worse, left a valid session cookie attached to
- * that same 401 response.
- *
- * Callers MUST instead resolve and compare the authenticated identity via
- * `verifyCredentials()` (`@/lib/authjs/credentials-user`) directly, BEFORE
- * calling this function — so that by the time a session is actually
- * established here, the identity is already known and trusted, and a
- * mismatch never results in a session being issued at all. See `login()`,
- * `activateAccount()`, `recoverAccount()` below for that ordering.
- *
- * Returns `true` once the Credentials provider accepts the sign-in and a
- * session cookie has been issued, or `false` (never throws) when it rejects
- * the sign-in (`AuthError`/`CredentialsSignin` — invalid credentials,
- * inactive account, etc.). Any other, unexpected error is rethrown so it
- * still surfaces as a 500 instead of being silently reinterpreted as
- * "invalid credentials".
- */
-async function establishAuthJsSession(email: string, password: string): Promise<boolean> {
-  try {
-    await authJsSignIn('credentials', { email, password, redirect: false })
-    return true
-  } catch (error) {
-    if (error instanceof AuthError) {
-      return false
-    }
-    throw error
-  }
-}
-
-/** Ends the current Auth.js session. Throws a 500 `ServiceError` on failure, same contract as the previous Supabase `signOut()`-based implementation. */
-async function signOutWithAuthJs(): Promise<void> {
-  try {
-    await authJsSignOut({ redirect: false })
-  } catch {
-    serviceError('Internal server error', 500)
   }
 }
 
@@ -560,36 +490,9 @@ export async function activateAccount(input: { token: unknown; password: unknown
     serviceError('Failed to activate account', 500)
   }
 
-  // Establish the post-activation session. Previously the route handler
-  // did this via Supabase's `signInWithPassword`; now it's done here so the
-  // route handler doesn't need any auth-client construction of its own.
-  // Account activation has already succeeded at this point regardless of
-  // whether this sign-in attempt succeeds — `signInFailed` lets the route
-  // handler report that distinction to the client (same behavior as before).
-  //
-  // Identity is resolved and compared BEFORE any session is established —
-  // see `establishAuthJsSession()`'s doc comment (KIM-433) for why a
-  // same-request signIn()-then-auth() readback cannot be relied on instead.
-  const authEmail = profile.authEmail
-  const verifiedUser = await verifyCredentials(authEmail, parsed.data.password)
-
-  // Defense-in-depth, mirroring login()'s identity-drift guard: `profile`
-  // here was resolved by activation token -> profile_id (unique), so this
-  // mismatch shouldn't be reachable in practice (verifyCredentials() now
-  // keys on the uniquely-indexed auth_email column — see
-  // lib/authjs/credentials-user.ts). Still checked — and checked BEFORE any
-  // signIn() call — so on mismatch no session is ever issued for a profile
-  // other than the one just activated; there is nothing to tear down.
-  const identityMismatch = verifiedUser !== null && verifiedUser.id !== profile.id
-
-  const signInFailed = identityMismatch || !verifiedUser
-    ? true
-    : !(await establishAuthJsSession(authEmail, parsed.data.password))
-
   return {
-    authEmail,
+    authEmail: profile.authEmail,
     user: toUser(updatedProfile),
-    signInFailed,
   }
 }
 
@@ -663,89 +566,16 @@ export async function recoverAccount(input: { token: unknown; password: unknown 
     serviceError('Failed to recover account', 500)
   }
 
-  // Establish the post-recovery session — see the matching comment in
-  // `activateAccount()` above for why this moved here from the route
-  // handler, and for why identity is resolved/compared before any session
-  // is established (KIM-433).
-  const authEmail = profile.authEmail
-  const verifiedUser = await verifyCredentials(authEmail, parsed.data.password)
-
-  // Defense-in-depth identity-drift guard — see the matching comment in
-  // `activateAccount()` above.
-  const identityMismatch = verifiedUser !== null && verifiedUser.id !== profile.id
-
-  const signInFailed = identityMismatch || !verifiedUser
-    ? true
-    : !(await establishAuthJsSession(authEmail, parsed.data.password))
-
   return {
-    authEmail,
+    authEmail: profile.authEmail,
     user: toUser(updatedProfile),
-    signInFailed,
   }
 }
 
 export async function login(
-  input: { identifier?: unknown; password?: unknown },
+  _input: { identifier?: unknown; password?: unknown },
 ): Promise<User> {
-  const identifier = String(input.identifier ?? '').trim()
-  const password = String(input.password ?? '')
-
-  if (!identifier || !password) {
-    serviceError('Identifier and password are required', 400)
-  }
-
-  // Resolve the auth credential profile by member number (email login not supported).
-  const credentialProfile = await getAuthCredentialByMemberNumber(identifier)
-
-  if (!credentialProfile) {
-    serviceError('Invalid credentials', 401)
-  }
-
-  const authEmail = credentialProfile.authEmail
-
-  if (!authEmail) {
-    serviceError('Invalid credentials', 401)
-  }
-
-  if (credentialProfile.isActive === false) {
-    // Suspended users cannot sign in.
-    serviceError('Invalid credentials', 401)
-  }
-
-  // Resolve and verify the authenticated identity BEFORE issuing any
-  // session — see `establishAuthJsSession()`'s doc comment (KIM-433) for
-  // why a same-request signIn()-then-auth() readback cannot be relied on
-  // instead. `verifyCredentials()` runs the same Credentials-provider
-  // lookup/compare `signIn()` would perform internally, without touching
-  // cookies at all.
-  const verifiedUser = await verifyCredentials(authEmail, password)
-
-  if (!verifiedUser) {
-    serviceError('Invalid credentials', 401)
-  }
-
-  if (verifiedUser.id !== credentialProfile.id) {
-    // Guard against profile/auth drift: the identity verifyCredentials()
-    // actually authenticated must match the profile resolved by member
-    // number above. Without this, a non-unique lookup could authenticate a
-    // different profile than the one whose data we're about to return.
-    // Checked BEFORE any signIn() call, so a mismatch here never results in
-    // a session cookie being issued at all — nothing to tear down, and no
-    // window where a valid cookie rides on a 401 response (unlike the
-    // previous read-back-after-signIn design this replaces).
-    serviceError('Invalid credentials', 401)
-  }
-
-  const sessionEstablished = await establishAuthJsSession(authEmail, password)
-  if (!sessionEstablished) {
-    // Extremely unlikely given verifyCredentials() above just accepted
-    // these same credentials, but fail closed rather than assume signIn()
-    // will always agree.
-    serviceError('Invalid credentials', 401)
-  }
-
-  return toUser(credentialProfile)
+  serviceError('Interactive login is handled by Clerk', 410)
 }
 
 export async function register(
@@ -824,18 +654,6 @@ export async function register(
     serviceError('Failed to create user profile', 500)
   }
 
-  // Registration succeeded regardless of whether auto-login works — the user can
-  // always log in manually. Verify identity first so no session is ever issued
-  // for the wrong profile if profile/auth state drifted unexpectedly.
-  const verifiedUser = await verifyCredentials(email, password)
-  if (verifiedUser && verifiedUser.id === userId) {
-    try {
-      await establishAuthJsSession(email, password)
-    } catch {
-      // Non-fatal: profile was created successfully. User can log in separately.
-    }
-  }
-
   return toUser(profileData)
 }
 
@@ -855,9 +673,7 @@ export async function getCurrentUser(
 }
 
 export async function logout() {
-  await signOutWithAuthJs()
-
-  return { success: true }
+  serviceError('Interactive logout is handled by Clerk', 410)
 }
 
 /**
@@ -868,7 +684,5 @@ export async function logout() {
  * this replaces.
  */
 export async function logoutWithClient(_client?: AuthClient) {
-  await signOutWithAuthJs()
-
-  return { success: true }
+  serviceError('Interactive logout is handled by Clerk', 410)
 }

--- a/lib/server/auth/auth.ts
+++ b/lib/server/auth/auth.ts
@@ -1,7 +1,7 @@
 import 'server-only'
 import { NextRequest, NextResponse } from 'next/server'
 import { eq } from 'drizzle-orm'
-import { auth as authJsAuth } from '@/lib/authjs/auth'
+import { auth as clerkAuth } from '@clerk/nextjs/server'
 import { getDrizzleDb } from '@/lib/db'
 import { profiles } from '@/lib/db/schema'
 export { enforceSameOriginForMutation } from '@/lib/server/shared/security'
@@ -21,36 +21,12 @@ type AuthContext = {
   applyCookies: (response: NextResponse) => NextResponse
 }
 
-/**
- * Auth.js (JWT strategy, no adapter) never needs to rewrite/refresh the
- * session cookie on a plain read — unlike the Supabase Auth client this
- * replaces, which could rotate the access/refresh token pair on
- * `auth.getUser()` and needed `applyCookies` to propagate that onto the
- * response. Kept as a no-op identity function (rather than removed) so
- * every call site across the app that destructures `applyCookies` off the
- * `requireAuth`/`requireAdmin` result keeps working unchanged.
- */
 function identityApplyCookies(response: NextResponse): NextResponse {
   return response
 }
 
-/**
- * Resolves the current session user.
- *
- * Reads the Auth.js JWT session (`auth()` — see `lib/authjs/auth.ts`) to
- * get the authenticated user id (`session.user.id`, sourced from the JWT
- * `sub` claim), then — same as the previous Supabase-based implementation —
- * always re-fetches `profiles.role` / `profiles.is_active` fresh from the
- * database on every call. This is intentional, preserved behavior: role and
- * active-status changes (e.g. an admin demoted, a member suspended) must
- * take effect immediately, not only once a JWT the size of the session
- * lifetime expires, so the JWT's own `role`/`isActive` claims (added for
- * display purposes in `lib/authjs/config.ts`'s `session()` callback) are
- * deliberately NOT trusted here as an authorization source.
- */
 async function getSessionUser(): Promise<SessionUser | null> {
-  const session = await authJsAuth()
-  const userId = session?.user?.id
+  const { userId } = await clerkAuth()
 
   if (!userId) {
     return null
@@ -60,7 +36,7 @@ async function getSessionUser(): Promise<SessionUser | null> {
   const [profile] = await db
     .select({ id: profiles.id, role: profiles.role, isActive: profiles.isActive })
     .from(profiles)
-    .where(eq(profiles.id, userId))
+    .where(eq(profiles.clerkUserId, userId))
     .limit(1)
 
   if (!profile || !profile.isActive) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
 import createMiddleware from 'next-intl/middleware'
-import { type NextRequest } from 'next/server'
+import { clerkMiddleware } from '@clerk/nextjs/server'
+import { NextResponse, type NextRequest } from 'next/server'
 import { ensureCsrfCookie } from './lib/server/shared/security-edge'
 import { locales, defaultLocale } from './lib/i18n/config'
 
@@ -9,18 +10,13 @@ const handleI18nRouting = createMiddleware({
   localePrefix: 'always',
 })
 
-export default async function middleware(request: NextRequest) {
-  const response = handleI18nRouting(request)
-
-  // No Auth.js session read happens here (KIM-433 follow-up): a prior
-  // `getToken()` call was added for the F3b cutover but its result was
-  // never used for anything (no redirect, no gating), so it was dead code
-  // — actual route protection happens per-request in route handlers via
-  // `requireAuth`/`requireAdmin` (`lib/server/auth/auth.ts`), not here.
-
+export default clerkMiddleware(async (_auth, request: NextRequest) => {
+  const response = request.nextUrl.pathname.startsWith('/api')
+    ? NextResponse.next()
+    : handleI18nRouting(request)
   return ensureCsrfCookie(request, response)
-}
+})
 
 export const config = {
-  matcher: ['/((?!api|_next|_vercel|.*\\..*).*)'],
+  matcher: ['/((?!_next|_vercel|.*\\..*).*)', '/(api|trpc)(.*)'],
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "hooks:verify:worktree": "node -e \"if (process.platform === 'win32') { console.log('Skipping worktree hook smoke test on Windows: requires Bash/WSL to run scripts/verify-hooks-worktree.sh.'); process.exit(0); } require('node:child_process').execFileSync('bash', ['./scripts/verify-hooks-worktree.sh'], { stdio: 'inherit' });\""
   },
   "dependencies": {
+    "@clerk/nextjs": "^7.6.2",
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@clerk/nextjs':
+        specifier: ^7.6.2
+        version: 7.6.2(next@15.5.19(@babel/core@7.29.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@hookform/resolvers':
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.72.1(react@19.2.1))
@@ -334,6 +337,37 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@clerk/backend@3.13.2':
+    resolution: {integrity: sha512-z6rPQzEj1SbGmjMoyGnECY1R7YrcD4dJILlWLXFvSUsWxb8csAYzcXp50T2kVtV3ThlcjOMrI0oDQyqvTdt65A==}
+    engines: {node: '>=20.9.0'}
+
+  '@clerk/nextjs@7.6.2':
+    resolution: {integrity: sha512-PetWyCwKYqIzY44ABU4DbFmQz0JBtmyybfy7Cy1DlnTxS4QNgo/TQEp2VcJLQWVmhPef/QmAo6NZSZIV/c2Z3g==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      next: ^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/react@6.12.8':
+    resolution: {integrity: sha512-F/wECRGlE9JtBcS7XqutCQAI5gKXVaOSamAH9x6YPtAP0hMKlNJIaHuLEjVMKNbOerMFm3iV6k8cZ+6JnDFcMQ==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/shared@4.25.8':
+    resolution: {integrity: sha512-ob0E/YJAoDTO4CzHI0nasXGsJUc1cFo0jxPO8xVz/A0+C1R0k1da0EJD8L6F03DzKMn3efSa4mOy3BXTpBVZqw==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -2008,6 +2042,9 @@ packages:
   '@rushstack/eslint-patch@1.16.1':
     resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@supabase/auth-js@2.101.1':
     resolution: {integrity: sha512-Kd0Wey+RkFHgyVep7adS6UOE2pN6MJ3mZ32PAXSvfw6IjUkFRC7IQpdZZjUOcUe5pXr1ejufCRgF6lsGINe4Tw==}
     engines: {node: '>=20.0.0'}
@@ -2046,6 +2083,9 @@ packages:
   '@tabby_ai/hijri-converter@1.0.5':
     resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
     engines: {node: '>=16.0.0'}
+
+  '@tanstack/query-core@5.101.4':
+    resolution: {integrity: sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==}
 
   '@tanstack/query-core@5.96.2':
     resolution: {integrity: sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==}
@@ -3159,6 +3199,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -3281,6 +3324,9 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -3566,6 +3612,10 @@ packages:
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -4420,6 +4470,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -5060,6 +5113,43 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@clerk/backend@3.13.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@clerk/shared': 4.25.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      standardwebhooks: 1.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/nextjs@7.6.2(next@15.5.19(@babel/core@7.29.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@clerk/backend': 3.13.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@clerk/react': 6.12.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@clerk/shared': 4.25.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next: 15.5.19(@babel/core@7.29.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      server-only: 0.0.1
+      tslib: 2.8.1
+
+  '@clerk/react@6.12.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@clerk/shared': 4.25.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      tslib: 2.8.1
+
+  '@clerk/shared@4.25.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@tanstack/query-core': 5.101.4
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.7
+    optionalDependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -6332,6 +6422,8 @@ snapshots:
 
   '@rushstack/eslint-patch@1.16.1': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@supabase/auth-js@2.101.1':
     dependencies:
       tslib: 2.8.1
@@ -6382,6 +6474,8 @@ snapshots:
       tslib: 2.8.1
 
   '@tabby_ai/hijri-converter@1.0.5': {}
+
+  '@tanstack/query-core@5.101.4': {}
 
   '@tanstack/query-core@5.96.2': {}
 
@@ -7726,6 +7820,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -7847,6 +7943,8 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob-to-regexp@0.4.1: {}
 
   glob@10.5.0:
     dependencies:
@@ -8137,6 +8235,8 @@ snapshots:
   jose@5.10.0: {}
 
   jose@6.2.3: {}
+
+  js-cookie@3.0.7: {}
 
   js-tokens@10.0.0: {}
 
@@ -9002,6 +9102,11 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   std-env@3.10.0: {}
 

--- a/tests/unit/app/api/auth-activate-route.test.ts
+++ b/tests/unit/app/api/auth-activate-route.test.ts
@@ -61,7 +61,6 @@ describe('POST /api/auth/activate', () => {
     enforceMutationSecurityMock.mockReturnValue(null)
     enforceRateLimitMock.mockReturnValue(null)
     activateAccountMock.mockResolvedValue({
-      signInFailed: false,
       user: {
         id: 'user-20',
         memberNumber: '100020',
@@ -73,7 +72,7 @@ describe('POST /api/auth/activate', () => {
     })
   })
 
-  it('activates account, signs member in, returns user payload and cookies', async () => {
+  it('activates the account and returns the user without a legacy session', async () => {
     const { POST } = await import('@/app/api/auth/activate/route')
     const response = await POST(createJsonRequest({
       token: 'plain-token',
@@ -146,7 +145,7 @@ describe('POST /api/auth/activate', () => {
     })
   })
 
-  it('returns 500 when activation succeeds but automatic sign-in fails', async () => {
+  it('ignores obsolete legacy session flags from transitional service mocks', async () => {
     activateAccountMock.mockResolvedValueOnce({
       signInFailed: true,
       user: {
@@ -165,11 +164,8 @@ describe('POST /api/auth/activate', () => {
       password: 'Password123',
     }))
 
-    expect(response.status).toBe(500)
-    await expect(response.json()).resolves.toMatchObject({
-      message: 'Account activated, but automatic sign-in failed. Please sign in with your member number and new password.',
-      statusCode: 500,
-    })
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ memberNumber: '100020' })
   })
 
   it('returns the security response before touching activation logic', async () => {

--- a/tests/unit/app/api/auth-recover-route.test.ts
+++ b/tests/unit/app/api/auth-recover-route.test.ts
@@ -45,7 +45,6 @@ describe('POST /api/auth/recover', () => {
     enforceMutationSecurityMock.mockReturnValue(null)
     enforceRateLimitMock.mockReturnValue(null)
     recoverAccountMock.mockResolvedValue({
-      signInFailed: false,
       user: {
         id: 'user-20',
         memberNumber: '100020',
@@ -57,7 +56,7 @@ describe('POST /api/auth/recover', () => {
     })
   })
 
-  it('recovers account, signs member in, returns user payload and cookies', async () => {
+  it('recovers the account and returns the user without a legacy session', async () => {
     const { POST } = await import('@/app/api/auth/recover/route')
     const response = await POST(createJsonRequest({
       token: 'plain-token',
@@ -116,7 +115,7 @@ describe('POST /api/auth/recover', () => {
     expect(recoverAccountMock).not.toHaveBeenCalled()
   })
 
-  it('returns 500 when recovery succeeds but automatic sign-in fails', async () => {
+  it('ignores obsolete legacy session flags from transitional service mocks', async () => {
     recoverAccountMock.mockResolvedValueOnce({
       signInFailed: true,
       user: {
@@ -135,11 +134,8 @@ describe('POST /api/auth/recover', () => {
       password: 'Password123',
     }))
 
-    expect(response.status).toBe(500)
-    await expect(response.json()).resolves.toMatchObject({
-      message: 'Password updated, but automatic sign-in failed. Please sign in with your member number and new password.',
-      statusCode: 500,
-    })
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ memberNumber: '100020' })
   })
 
   it('returns the security response before touching recovery logic', async () => {

--- a/tests/unit/app/api/auth-routes.test.ts
+++ b/tests/unit/app/api/auth-routes.test.ts
@@ -1,26 +1,22 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 
 let requestCounter = 0
 
-const loginMock = vi.fn()
 const registerMock = vi.fn()
-const logoutWithClientMock = vi.fn()
 const getCurrentUserMock = vi.fn()
-const authJsAuthMock = vi.fn()
+const clerkAuthMock = vi.fn()
 const drizzleSelectMock = vi.fn()
 const drizzleFromMock = vi.fn()
 const drizzleWhereMock = vi.fn()
 const drizzleLimitMock = vi.fn()
 
-// Mock Auth.js auth() to prevent loading next-auth
-vi.mock('@/lib/authjs/auth', () => ({
-  auth: authJsAuthMock,
-  handlers: { GET: vi.fn(), POST: vi.fn() },
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: clerkAuthMock,
+  clerkMiddleware: vi.fn((handler: unknown) => handler),
 }))
 
-// Mock Drizzle database to prevent loading
 vi.mock('@/lib/db', () => ({
   getDrizzleDb: vi.fn(() => ({
     select: drizzleSelectMock,
@@ -29,35 +25,9 @@ vi.mock('@/lib/db', () => ({
   getAdminDb: vi.fn(),
 }))
 
-// Mock next-auth/jwt to prevent loading next-auth
-vi.mock('next-auth/jwt', () => ({
-  getToken: vi.fn(),
-}))
-
 vi.mock('@/lib/server/auth/auth-service', () => ({
-  login: loginMock,
   register: registerMock,
-  logoutWithClient: logoutWithClientMock,
   getCurrentUser: getCurrentUserMock,
-}))
-
-vi.mock('@/lib/supabase/server', () => ({
-  createSupabaseRouteHandlerClient: vi.fn(() => ({
-    supabase: {
-      auth: {
-        getUser: vi.fn(),
-        signInWithPassword: vi.fn(),
-      },
-      from: vi.fn(() => ({
-        select: vi.fn(() => ({
-          eq: vi.fn(() => ({
-            maybeSingle: vi.fn(),
-          })),
-        })),
-      })),
-    },
-    applyCookies: (response: NextResponse) => response,
-  })),
 }))
 
 function createJsonRequest(
@@ -108,13 +78,6 @@ describe('auth API routes', () => {
     vi.stubEnv('TRUST_PROXY_HEADERS', 'true')
     vi.stubEnv('TRUSTED_PROXY_CIDRS', '127.0.0.1/32')
     requestCounter = 0
-    loginMock.mockResolvedValue({
-      id: 'user-1',
-      memberNumber: '100001',
-      role: 'admin',
-      createdAt: '2024-01-01T00:00:00.000Z',
-      updatedAt: '2024-01-01T00:00:00.000Z',
-    })
     registerMock.mockResolvedValue({
       id: 'new-user-id',
       memberNumber: '100099',
@@ -123,7 +86,6 @@ describe('auth API routes', () => {
       createdAt: '2024-01-01T00:00:00.000Z',
       updatedAt: '2024-01-01T00:00:00.000Z',
     })
-    logoutWithClientMock.mockResolvedValue({ success: true })
     getCurrentUserMock.mockResolvedValue({
       id: 'user-2',
       memberNumber: '100099',
@@ -131,22 +93,14 @@ describe('auth API routes', () => {
       createdAt: '2024-01-01T00:00:00.000Z',
       updatedAt: '2024-01-01T00:00:00.000Z',
     })
-    // Default auth returns null (no session) - tests can override per-test
-    authJsAuthMock.mockResolvedValue(null)
-    // Default drizzle profile lookup for getSessionUser
-    drizzleSelectMock.mockReturnValue({
-      from: drizzleFromMock,
-    })
-    drizzleFromMock.mockReturnValue({
-      where: drizzleWhereMock,
-    })
-    drizzleWhereMock.mockReturnValue({
-      limit: drizzleLimitMock,
-    })
+    clerkAuthMock.mockResolvedValue({ userId: null })
+    drizzleSelectMock.mockReturnValue({ from: drizzleFromMock })
+    drizzleFromMock.mockReturnValue({ where: drizzleWhereMock })
+    drizzleWhereMock.mockReturnValue({ limit: drizzleLimitMock })
     drizzleLimitMock.mockResolvedValue([{ id: 'user-2', role: 'member', isActive: true }])
   })
 
-  it('logs in and returns the public user payload with Supabase session cookies', async () => {
+  it('retires the legacy login route with a 410 response', async () => {
     const { POST } = await import('@/app/api/auth/login/route')
 
     const response = await POST(
@@ -156,80 +110,32 @@ describe('auth API routes', () => {
       }),
     )
 
-    expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toMatchObject({
-      id: 'user-1',
-      role: 'admin',
-    })
+    expect(response.status).toBe(410)
+    await expect(response.json()).resolves.toMatchObject({ statusCode: 410 })
   })
 
   it('rejects login requests from a different origin', async () => {
     const { POST } = await import('@/app/api/auth/login/route')
 
     const response = await POST(
-      createJsonRequest(
-        '/api/auth/login',
-        {
-          identifier: '100001',
-          password: 'Admin123',
-        },
-        { origin: 'https://attacker.example' },
-      ),
-    )
-
-    expect(response.status).toBe(403)
-  })
-
-  it('rejects login requests with a missing CSRF token', async () => {
-    const { POST } = await import('@/app/api/auth/login/route')
-
-    const response = await POST(
-      createJsonRequest(
-        '/api/auth/login',
-        {
-          identifier: '100001',
-          password: 'Admin123',
-        },
-        { csrfToken: null },
-      ),
-    )
-
-    expect(response.status).toBe(403)
-    await expect(response.json()).resolves.toMatchObject({ message: 'Invalid CSRF token' })
-  })
-
-  it('rejects login requests flagged as cross-site by fetch metadata', async () => {
-    const { POST } = await import('@/app/api/auth/login/route')
-
-    const response = await POST(
-      createJsonRequest(
-        '/api/auth/login',
-        {
-          identifier: '100001',
-          password: 'Admin123',
-        },
-        { fetchSite: 'cross-site' },
-      ),
-    )
-
-    expect(response.status).toBe(403)
-    await expect(response.json()).resolves.toMatchObject({ message: 'Cross-site requests are not allowed' })
-  })
-
-  it('maps invalid credentials from the service to a 401 response', async () => {
-    const { POST } = await import('@/app/api/auth/login/route')
-    const { ServiceError } = await import('@/lib/server/shared/service-error')
-    loginMock.mockRejectedValueOnce(new ServiceError('Invalid credentials', 401))
-
-    const response = await POST(
-      createJsonRequest('/api/auth/login', {
-        identifier: '100001',
-        password: 'wrong-password',
+      createJsonRequest('/api/auth/login', { identifier: '100001', password: 'Admin123' }, {
+        origin: 'https://attacker.example',
       }),
     )
 
-    expect(response.status).toBe(401)
-    await expect(response.json()).resolves.toMatchObject({ statusCode: 401 })
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects login requests without a CSRF token', async () => {
+    const { POST } = await import('@/app/api/auth/login/route')
+
+    const response = await POST(
+      createJsonRequest('/api/auth/login', { identifier: '100001', password: 'Admin123' }, {
+        csrfToken: null,
+      }),
+    )
+
+    expect(response.status).toBe(403)
   })
 
   it('rate limits repeated login attempts from the same client', async () => {
@@ -237,32 +143,21 @@ describe('auth API routes', () => {
 
     for (let attempt = 0; attempt < 5; attempt += 1) {
       const response = await POST(
-        createJsonRequest(
-          '/api/auth/login',
-          {
-            identifier: '100001',
-            password: 'Admin123',
-          },
-          { forwardedFor: '203.0.113.10' },
-        ),
+        createJsonRequest('/api/auth/login', { identifier: '100001', password: 'Admin123' }, {
+          forwardedFor: '203.0.113.10',
+        }),
       )
 
-      expect(response.status).toBe(200)
+      expect(response.status).toBe(410)
     }
 
     const blocked = await POST(
-      createJsonRequest(
-        '/api/auth/login',
-        {
-          identifier: '100001',
-          password: 'Admin123',
-        },
-        { forwardedFor: '203.0.113.10' },
-      ),
+      createJsonRequest('/api/auth/login', { identifier: '100001', password: 'Admin123' }, {
+        forwardedFor: '203.0.113.10',
+      }),
     )
 
     expect(blocked.status).toBe(429)
-    expect(blocked.headers.get('retry-after')).toBeTruthy()
   })
 
   it('returns 410 when self-registration is disabled', async () => {
@@ -276,112 +171,16 @@ describe('auth API routes', () => {
     )
 
     expect(response.status).toBe(410)
-    await expect(response.json()).resolves.toMatchObject({
-      message: 'Self-registration is disabled. Ask an administrator for an activation link.',
-      statusCode: 410,
-    })
     expect(registerMock).not.toHaveBeenCalled()
   })
 
-  it('still returns 410 even if a member number is supplied', async () => {
-    const { POST } = await import('@/app/api/auth/register/route')
+  it('retires the legacy logout route with a 410 response', async () => {
+    const { POST } = await import('@/app/api/auth/logout/route')
 
-    const response = await POST(
-      createJsonRequest('/api/auth/register', {
-        memberNumber: '100001',
-        password: 'Password123',
-      }),
-    )
+    const response = await POST(createJsonRequest('/api/auth/logout'))
 
     expect(response.status).toBe(410)
     await expect(response.json()).resolves.toMatchObject({ statusCode: 410 })
-    expect(registerMock).not.toHaveBeenCalled()
-  })
-
-  it('rejects register requests from a different origin before returning 410', async () => {
-    const { POST } = await import('@/app/api/auth/register/route')
-
-    const response = await POST(
-      createJsonRequest('/api/auth/register', {
-        memberNumber: '100099',
-        password: 'Password123',
-      }, {
-        origin: 'https://attacker.example',
-      }),
-    )
-
-    expect(response.status).toBe(403)
-  })
-
-  it('rate limits repeated register attempts from the same client', async () => {
-    const { POST } = await import('@/app/api/auth/register/route')
-    const statuses: number[] = []
-
-    for (let attempt = 0; attempt < 6; attempt += 1) {
-      const response = await POST(
-        createJsonRequest('/api/auth/register', {
-          memberNumber: '100099',
-          password: 'Password123',
-        }, {
-          forwardedFor: '203.0.113.99',
-        }),
-      )
-
-      statuses.push(response.status)
-    }
-
-    expect(statuses).toContain(410)
-    expect(statuses.at(-1)).toBe(429)
-  })
-
-  it('reads the session from /me after login and signs out through the auth routes', async () => {
-    const loginRoute = await import('@/app/api/auth/login/route')
-    const meRoute = await import('@/app/api/auth/me/route')
-    const logoutRoute = await import('@/app/api/auth/logout/route')
-    // Mock auth to return a session for the /me test
-    authJsAuthMock.mockResolvedValueOnce({ user: { id: 'user-2' } })
-    drizzleLimitMock.mockResolvedValueOnce([{ id: 'user-2', role: 'member', isActive: true }])
-
-    const loginResponse = await loginRoute.POST(
-      createJsonRequest('/api/auth/login', {
-        identifier: '100001',
-        password: 'Admin123',
-      }),
-    )
-
-    expect(loginResponse.status).toBe(200)
-
-    const meResponse = await meRoute.GET(new NextRequest('http://localhost:3000/api/auth/me'))
-    expect(meResponse.status).toBe(200)
-    await expect(meResponse.json()).resolves.toMatchObject({
-      memberNumber: '100099',
-      role: 'member',
-    })
-
-    const logoutResponse = await logoutRoute.POST(createJsonRequest('/api/auth/logout'))
-    expect(logoutResponse.status).toBe(200)
-    await expect(logoutResponse.json()).resolves.toEqual({ success: true })
-  })
-
-  it('returns 401 from /me when current-user resolution is unauthorized', async () => {
-    const { GET } = await import('@/app/api/auth/me/route')
-    const { ServiceError } = await import('@/lib/server/shared/service-error')
-    getCurrentUserMock.mockRejectedValueOnce(new ServiceError('Unauthorized', 401))
-
-    const response = await GET(new NextRequest('http://localhost:3000/api/auth/me'))
-
-    expect(response.status).toBe(401)
-    await expect(response.json()).resolves.toMatchObject({ statusCode: 401 })
-  })
-
-  it('returns 401 from /me when there is no authenticated session', async () => {
-    const { GET } = await import('@/app/api/auth/me/route')
-    getCurrentUserMock.mockRejectedValueOnce(new Error('No session'))
-
-    const response = await GET(new NextRequest('http://localhost:3000/api/auth/me'))
-
-    expect(response.status).toBe(401)
-    await expect(response.json()).resolves.toMatchObject({ statusCode: 401 })
   })
 
   it('rejects logout requests from a different origin', async () => {
@@ -396,14 +195,162 @@ describe('auth API routes', () => {
     expect(response.status).toBe(403)
   })
 
-  it('maps logout service failures to a 500 response', async () => {
+  it('rejects logout requests without a CSRF token', async () => {
     const { POST } = await import('@/app/api/auth/logout/route')
-    const { ServiceError } = await import('@/lib/server/shared/service-error')
-    logoutWithClientMock.mockRejectedValueOnce(new ServiceError('Internal server error', 500))
+
+    const response = await POST(
+      createJsonRequest('/api/auth/logout', undefined, {
+        csrfToken: null,
+      }),
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('retires the legacy logout route with a 410 response', async () => {
+    const { POST } = await import('@/app/api/auth/logout/route')
 
     const response = await POST(createJsonRequest('/api/auth/logout'))
 
-    expect(response.status).toBe(500)
-    await expect(response.json()).resolves.toMatchObject({ statusCode: 500 })
+    expect(response.status).toBe(410)
+    await expect(response.json()).resolves.toMatchObject({ statusCode: 410 })
+  })
+
+  it('rejects logout requests from a different origin', async () => {
+    const { POST } = await import('@/app/api/auth/logout/route')
+
+    const response = await POST(
+      createJsonRequest('/api/auth/logout', undefined, {
+        origin: 'https://attacker.example',
+      }),
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects logout requests without a CSRF token', async () => {
+    const { POST } = await import('@/app/api/auth/logout/route')
+
+    const response = await POST(
+      createJsonRequest('/api/auth/logout', undefined, {
+        csrfToken: null,
+      }),
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects register requests from a different origin', async () => {
+    const { POST } = await import('@/app/api/auth/register/route')
+
+    const response = await POST(
+      createJsonRequest('/api/auth/register', { memberNumber: '100099', password: 'Password123' }, {
+        origin: 'https://attacker.example',
+      }),
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects register requests without a CSRF token', async () => {
+    const { POST } = await import('@/app/api/auth/register/route')
+
+    const response = await POST(
+      createJsonRequest('/api/auth/register', { memberNumber: '100099', password: 'Password123' }, {
+        csrfToken: null,
+      }),
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('reads the session from /me for a mapped Clerk user', async () => {
+    const { GET } = await import('@/app/api/auth/me/route')
+    clerkAuthMock.mockResolvedValueOnce({ userId: 'clerk-user-2' })
+    drizzleLimitMock.mockResolvedValueOnce([{ id: 'user-2', role: 'member', isActive: true }])
+
+    const response = await GET(new NextRequest('http://localhost:3000/api/auth/me'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      memberNumber: '100099',
+      role: 'member',
+    })
+  })
+
+  it('uses the Neon profile role for a mapped Clerk admin', async () => {
+    const { GET } = await import('@/app/api/auth/me/route')
+    clerkAuthMock.mockResolvedValueOnce({ userId: 'clerk-admin' })
+    drizzleLimitMock.mockResolvedValueOnce([{ id: 'admin-1', role: 'admin', isActive: true }])
+    getCurrentUserMock.mockResolvedValueOnce({
+      id: 'admin-1',
+      memberNumber: '100001',
+      role: 'admin',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    })
+
+    const response = await GET(new NextRequest('http://localhost:3000/api/auth/me'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ role: 'admin' })
+  })
+
+  it('returns 401 from /me when there is no authenticated session', async () => {
+    const { GET } = await import('@/app/api/auth/me/route')
+
+    const response = await GET(new NextRequest('http://localhost:3000/api/auth/me'))
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toMatchObject({ statusCode: 401 })
+  })
+
+  it('returns 401 from /me when the Clerk user is unmapped', async () => {
+    const { GET } = await import('@/app/api/auth/me/route')
+    clerkAuthMock.mockResolvedValueOnce({ userId: 'clerk-unmapped' })
+    drizzleLimitMock.mockResolvedValueOnce([])
+
+    const response = await GET(new NextRequest('http://localhost:3000/api/auth/me'))
+
+    expect(response.status).toBe(401)
+  })
+
+  it('returns 401 from /me when the mapped profile is inactive', async () => {
+    const { GET } = await import('@/app/api/auth/me/route')
+    clerkAuthMock.mockResolvedValueOnce({ userId: 'clerk-suspended' })
+    drizzleLimitMock.mockResolvedValueOnce([{ id: 'user-2', role: 'member', isActive: false }])
+
+    const response = await GET(new NextRequest('http://localhost:3000/api/auth/me'))
+
+    expect(response.status).toBe(401)
+  })
+
+  it('retires the legacy logout route with a 410 response', async () => {
+    const { POST } = await import('@/app/api/auth/logout/route')
+
+    const response = await POST(createJsonRequest('/api/auth/logout'))
+
+    expect(response.status).toBe(410)
+    await expect(response.json()).resolves.toMatchObject({ statusCode: 410 })
+  })
+
+  it('rejects logout requests from a different origin', async () => {
+    const { POST } = await import('@/app/api/auth/logout/route')
+
+    const response = await POST(
+      createJsonRequest('/api/auth/logout', undefined, { origin: 'https://attacker.example' }),
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects logout requests without a CSRF token', async () => {
+    const { POST } = await import('@/app/api/auth/logout/route')
+
+    const response = await POST(
+      createJsonRequest('/api/auth/logout', undefined, { csrfToken: null }),
+    )
+
+    expect(response.status).toBe(403)
   })
 })

--- a/tests/unit/app/api/authjs-route.test.ts
+++ b/tests/unit/app/api/authjs-route.test.ts
@@ -1,95 +1,50 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 
-const handlersGetMock = vi.fn()
-const handlersPostMock = vi.fn()
-
-vi.mock('@/lib/authjs/auth', () => ({
-  handlers: {
-    GET: handlersGetMock,
-    POST: handlersPostMock,
-  },
-}))
-
-describe('Auth.js route handler', () => {
+describe('retired Auth.js route', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     vi.unstubAllEnvs()
   })
 
-  describe('AUTH_JS_ENABLED guard', () => {
-    it('returns 404 when AUTH_JS_ENABLED is unset', async () => {
-      // AUTH_JS_ENABLED is unset by default
-      const { GET, POST } = await import('@/app/api/authjs/[...nextauth]/route')
+  it('returns 404 for GET requests', async () => {
+    const { GET } = await import('@/app/api/authjs/[...nextauth]/route')
+    const response = await GET(new NextRequest('http://localhost:3000/api/authjs/session'))
 
-      const getResponse = await GET(new NextRequest('http://localhost:3000/api/authjs/signin'))
-      expect(getResponse.status).toBe(404)
-      expect(handlersGetMock).not.toHaveBeenCalled()
+    expect(response.status).toBe(404)
+  })
 
-      const postResponse = await POST(new NextRequest('http://localhost:3000/api/authjs/signin', {
-        method: 'POST',
-      }))
-      expect(postResponse.status).toBe(404)
-      expect(handlersPostMock).not.toHaveBeenCalled()
-    })
+  it('returns 404 for POST requests', async () => {
+    const { POST } = await import('@/app/api/authjs/[...nextauth]/route')
+    const response = await POST(new NextRequest('http://localhost:3000/api/authjs/session', {
+      method: 'POST',
+    }))
 
-    it('returns 404 when AUTH_JS_ENABLED is false', async () => {
-      vi.stubEnv('AUTH_JS_ENABLED', 'false')
-      const { GET, POST } = await import('@/app/api/authjs/[...nextauth]/route')
+    expect(response.status).toBe(404)
+  })
 
-      const getResponse = await GET(new NextRequest('http://localhost:3000/api/authjs/signin'))
-      expect(getResponse.status).toBe(404)
-      expect(handlersGetMock).not.toHaveBeenCalled()
+  it('cannot be re-enabled through AUTH_JS_ENABLED for GET requests', async () => {
+    vi.stubEnv('AUTH_JS_ENABLED', 'true')
+    const { GET } = await import('@/app/api/authjs/[...nextauth]/route')
 
-      const postResponse = await POST(new NextRequest('http://localhost:3000/api/authjs/signin', {
-        method: 'POST',
-      }))
-      expect(postResponse.status).toBe(404)
-      expect(handlersPostMock).not.toHaveBeenCalled()
-    })
+    expect((await GET(new NextRequest('http://localhost:3000/api/authjs/session'))).status).toBe(404)
+  })
 
-    it('returns 404 when AUTH_JS_ENABLED is any value other than "true"', async () => {
-      vi.stubEnv('AUTH_JS_ENABLED', 'yes')
-      const { GET, POST } = await import('@/app/api/authjs/[...nextauth]/route')
+  it('cannot be re-enabled through AUTH_JS_ENABLED for POST requests', async () => {
+    vi.stubEnv('AUTH_JS_ENABLED', 'true')
+    const { POST } = await import('@/app/api/authjs/[...nextauth]/route')
 
-      const getResponse = await GET(new NextRequest('http://localhost:3000/api/authjs/signin'))
-      expect(getResponse.status).toBe(404)
-      expect(handlersGetMock).not.toHaveBeenCalled()
+    expect((await POST(new NextRequest('http://localhost:3000/api/authjs/session', {
+      method: 'POST',
+    }))).status).toBe(404)
+  })
 
-      const postResponse = await POST(new NextRequest('http://localhost:3000/api/authjs/signin', {
-        method: 'POST',
-      }))
-      expect(postResponse.status).toBe(404)
-      expect(handlersPostMock).not.toHaveBeenCalled()
-    })
+  it('returns an empty response without session cookies', async () => {
+    const { GET } = await import('@/app/api/authjs/[...nextauth]/route')
+    const request = new NextRequest('http://localhost:3000/api/authjs/session')
+    const response = await GET(request)
 
-    it('delegates to handlers.GET when AUTH_JS_ENABLED is "true"', async () => {
-      vi.stubEnv('AUTH_JS_ENABLED', 'true')
-      const mockResponse = new NextResponse(JSON.stringify({ status: 'ok' }), { status: 200 })
-      handlersGetMock.mockResolvedValueOnce(mockResponse)
-
-      const { GET } = await import('@/app/api/authjs/[...nextauth]/route')
-      const request = new NextRequest('http://localhost:3000/api/authjs/signin')
-      const response = await GET(request)
-
-      expect(handlersGetMock).toHaveBeenCalledWith(request)
-      expect(response).toBe(mockResponse)
-    })
-
-    it('delegates to handlers.POST when AUTH_JS_ENABLED is "true"', async () => {
-      vi.stubEnv('AUTH_JS_ENABLED', 'true')
-      const mockResponse = new NextResponse(JSON.stringify({ status: 'ok' }), { status: 200 })
-      handlersPostMock.mockResolvedValueOnce(mockResponse)
-
-      const { POST } = await import('@/app/api/authjs/[...nextauth]/route')
-      const request = new NextRequest('http://localhost:3000/api/authjs/signin', {
-        method: 'POST',
-      })
-      const response = await POST(request)
-
-      expect(handlersPostMock).toHaveBeenCalledWith(request)
-      expect(response).toBe(mockResponse)
-    })
+    await expect(response.text()).resolves.toBe('')
+    expect(response.headers.get('set-cookie')).toBeNull()
   })
 })

--- a/tests/unit/app/auth-password-flows.test.tsx
+++ b/tests/unit/app/auth-password-flows.test.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ActivationForm } from '@/components/auth/activation-form'
+import { RecoveryForm } from '@/components/auth/recovery-form'
+import esMessages from '@/messages/es.json'
+
+const routerPushMock = vi.fn()
+
+const apiClientMock = vi.hoisted(() => ({
+  post: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: routerPushMock }),
+}))
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: apiClientMock,
+}))
+
+function renderWithIntl(ui: ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="es" messages={esMessages}>
+      {ui}
+    </NextIntlClientProvider>,
+  )
+}
+
+describe('password setup flows', () => {
+  beforeEach(() => {
+    apiClientMock.post.mockReset()
+    routerPushMock.mockReset()
+  })
+
+  it('redirects to login after a successful activation', async () => {
+    apiClientMock.post.mockResolvedValueOnce({ ok: true })
+    renderWithIntl(<ActivationForm locale="es" token="activation-token" />)
+
+    fireEvent.change(screen.getByLabelText('Contraseña'), {
+      target: { value: 'Password123' },
+    })
+    fireEvent.change(screen.getByLabelText('Confirmar contraseña'), {
+      target: { value: 'Password123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Activar cuenta' }))
+
+    await waitFor(() => {
+      expect(apiClientMock.post).toHaveBeenCalledWith('/auth/activate', {
+        token: 'activation-token',
+        password: 'Password123',
+      })
+    })
+    await waitFor(() => expect(routerPushMock).toHaveBeenCalledWith('/es/login'))
+  })
+
+  it('redirects to login after a successful recovery', async () => {
+    apiClientMock.post.mockResolvedValueOnce({ ok: true })
+    renderWithIntl(<RecoveryForm locale="es" token="recovery-token" />)
+
+    fireEvent.change(screen.getByLabelText('Contraseña'), {
+      target: { value: 'Password123' },
+    })
+    fireEvent.change(screen.getByLabelText('Confirmar contraseña'), {
+      target: { value: 'Password123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar nueva contraseña' }))
+
+    await waitFor(() => {
+      expect(apiClientMock.post).toHaveBeenCalledWith('/auth/recover', {
+        token: 'recovery-token',
+        password: 'Password123',
+      })
+    })
+    await waitFor(() => expect(routerPushMock).toHaveBeenCalledWith('/es/login'))
+  })
+})

--- a/tests/unit/app/middleware.test.ts
+++ b/tests/unit/app/middleware.test.ts
@@ -5,30 +5,23 @@ import { NextRequest, NextResponse } from 'next/server'
 const createI18nResponse = vi.fn((request: NextRequest) =>
   NextResponse.redirect(new URL('/es', request.url)),
 )
-const getTokenMock = vi.fn()
 
 vi.mock('next-intl/middleware', () => ({
   default: vi.fn(() => (request: NextRequest) => createI18nResponse(request)),
 }))
 
-vi.mock('next-auth/jwt', () => ({
-  getToken: getTokenMock,
-}))
-
-vi.mock('@/lib/authjs/config-edge', () => ({
-  AUTHJS_SESSION_COOKIE_NAME: 'authjs.session-token',
+vi.mock('@clerk/nextjs/server', () => ({
+  clerkMiddleware: vi.fn((handler: (auth: unknown, request: NextRequest) => Response | Promise<Response>) =>
+    (request: NextRequest) => handler({}, request)),
 }))
 
 describe('middleware', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
-    vi.unstubAllEnvs()
-    vi.stubEnv('AUTH_SECRET', 'test-secret')
-    getTokenMock.mockResolvedValue(null)
   })
 
-  it('preserves the locale middleware response while reading Auth.js JWT session', async () => {
+  it('preserves the locale middleware response while setting a CSRF cookie', async () => {
     const middleware = (await import('@/middleware')).default
 
     const response = await middleware(new NextRequest('http://localhost:3000/rooms'))
@@ -38,7 +31,6 @@ describe('middleware', () => {
     expect(csrfCookie?.value).toBeTruthy()
     expect(csrfCookie?.httpOnly).toBe(false)
     expect(csrfCookie?.sameSite).toBe('lax')
-
   })
 
   it('does not rewrite the CSRF cookie when a valid token already exists', async () => {
@@ -53,4 +45,11 @@ describe('middleware', () => {
     expect(response.cookies.get('alea-csrf-token')).toBeUndefined()
   })
 
+  it('sets the CSRF cookie for matched api requests too', async () => {
+    const middleware = (await import('@/middleware')).default
+
+    const response = await middleware(new NextRequest('http://localhost:3000/api/auth/me'))
+
+    expect(response.cookies.get('alea-csrf-token')?.value).toBeTruthy()
+  })
 })

--- a/tests/unit/lib/auth-context.test.tsx
+++ b/tests/unit/lib/auth-context.test.tsx
@@ -3,10 +3,26 @@ import type { User } from '@/lib/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const routerPushMock = vi.fn()
+const clerkSignOutMock = vi.fn()
+const signInPasswordMock = vi.fn()
+const signInFinalizeMock = vi.fn()
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: routerPushMock }),
   usePathname: () => '/es/rooms',
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useAuth: () => ({ isLoaded: true, userId: 'clerk-user-1' }),
+  useClerk: () => ({ signOut: clerkSignOutMock }),
+  useSignIn: () => ({
+    fetchStatus: 'idle',
+    signIn: {
+      password: signInPasswordMock,
+      finalize: signInFinalizeMock,
+      status: 'complete',
+    },
+  }),
 }))
 
 const apiClientMock = vi.hoisted(() => ({
@@ -34,6 +50,9 @@ describe('AuthProvider', () => {
     apiClientMock.get.mockReset()
     apiClientMock.post.mockReset()
     routerPushMock.mockReset()
+    clerkSignOutMock.mockReset()
+    signInPasswordMock.mockReset()
+    signInFinalizeMock.mockReset()
   })
 
   it('hydrates from /auth/me when no initial user is provided', async () => {
@@ -90,10 +109,10 @@ describe('AuthProvider', () => {
       role: 'member',
     })
 
-    apiClientMock.post
-      .mockResolvedValueOnce(loggedInUser)
-      .mockResolvedValueOnce(registeredUser)
-      .mockResolvedValueOnce(undefined)
+    signInPasswordMock.mockResolvedValueOnce({ error: null })
+    signInFinalizeMock.mockResolvedValueOnce({ error: null })
+    apiClientMock.get.mockResolvedValueOnce(loggedInUser)
+    apiClientMock.post.mockResolvedValueOnce(registeredUser)
 
     const { AuthProvider, useAuth } = await import('@/lib/auth/auth-context')
     const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -103,10 +122,15 @@ describe('AuthProvider', () => {
     const { result } = renderHook(() => useAuth(), { wrapper })
 
     await act(async () => {
-      await result.current.login('admin@alea.club', 'Admin123')
+      await result.current.login('100001', 'Admin123')
     })
 
     expect(result.current.user).toEqual(loggedInUser)
+    expect(signInPasswordMock).toHaveBeenCalledWith({
+      identifier: '100001@members.alea.internal',
+      password: 'Admin123',
+    })
+    expect(signInFinalizeMock).toHaveBeenCalledOnce()
 
     await act(async () => {
       await result.current.register('100099', 'Password123')
@@ -120,6 +144,25 @@ describe('AuthProvider', () => {
 
     expect(result.current.user).toBeNull()
     expect(result.current.isAuthenticated).toBe(false)
+    expect(clerkSignOutMock).toHaveBeenCalledOnce()
     expect(routerPushMock).toHaveBeenCalledWith('/es/login')
+  })
+
+  it('signs Clerk out when the authenticated identity is unmapped or suspended', async () => {
+    signInPasswordMock.mockResolvedValueOnce({ error: null })
+    signInFinalizeMock.mockResolvedValueOnce({ error: null })
+    apiClientMock.get.mockRejectedValueOnce(new Error('Unauthorized'))
+
+    const { AuthProvider, useAuth } = await import('@/lib/auth/auth-context')
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider initialUser={null}>{children}</AuthProvider>
+    )
+    const { result } = renderHook(() => useAuth(), { wrapper })
+
+    await expect(
+      act(async () => result.current.login('100099', 'Password123')),
+    ).rejects.toThrow('Invalid credentials')
+    expect(clerkSignOutMock).toHaveBeenCalledOnce()
+    expect(result.current.user).toBeNull()
   })
 })

--- a/tests/unit/lib/auth-context.test.tsx
+++ b/tests/unit/lib/auth-context.test.tsx
@@ -159,10 +159,17 @@ describe('AuthProvider', () => {
     )
     const { result } = renderHook(() => useAuth(), { wrapper })
 
-    await expect(
-      act(async () => result.current.login('100099', 'Password123')),
-    ).rejects.toThrow('Invalid credentials')
-    expect(clerkSignOutMock).toHaveBeenCalledOnce()
-    expect(result.current.user).toBeNull()
+    let loginError: unknown
+    await act(async () => {
+      try {
+        await result.current.login('100099', 'Password123')
+      } catch (error) {
+        loginError = error
+      }
+    })
+
+    expect(loginError).toEqual(new Error('Invalid credentials'))
+    await waitFor(() => expect(clerkSignOutMock).toHaveBeenCalledOnce())
+    await waitFor(() => expect(result.current.user).toBeNull())
   })
 })

--- a/tests/unit/server/auth-service.test.ts
+++ b/tests/unit/server/auth-service.test.ts
@@ -247,144 +247,71 @@ describe('auth service', () => {
   })
 
   describe('login', () => {
-    it('returns the public user for a valid member number / password pair', async () => {
-      const profile = makeProfile({ id: 'user-1', member_number: '100001' })
-      adminState.byMemberNumber.set('100001', profile)
-      adminState.byId.set('user-1', profile)
-      adminState.byEmail.set('admin@alea.club', profile)
-      authJsSignInMock.mockResolvedValueOnce({ ok: true })
-
+    it('retires valid credential submissions with 410', async () => {
       const { login } = await loadService()
-      const result = await login({ identifier: '100001', password: 'password123' })
 
-      expect(result).toMatchObject({
-        id: 'user-1',
-        role: 'admin',
-        memberNumber: '100001',
-      })
-      expect(authJsSignInMock).toHaveBeenCalled()
+      await expect(login({ identifier: '100001', password: 'password123' }))
+        .rejects.toMatchObject({ statusCode: 410 })
     })
 
-    it('resolves the member number to the Supabase Auth email before signing in', async () => {
-      const profile = makeProfile({ member_number: '100001', auth_email: 'admin@alea.club' })
-      adminState.byMemberNumber.set('100001', profile)
-      adminState.byId.set('user-1', profile)
-      adminState.byEmail.set('admin@alea.club', profile)
-      authJsSignInMock.mockResolvedValueOnce({ ok: true })
-
+    it('does not expose whether a member number exists', async () => {
       const { login } = await loadService()
-      const result = await login({ identifier: '100001', password: 'password123' })
 
-      expect(result.id).toBe('user-1')
-      expect(authJsSignInMock).toHaveBeenCalled()
+      await expect(login({ identifier: '999999', password: 'password123' }))
+        .rejects.toThrow('Interactive login is handled by Clerk')
     })
 
-    it('rejects missing credentials with a 400 ServiceError', async () => {
+    it('retires missing credential submissions with 410', async () => {
       const { login } = await loadService()
 
-      await expect(login({})).rejects.toThrow()
+      await expect(login({})).rejects.toMatchObject({ statusCode: 410 })
     })
 
-    it('rejects an unknown member number with a 401 ServiceError', async () => {
+    it('retires invalid password submissions with 410', async () => {
       const { login } = await loadService()
 
-      await expect(login({ identifier: '999999', password: 'password123' })).rejects.toThrow()
+      await expect(login({ identifier: '100001', password: 'wrongpassword' }))
+        .rejects.toMatchObject({ statusCode: 410 })
     })
 
-    it('rejects invalid credentials when credential verification fails', async () => {
-      const profile = makeProfile({ member_number: '100001' })
-      adminState.byMemberNumber.set('100001', profile)
-      adminState.byId.set('user-1', profile)
-      adminState.byEmail.set('admin@alea.club', profile)
-      const { AuthError } = await import('next-auth')
-      authJsSignInMock.mockRejectedValueOnce(new AuthError('Invalid credentials'))
-
+    it('retires suspended member submissions without profile lookup', async () => {
+      adminState.byMemberNumber.set('100001', makeProfile({ is_active: false }))
       const { login } = await loadService()
 
-      await expect(login({ identifier: '100001', password: 'wrongpassword' })).rejects.toThrow()
+      await expect(login({ identifier: '100001', password: 'password123' }))
+        .rejects.toMatchObject({ statusCode: 410 })
+      expect(drizzleSelectMock).not.toHaveBeenCalled()
     })
 
-    it('rejects a suspended user (is_active: false) with a 401 ServiceError before signing in', async () => {
-      const profile = makeProfile({ member_number: '100001', is_active: false })
-      adminState.byMemberNumber.set('100001', profile)
-
+    it('retires email identifier submissions with 410', async () => {
       const { login } = await loadService()
 
-      await expect(login({ identifier: '100001', password: 'password123' })).rejects.toThrow()
+      await expect(login({ identifier: 'member@example.com', password: 'password123' }))
+        .rejects.toMatchObject({ statusCode: 410 })
     })
 
-    it('rejects when the credential profile has no auth email', async () => {
-      const profile = makeProfile({ member_number: '100001', auth_email: '', email: undefined })
-      adminState.byMemberNumber.set('100001', profile)
-
+    it('retires empty identifier submissions with 410', async () => {
       const { login } = await loadService()
 
-      await expect(login({ identifier: '100001', password: 'password123' })).rejects.toThrow()
+      await expect(login({ identifier: '', password: 'password123' }))
+        .rejects.toMatchObject({ statusCode: 410 })
       expect(verifyCredentialsMock).not.toHaveBeenCalled()
     })
 
-  })
-
-    it('rejects when authenticated identity differs from member-number-resolved profile (identity-drift guard)', async () => {
-      const credentialProfile = makeProfile({ id: 'user-1', member_number: '100001' })
-      adminState.byMemberNumber.set('100001', credentialProfile)
-      adminState.byId.set('user-1', credentialProfile)
-      adminState.byEmail.set('admin@alea.club', credentialProfile)
-      
-      // verifyCredentials() authenticates a DIFFERENT user ID than the profile we resolved
-      verifyCredentialsMock.mockResolvedValueOnce({
-        id: 'different-user-id',
-        member_number: '100001',
-        auth_email: 'admin@alea.club',
-        email: 'admin@alea.club',
-        role: 'member' as const,
-        is_active: true,
-        created_at: '2024-01-01T00:00:00Z',
-        updated_at: '2024-01-01T00:00:00Z',
-      })
-
+    it('never invokes the retired Auth.js sign-in runtime', async () => {
       const { login } = await loadService()
 
-      // (a) Assertion: login rejects with 401
-      await expect(login({ identifier: '100001', password: 'Admin123' })).rejects.toThrow('Invalid credentials')
-      
-      // (b) Assertion: authJsSignIn is NEVER called
-      // This proves no session cookie was ever issued, even though credentials were valid.
-      // The new design verifies identity BEFORE calling signIn, so a mismatch never results in
-      // any session being issued at all — no window where a valid session rides on a 401 response.
+      await expect(login({ identifier: '100001', password: 'Admin123' })).rejects.toThrow()
       expect(authJsSignInMock).not.toHaveBeenCalled()
     })
 
-
-    it('never attempts same-request session readback via auth() during login (regression guard for KIM-433 root cause)', async () => {
-      const profile = makeProfile({ member_number: '100001' })
-      adminState.byMemberNumber.set('100001', profile)
-      adminState.byId.set('user-1', profile)
-      adminState.byEmail.set('admin@alea.club', profile)
-      
-      // Mock verifyCredentials to succeed with matching ID
-      verifyCredentialsMock.mockResolvedValueOnce({
-        id: 'user-1',
-        member_number: '100001',
-        auth_email: 'admin@alea.club',
-        email: 'admin@alea.club',
-        role: 'member' as const,
-        is_active: true,
-        created_at: '2024-01-01T00:00:00Z',
-        updated_at: '2024-01-01T00:00:00Z',
-      })
-
+    it('never invokes retired Auth.js session reads', async () => {
       const { login } = await loadService()
-      await login({ identifier: '100001', password: 'Admin123' })
 
-      // Trip-wire: auth() should NEVER be called. This guards against a regression
-      // that reintroduces the broken same-request readback pattern (see
-      // establishAuthJsSession() doc comment in lib/server/auth/auth-service.ts
-      // for why that pattern fails: auth() reads from frozen incoming-request
-      // headers snapshot while signIn() writes to mutable cookie jar; the snapshot
-      // doesn't see the write in the same request).
+      await expect(login({ identifier: '100001', password: 'Admin123' })).rejects.toThrow()
       expect(authJsAuthMock).not.toHaveBeenCalled()
     })
+  })
 
   describe('register', () => {
     it('creates a Supabase Auth user, inserts the Drizzle profile row, and returns the public user', async () => {
@@ -402,7 +329,7 @@ describe('auth service', () => {
       })
     })
 
-    it('calls Auth.js signIn after creating the profile to establish a session', async () => {
+    it('does not establish an Auth.js session after registration', async () => {
       authCreateUserMock.mockResolvedValueOnce({ data: { user: { id: 'new-user-id' } }, error: null })
       verifyCredentialsMock.mockResolvedValueOnce({
         id: 'new-user-id',
@@ -418,7 +345,7 @@ describe('auth service', () => {
         password: 'Password123',
       })
 
-      expect(authJsSignInMock).toHaveBeenCalled()
+      expect(authJsSignInMock).not.toHaveBeenCalled()
     })
 
     it('persists the internal auth email during registration', async () => {
@@ -495,7 +422,7 @@ describe('auth service', () => {
       await expect(register({ memberNumber: '100099', password: 'Password123' })).rejects.toThrow('Failed to create user profile')
     })
 
-    it('succeeds even when auto-login after registration fails', async () => {
+    it('does not depend on the retired Auth.js runtime after registration', async () => {
       authCreateUserMock.mockResolvedValueOnce({ data: { user: { id: 'new-user-id' } }, error: null })
       verifyCredentialsMock.mockResolvedValueOnce({
         id: 'new-user-id',
@@ -504,16 +431,16 @@ describe('auth service', () => {
         role: 'member' as const,
         isActive: true,
       })
-      // signInWithAuthJs calls authJsSignIn, which should reject on auth failure
       authJsSignInMock.mockRejectedValueOnce(new Error('Auth failed'))
 
       const { register } = await loadService()
       const result = await register({ memberNumber: '100099', password: 'Password123' })
 
       expect(result.id).toBe('new-user-id')
+      expect(authJsSignInMock).not.toHaveBeenCalled()
     })
 
-    it('creates a session with Auth.js when no session client is provided', async () => {
+    it('does not create a legacy session when no session client is provided', async () => {
       authCreateUserMock.mockResolvedValueOnce({ data: { user: { id: 'new-user-id' } }, error: null })
       verifyCredentialsMock.mockResolvedValueOnce({
         id: 'new-user-id',
@@ -526,7 +453,7 @@ describe('auth service', () => {
       const { register } = await loadService()
       await register({ memberNumber: '100099', password: 'Password123' })
 
-      expect(authJsSignInMock).toHaveBeenCalled()
+      expect(authJsSignInMock).not.toHaveBeenCalled()
     })
 
     it('cleans up the auth user and rejects when profile insert returns no row', async () => {
@@ -565,39 +492,37 @@ describe('auth service', () => {
   })
 
   describe('logout', () => {
-    it('returns success when the server client signs out cleanly', async () => {
+    it('retires server-side logout with 410', async () => {
       signOut.mockResolvedValueOnce({ error: null })
 
       const { logout } = await loadService()
-      const result = await logout()
-
-      expect(result).toEqual({ success: true })
-      expect(authJsSignOutMock).toHaveBeenCalled()
+      await expect(logout()).rejects.toMatchObject({ statusCode: 410 })
+      expect(authJsSignOutMock).not.toHaveBeenCalled()
     })
 
-    it('maps sign-out failures to a 500 ServiceError', async () => {
+    it('does not invoke Auth.js when its sign-out would fail', async () => {
       authJsSignOutMock.mockRejectedValueOnce(new Error('Signout failed'))
 
       const { logout } = await loadService()
 
-      await expect(logout()).rejects.toThrow()
+      await expect(logout()).rejects.toMatchObject({ statusCode: 410 })
+      expect(authJsSignOutMock).not.toHaveBeenCalled()
     })
 
-    it('maps route-handler sign-out failures to a 500 ServiceError', async () => {
+    it('always reports retired logout independently of Auth.js state', async () => {
       authJsSignOutMock.mockRejectedValueOnce(new Error('Auth.js signout failed'))
 
       const { logout } = await loadService()
 
-      await expect(logout()).rejects.toThrow()
+      await expect(logout()).rejects.toThrow('Interactive logout is handled by Clerk')
     })
 
-    it('returns success when a route-handler client signs out cleanly', async () => {
+    it('retires the compatibility logout helper with 410', async () => {
       signOut.mockResolvedValueOnce({ error: null })
 
       const { logoutWithClient } = await loadService()
-      const result = await logoutWithClient()
-
-      expect(result).toEqual({ success: true })
+      await expect(logoutWithClient()).rejects.toMatchObject({ statusCode: 410 })
+      expect(authJsSignOutMock).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/server/auth.test.ts
+++ b/tests/unit/server/auth.test.ts
@@ -2,19 +2,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest, NextResponse } from 'next/server'
 
-const authJsAuthMock = vi.fn()
+const clerkAuthMock = vi.fn()
 const drizzleSelectMock = vi.fn()
 const drizzleFromMock = vi.fn()
 const drizzleWhereMock = vi.fn()
 const drizzleLimitMock = vi.fn()
+const eqMock = vi.fn((column, value) => ({ column, value }))
 
-// Mock Auth.js auth() to prevent loading next-auth
-vi.mock('@/lib/authjs/auth', () => ({
-  auth: authJsAuthMock,
-  handlers: { GET: vi.fn(), POST: vi.fn() },
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>()
+  return { ...actual, eq: eqMock }
+})
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: clerkAuthMock,
+  clerkMiddleware: vi.fn((handler: unknown) => handler),
 }))
 
-// Mock Drizzle database
 vi.mock('@/lib/db', () => ({
   getDrizzleDb: vi.fn(() => ({
     select: drizzleSelectMock,
@@ -23,66 +27,57 @@ vi.mock('@/lib/db', () => ({
   getAdminDb: vi.fn(),
 }))
 
-// Mock next-auth/jwt to prevent loading next-auth
-vi.mock('next-auth/jwt', () => ({
-  getToken: vi.fn(),
-}))
-
-function withSession(userId = 'user-1', role: 'member' | 'admin' = 'admin') {
-  const sessionResult = { user: { id: userId } }
-  const profileResult = [
-    {
-      id: userId,
-      role,
-      isActive: true,
-      email: 'admin@alea.club',
-      memberNumber: '100001',
-      createdAt: '2024-01-01T00:00:00.000Z',
-      updatedAt: '2024-01-01T00:00:00.000Z',
-    },
-  ]
-  authJsAuthMock.mockResolvedValue(sessionResult)
+function withSession(userId = 'clerk-user-1', role: 'member' | 'admin' = 'admin') {
+  clerkAuthMock.mockResolvedValue({ userId })
   drizzleSelectMock.mockReturnValue({ from: drizzleFromMock })
   drizzleFromMock.mockReturnValue({ where: drizzleWhereMock })
   drizzleWhereMock.mockReturnValue({ limit: drizzleLimitMock })
-  drizzleLimitMock.mockResolvedValue(profileResult)
+  drizzleLimitMock.mockResolvedValue([
+    {
+      id: 'profile-1',
+      role,
+      isActive: true,
+    },
+  ])
 }
 
 describe('server auth helpers', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
-    authJsAuthMock.mockResolvedValue(null)
+    clerkAuthMock.mockResolvedValue({ userId: null })
     drizzleSelectMock.mockReturnValue({ from: drizzleFromMock })
     drizzleFromMock.mockReturnValue({ where: drizzleWhereMock })
     drizzleWhereMock.mockReturnValue({ limit: drizzleLimitMock })
     drizzleLimitMock.mockResolvedValue([])
   })
 
-  it('reads the session from a request-scoped Drizzle client', async () => {
-    withSession('user-1', 'admin')
+  it('reads the session from a Clerk identity mapped in Drizzle', async () => {
+    withSession('clerk-admin', 'admin')
     const { getSessionFromRequest } = await import('@/lib/server/auth/auth')
+    const { profiles } = await import('@/lib/db/schema')
 
     await expect(
       getSessionFromRequest(new NextRequest('http://localhost:3000/api/auth/me')),
     ).resolves.toMatchObject({
-      session: { id: 'user-1', role: 'admin' },
+      session: { id: 'profile-1', role: 'admin' },
       applyCookies: expect.any(Function),
     })
+    expect(eqMock).toHaveBeenCalledWith(profiles.clerkUserId, 'clerk-admin')
   })
 
   it('reads the session from server cookies for SSR hydration', async () => {
-    withSession('user-2', 'member')
+    withSession('clerk-member', 'member')
     const { getSessionFromServerCookies } = await import('@/lib/server/auth/auth')
 
     await expect(getSessionFromServerCookies()).resolves.toEqual({
-      id: 'user-2',
+      id: 'profile-1',
       role: 'member',
     })
   })
 
-  it('returns null when the profile lookup fails after a valid auth session', async () => {
-    authJsAuthMock.mockResolvedValueOnce({ user: { id: 'user-1' } })
+  it('returns null when the Clerk user has no mapped profile', async () => {
+    clerkAuthMock.mockResolvedValueOnce({ userId: 'clerk-unmapped' })
     drizzleLimitMock.mockResolvedValueOnce([])
     const { getSessionFromRequest } = await import('@/lib/server/auth/auth')
 
@@ -91,10 +86,10 @@ describe('server auth helpers', () => {
     ).resolves.toMatchObject({ session: null })
   })
 
-  it('returns null when the profile is inactive', async () => {
-    authJsAuthMock.mockResolvedValueOnce({ user: { id: 'user-1' } })
+  it('returns null when the mapped profile is inactive', async () => {
+    clerkAuthMock.mockResolvedValueOnce({ userId: 'clerk-suspended' })
     drizzleLimitMock.mockResolvedValueOnce([
-      { id: 'user-1', role: 'admin', isActive: false },
+      { id: 'profile-1', role: 'admin', isActive: false },
     ])
     const { getSessionFromRequest } = await import('@/lib/server/auth/auth')
 
@@ -103,7 +98,7 @@ describe('server auth helpers', () => {
     ).resolves.toMatchObject({ session: null })
   })
 
-  it('returns 401 from requireAuth when no Auth.js session is present', async () => {
+  it('returns 401 from requireAuth when no Clerk session is present', async () => {
     const { requireAuth } = await import('@/lib/server/auth/auth')
 
     const response = await requireAuth(new NextRequest('http://localhost:3000/api/users'))
@@ -112,7 +107,7 @@ describe('server auth helpers', () => {
   })
 
   it('returns 403 from requireAdmin for authenticated members', async () => {
-    withSession('user-2', 'member')
+    withSession('clerk-member', 'member')
     const { requireAdmin } = await import('@/lib/server/auth/auth')
 
     const response = await requireAdmin(new NextRequest('http://localhost:3000/api/users'))
@@ -121,13 +116,13 @@ describe('server auth helpers', () => {
   })
 
   it('returns the session user from requireAdmin for admins', async () => {
-    withSession('user-1', 'admin')
+    withSession('clerk-admin', 'admin')
     const { requireAdmin } = await import('@/lib/server/auth/auth')
 
     await expect(
       requireAdmin(new NextRequest('http://localhost:3000/api/users')),
     ).resolves.toMatchObject({
-      session: { id: 'user-1', role: 'admin' },
+      session: { id: 'profile-1', role: 'admin' },
       applyCookies: expect.any(Function),
     })
   })
@@ -178,7 +173,6 @@ describe('server auth helpers', () => {
         },
       }),
     )
-
     expect(schemeMismatch?.status).toBe(403)
 
     const rejected = enforceSameOriginForMutation(
@@ -191,22 +185,17 @@ describe('server auth helpers', () => {
         },
       }),
     )
-
     expect(rejected?.status).toBe(403)
 
     const missingOrigin = enforceSameOriginForMutation(
-      new NextRequest('http://localhost:3000/api/auth/login', {
-        method: 'POST',
-      }),
+      new NextRequest('http://localhost:3000/api/auth/login', { method: 'POST' }),
     )
     expect(missingOrigin?.status).toBe(403)
 
     const malformedOrigin = enforceSameOriginForMutation(
       new NextRequest('http://localhost:3000/api/auth/login', {
         method: 'POST',
-        headers: {
-          origin: 'not-a-valid-origin',
-        },
+        headers: { origin: 'not-a-valid-origin' },
       }),
     )
     expect(malformedOrigin?.status).toBe(403)
@@ -227,9 +216,7 @@ describe('server auth helpers', () => {
     const missingCsrf = enforceSameOriginForMutation(
       new NextRequest('http://localhost:3000/api/auth/login', {
         method: 'POST',
-        headers: {
-          origin: 'http://localhost:3000',
-        },
+        headers: { origin: 'http://localhost:3000' },
       }),
     )
     expect(missingCsrf?.status).toBe(403)

--- a/tests/unit/server/availability.test.ts
+++ b/tests/unit/server/availability.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { GameTable } from '@/lib/types'
 import type { Tables } from '@/lib/supabase/types'
 import { resolveDate, normalizeTime, generateDaySlots, buildAvailability } from '@/lib/server/reservations/availability'
+import { getCurrentClubDate } from '@/lib/club-time'
 
 type ReservationRow = Tables<'reservations'>
 
@@ -35,22 +36,22 @@ function makeGameTable(overrides?: Partial<GameTable>): GameTable {
 
 describe('resolveDate', () => {
   it('returns today when input is null', () => {
-    const today = new Date().toISOString().split('T')[0]
+    const today = getCurrentClubDate()
     expect(resolveDate(null)).toBe(today)
   })
 
   it('returns today when input is undefined', () => {
-    const today = new Date().toISOString().split('T')[0]
+    const today = getCurrentClubDate()
     expect(resolveDate(undefined)).toBe(today)
   })
 
   it('returns today when input is empty string', () => {
-    const today = new Date().toISOString().split('T')[0]
+    const today = getCurrentClubDate()
     expect(resolveDate('')).toBe(today)
   })
 
   it('returns today when input is whitespace only', () => {
-    const today = new Date().toISOString().split('T')[0]
+    const today = getCurrentClubDate()
     expect(resolveDate('   ')).toBe(today)
   })
 


### PR DESCRIPTION
## Summary

- install and configure Clerk provider plus middleware alongside next-intl and CSRF handling
- move client login/logout and server session reads from Auth.js to Clerk
- resolve every authenticated Clerk identity through `profiles.clerk_user_id`
- keep `role` and `is_active` authorization authority in Neon
- reject anonymous, unmapped, and suspended identities
- permanently tombstone the Auth.js route and retire legacy login/logout API endpoints
- send activation and recovery completions to the locale-aware Clerk login page

## Security and behavior

- protected server paths never trust Clerk client metadata for authorization
- unmapped or inactive Clerk identities receive unauthorized responses
- client login signs Clerk out if Neon rejects the mapped identity
- existing CSRF and same-origin controls remain enforced on mutation endpoints

## Migration sequence

KIM-452 owns Clerk provisioning for activation, recovery, and admin lifecycle. KIM-453 owns backfilling existing member identities. Until those dependent issues land, profiles without `clerk_user_id` intentionally remain unauthorized.

## Validation

- exhaustive parallel security, performance, and QA review
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 1,195 passed
- `pnpm build`
- local pre-push CI hook passed

Linear: KIM-451