### PR TITLE
fix(auth): remove dead-end register() flow that fakes logged-in state

### DIFF
--- a/app/[locale]/register/page.tsx
+++ b/app/[locale]/register/page.tsx
@@ -1,4 +1,12 @@
-import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
+import { Sword, Scroll } from 'lucide-react'
+import { RegisterForm } from '@/components/auth/register-form'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('auth')
+  return { title: `${t('register')} -- Alea` }
+}
 
 interface RegisterPageProps {
   params: Promise<{ locale: string }>
@@ -6,5 +14,23 @@ interface RegisterPageProps {
 
 export default async function RegisterPage({ params }: RegisterPageProps) {
   const { locale } = await params
-  redirect(`/${locale}/login`)
+  const t = await getTranslations('auth')
+
+  return (
+    <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-8">
+          <div className="flex items-center justify-center gap-3 mb-4" aria-hidden="true">
+            <Scroll className="h-8 w-8 text-primary" />
+            <Sword className="h-8 w-8 text-primary" />
+          </div>
+          <h1 className="font-cinzel text-3xl font-bold text-gradient-gold mb-2">{t('register')}</h1>
+          <p className="text-muted-foreground">{t('registerSubtitle')}</p>
+        </div>
+        <div className="rpg-card p-8">
+          <RegisterForm locale={locale} />
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/app/[locale]/register/page.tsx
+++ b/app/[locale]/register/page.tsx
@@ -5,7 +5,7 @@ import { RegisterForm } from '@/components/auth/register-form'
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('auth')
-  return { title: `${t('register')} -- Alea` }
+  return { title: `${t('register')} — Alea` }
 }
 
 interface RegisterPageProps {

--- a/components/auth/register-form.tsx
+++ b/components/auth/register-form.tsx
@@ -1,119 +1,38 @@
-'use client'
-
-import { useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { useRouter } from 'next/navigation'
-import { useTranslations } from 'next-intl'
-import { Check, X } from 'lucide-react'
-import { DiceLoader } from '@/components/ui/dice-loader'
-import { getPasswordRequirementChecks, registerSchema, type RegisterFormData } from '@/lib/validations/auth'
-import { useAuth } from '@/lib/auth/auth-context'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { PasswordInput } from '@/components/ui/password-input'
-
-function PasswordStrengthIndicator({ password }: { password: string }) {
-  const t = useTranslations('auth.passwordRequirements')
-  const checks = getPasswordRequirementChecks(password)
-
-  return (
-    <ul className="mt-2 space-y-1" aria-label={t('title')}>
-      {checks.map((check) => (
-        <li key={check.key} className="flex items-center gap-2 text-xs">
-          {check.passed
-            ? <Check className="h-3 w-3 text-emerald-500 flex-shrink-0" aria-hidden="true" />
-            : <X className="h-3 w-3 text-muted-foreground flex-shrink-0" aria-hidden="true" />}
-          <span className={check.passed ? 'text-emerald-400' : 'text-muted-foreground'}>
-            {t(check.key)}
-          </span>
-          <span className="sr-only">{check.passed ? t('met') : t('pending')}</span>
-        </li>
-      ))}
-    </ul>
-  )
-}
+import Link from 'next/link'
+import { getTranslations } from 'next-intl/server'
 
 interface RegisterFormProps { locale: string }
 
-export function RegisterForm({ locale }: RegisterFormProps) {
-  const t = useTranslations('auth')
-  const { register: registerUser } = useAuth()
-  const router = useRouter()
-  const [serverError, setServerError] = useState<string | null>(null)
-
-  const { register, handleSubmit, watch, formState: { errors, isSubmitting } } = useForm<RegisterFormData>({
-    resolver: zodResolver(registerSchema),
-  })
-
-  const passwordValue = watch('password', '')
-  const allPasswordChecksPassed = getPasswordRequirementChecks(passwordValue).every((c) => c.passed)
-
-  const onSubmit = async (data: RegisterFormData) => {
-    setServerError(null)
-    try {
-      await registerUser(data.memberNumber, data.password)
-      router.push(`/${locale}/rooms`)
-    } catch (err: unknown) {
-      const error = err as { message?: string }
-      setServerError(error?.message ?? t('errors.invalidCredentials'))
-    }
-  }
+// Self-registration is disabled while the Clerk migration is in progress — the
+// /api/auth/register route unconditionally returns 410 Gone. This renders the
+// disabled-state explanation instead of a live sign-up form so users never
+// believe they successfully registered/authenticated (see GitHub issue #284).
+export async function RegisterForm({ locale }: RegisterFormProps) {
+  const t = await getTranslations('auth')
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-5">
-      {serverError && (
-        <div role="alert" className="rounded-md bg-destructive/15 border border-destructive/30 px-4 py-3 text-sm text-destructive">
-          {serverError}
+    <>
+      <div className="space-y-4 text-center">
+        <div className="rounded-md border border-primary/30 bg-primary/10 px-4 py-4 text-sm text-foreground">
+          <p className="font-medium">{t('registerUnavailableTitle')}</p>
+          <p className="mt-2 text-muted-foreground">{t('registerUnavailableBody')}</p>
         </div>
-      )}
-
-      <div className="space-y-1.5">
-        <Label htmlFor="memberNumber">{t('memberNumber')}</Label>
-        <Input id="memberNumber" type="text" placeholder="123456"
-          aria-describedby={errors.memberNumber ? 'memberNumber-error' : undefined}
-          aria-invalid={!!errors.memberNumber}
-          {...register('memberNumber')}
-        />
-        {errors.memberNumber && <p id="memberNumber-error" role="alert" className="text-xs text-destructive">{t(errors.memberNumber.message as Parameters<typeof t>[0])}</p>}
+        <Link
+          href={`/${locale}/login`}
+          className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {t('login')}
+        </Link>
       </div>
-
-      <div className="space-y-1.5">
-        <Label htmlFor="reg-password">{t('password')}</Label>
-        <PasswordInput id="reg-password" autoComplete="new-password"
-          aria-describedby="password-requirements"
-          aria-invalid={!!errors.password}
-          {...register('password')}
-        />
-        <div id="password-requirements"><PasswordStrengthIndicator password={passwordValue} /></div>
-        {errors.password && <p role="alert" className="text-xs text-destructive">{t(errors.password.message as Parameters<typeof t>[0])}</p>}
+      <div className="mt-6 text-center text-sm">
+        <span className="text-muted-foreground">{t('hasAccount')}</span>{' '}
+        <Link
+          href={`/${locale}/login`}
+          className="text-primary hover:text-primary/80 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+        >
+          {t('login')}
+        </Link>
       </div>
-
-      <div className="space-y-1.5">
-        <Label htmlFor="confirmPassword">{t('confirmPassword')}</Label>
-        <PasswordInput id="confirmPassword" variant="confirmation" autoComplete="new-password"
-          aria-describedby={errors.confirmPassword ? 'confirm-error' : undefined}
-          aria-invalid={!!errors.confirmPassword}
-          {...register('confirmPassword')}
-        />
-        {errors.confirmPassword && <p id="confirm-error" role="alert" className="text-xs text-destructive">{t(errors.confirmPassword.message as Parameters<typeof t>[0])}</p>}
-      </div>
-
-      <Button
-        type="submit"
-        className="w-full h-11 text-base font-semibold bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg shadow-primary/25 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none"
-        disabled={isSubmitting || !allPasswordChecksPassed}
-      >
-        {isSubmitting
-          ? (
-            <span className="inline-flex items-center gap-2">
-              <DiceLoader size="sm" />
-              <span>{t('register')}...</span>
-            </span>
-          )
-          : t('register')}
-      </Button>
-    </form>
+    </>
   )
 }

--- a/lib/auth/auth-context.tsx
+++ b/lib/auth/auth-context.tsx
@@ -83,9 +83,13 @@ export function AuthProvider({ children, initialUser }: { children: React.ReactN
     router.push(`/${locale}/login`)
   }
 
-  const register = async (memberNumber: string, password: string) => {
-    const data = await apiClient.post<User>(endpoints.auth.register, { memberNumber, password })
-    setUser(data)
+  // Self-registration has no server-side Clerk identity creation (see auth/register route,
+  // which unconditionally returns 410 Gone). register() must never call setUser() with data
+  // that doesn't reflect a real, verified Clerk session, so it fails closed immediately instead
+  // of trusting the dead endpoint's response. UI-facing copy comes from i18n at the call site,
+  // not from this error's message (same convention as login()'s thrown errors).
+  const register = async (_memberNumber: string, _password: string): Promise<void> => {
+    throw new Error('Self-registration is disabled')
   }
 
   return (

--- a/tests/unit/components/auth/register-form.test.tsx
+++ b/tests/unit/components/auth/register-form.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { RegisterForm } from '@/components/auth/register-form'
+
+// Mock next-intl's getTranslations to return a simple translator function
+vi.mock('next-intl/server', () => ({
+  getTranslations: () => (key: string) => {
+    const translations: Record<string, string> = {
+      registerUnavailableTitle: 'Registration is temporarily unavailable',
+      registerUnavailableBody: 'We have paused self-service registration while the authentication cutover is being finalized. Please sign in with an existing account or contact the association to request access.',
+      login: 'Sign In',
+      hasAccount: 'Already have an account?',
+    }
+    return translations[key] || key
+  },
+}))
+
+describe('RegisterForm', () => {
+  it('renders disabled-state message with i18n keys', async () => {
+    render(await RegisterForm({ locale: 'en' }))
+
+    expect(screen.getByText('Registration is temporarily unavailable')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'We have paused self-service registration while the authentication cutover is being finalized. Please sign in with an existing account or contact the association to request access.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('renders login links pointing to the correct locale', async () => {
+    render(await RegisterForm({ locale: 'en' }))
+
+    const links = screen.getAllByRole('link')
+    expect(links.length).toBeGreaterThanOrEqual(2)
+
+    // Both links should point to /en/login
+    links.forEach((link) => {
+      expect(link.getAttribute('href')).toMatch(/\/en\/login/)
+    })
+  })
+
+  it('uses the locale param in login link hrefs', async () => {
+    render(await RegisterForm({ locale: 'es' }))
+
+    const links = screen.getAllByRole('link')
+    expect(links.length).toBeGreaterThanOrEqual(2)
+
+    // Both links should point to /es/login
+    links.forEach((link) => {
+      expect(link.getAttribute('href')).toMatch(/\/es\/login/)
+    })
+  })
+
+  it('does not render form inputs or submit button', async () => {
+    render(await RegisterForm({ locale: 'en' }))
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /register/i })).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/member number/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/password/i)).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/lib/auth-context.test.tsx
+++ b/tests/unit/lib/auth-context.test.tsx
@@ -101,18 +101,12 @@ describe('AuthProvider', () => {
     expect(apiClientMock.get).not.toHaveBeenCalled()
   })
 
-  it('updates the auth state on login, register, and logout', async () => {
+  it('updates the auth state on login and logout', async () => {
     const loggedInUser = createUser()
-    const registeredUser = createUser({
-      id: '2',
-      memberNumber: '100099',
-      role: 'member',
-    })
 
     signInPasswordMock.mockResolvedValueOnce({ error: null })
     signInFinalizeMock.mockResolvedValueOnce({ error: null })
     apiClientMock.get.mockResolvedValueOnce(loggedInUser)
-    apiClientMock.post.mockResolvedValueOnce(registeredUser)
 
     const { AuthProvider, useAuth } = await import('@/lib/auth/auth-context')
     const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -133,12 +127,6 @@ describe('AuthProvider', () => {
     expect(signInFinalizeMock).toHaveBeenCalledOnce()
 
     await act(async () => {
-      await result.current.register('100099', 'Password123')
-    })
-
-    expect(result.current.user).toEqual(registeredUser)
-
-    await act(async () => {
       await result.current.logout()
     })
 
@@ -146,6 +134,28 @@ describe('AuthProvider', () => {
     expect(result.current.isAuthenticated).toBe(false)
     expect(clerkSignOutMock).toHaveBeenCalledOnce()
     expect(routerPushMock).toHaveBeenCalledWith('/es/login')
+  })
+
+  it('reject register() immediately without calling setUser', async () => {
+    const { AuthProvider, useAuth } = await import('@/lib/auth/auth-context')
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider initialUser={null}>{children}</AuthProvider>
+    )
+
+    const { result } = renderHook(() => useAuth(), { wrapper })
+
+    let registerError: unknown
+    await act(async () => {
+      try {
+        await result.current.register('100099', 'Password123')
+      } catch (error) {
+        registerError = error
+      }
+    })
+
+    expect(registerError).toEqual(new Error('Self-registration is disabled'))
+    expect(result.current.user).toBeNull()
+    expect(apiClientMock.post).not.toHaveBeenCalled()
   })
 
   it('signs Clerk out when the authenticated identity is unmapped or suspended', async () => {


### PR DESCRIPTION
## Summary

Closes #284

`register()` in `lib/auth/auth-context.tsx` called the tombstoned `/api/auth/register` endpoint (already returning `410 Gone`, consistent with login/logout, from an earlier PR) and called `setUser(data)` with whatever the dead endpoint returned — which could fake an authenticated UI state without a real Clerk session. This closes that gap:

- `lib/auth/auth-context.tsx`: `register()` now throws `Error('Self-registration is disabled')` immediately and never calls `setUser()`, so there is no code path that can present a logged-in UI state without a real Clerk session.
- `components/auth/register-form.tsx`: rewritten from a live sign-up form to a disabled-state message (server component, no `useAuth`/`apiClient` calls) directing users to sign in or contact an admin for an activation link.
- `app/[locale]/register/page.tsx`: renders the new disabled-state component instead of a raw redirect.
- `tests/unit/lib/auth-context.test.tsx`: updated to assert `register()` rejects and never calls `setUser`/`apiClient.post`.
- `tests/unit/components/auth/register-form.test.tsx`: new tests for the disabled-state UI (no form inputs/submit button rendered, correct locale-aware login links).

Out of scope, confirmed untouched: `app/api/auth/register/route.ts` (still returns 410 Gone) and `lib/server/auth/auth-service.ts` register() export — both were already tombstoned correctly and are unrelated to this UI-state bug.

## Security review

Reviewed by security-reviewer against origin/develop diff:
- No code path results in `setUser()` being called from `register()` — verified by reading the diff directly, not just trusting the test.
- Dead register API route and server-side auth-service register() export left untouched (confirmed via `git diff --stat`, zero changes to either file).
- i18n keys `auth.registerUnavailableTitle` / `auth.registerUnavailableBody` (plus `hasAccount`, `registerSubtitle`) verified present in both `messages/en.json` and `messages/es.json`; `tests/unit/i18n-parity.test.ts` also passes.
- No secrets/credentials found in the diff.
- Scope confirmed limited to the register flow — diff touches exactly the 5 files listed above, nothing else.

## Validation (independently re-run in an isolated git worktree, not the shared checkout)

Typecheck:
```
> next typegen && ... && tsc --noEmit
Generating route types...
✓ Route types generated successfully
TYPECHECK_EXIT=0
```

Full test suite:
```
Test Files  77 passed (77)
     Tests  1200 passed (1200)
  Duration  27.13s
```
(Matches QA's reported numbers exactly. `tests/unit/server/availability.test.ts` — the known pre-existing timezone flake — passed in this run, not hit.)

Build:
```
✓ Compiled successfully in 3.9s
BUILD_EXIT=0
```
(Static-generation warnings about missing `POSTGRES_URL` during prerender of the public landing page are expected in an isolated worktree with no `.env.local` and are unrelated to this change.)

## Test plan

- [x] Typecheck passes
- [x] Full unit test suite passes (1200/1200, 77 files)
- [x] Production build passes
- [ ] Manual: visit `/en/register` and `/es/register`, confirm disabled-state message renders with working "sign in" links, confirm no way to reach an authenticated UI state from this page

🤖 Generated with [Claude Code](https://claude.com/claude-code)