### PR TITLE
Migrate rooms-service.ts and tables-service.ts to Drizzle/Neon (KIM-434 F3c)

### DIFF
--- a/lib/server/rooms/rooms-service.ts
+++ b/lib/server/rooms/rooms-service.ts
@@ -1,10 +1,9 @@
-import { asc, eq } from 'drizzle-orm'
+import { and, asc, eq, gte, inArray, lte } from 'drizzle-orm'
 import type { TableAvailability } from '@/lib/types'
-import { getAdminDb, getDrizzleAdminDb, getDrizzleDb } from '@/lib/db'
-import { rooms, tables } from '@/lib/db/schema'
+import { getDrizzleAdminDb, getDrizzleDb } from '@/lib/db'
+import { eventRoomBlocks, events, reservations, rooms, savedGames, tables } from '@/lib/db/schema'
 import { serviceError } from '@/lib/server/shared/service-error'
 import { resolveDate, buildAvailability } from '@/lib/server/reservations/availability'
-import type { Tables } from '@/lib/supabase/types'
 import { regenerateQrCodes } from '@/lib/server/tables/tables-service'
 import { toGameTable } from '@/lib/server/tables/table-mappers'
 import { getDatabaseNow } from '@/lib/server/shared/database-time'
@@ -12,20 +11,24 @@ import { isPendingReservationExpired } from '@/lib/server/reservations/pending-r
 import type { SessionUser } from '@/lib/server/auth/auth'
 
 /**
- * KIM-434 (F3c) PR2: `rooms` and `tables` reads/writes below use the
- * Drizzle/Neon seam (`getDrizzleDb()` / `getDrizzleAdminDb()`), following the
- * pilot pattern established in `lib/server/equipment/equipment-service.ts`
- * (PR1).
+ * GitHub #244 (KIM-434 F3c stack, split-brain follow-up to #238): finishes
+ * migrating this file off the legacy Supabase `getAdminDb()` seam onto the
+ * Drizzle/Neon client (`getDrizzleDb()` / `getDrizzleAdminDb()`). PR2 (KIM-434)
+ * already migrated `rooms`/`tables` reads/writes; `getRoomTablesAvailability()`
+ * below was the last holdout reading `reservations`, `event_room_blocks` and
+ * `saved_games` from Supabase — a live cross-backend read now that
+ * `reservations-service.ts` (#238) writes those same tables to Neon. All
+ * reads in this file now go through Drizzle/Neon; no Supabase client usage
+ * remains.
  *
- * `reservations`, `event_room_blocks` and `saved_games` are owned by
- * services NOT yet migrated (PR3-PR5), so those cross-domain reads
- * intentionally stay on the legacy Supabase seam (`getAdminDb()`) — their
- * source of truth hasn't moved to Neon yet. Combining a Neon read (rooms /
- * tables) with Supabase reads (reservations/blocks/saved games) here is two
- * independent round-trips joined in application code, same as before this
- * PR — not a single SQL join — but see the PR description's "Split-brain
- * disclosure" section for the consistency caveat this implies during the
- * migration window.
+ * Row-shape convention: query results below are selected with explicit
+ * snake_case column aliases (e.g. `table_id: reservations.tableId`) so they
+ * keep matching the structural, backend-agnostic `ReservationRow` shape
+ * `buildAvailability()` (lib/server/reservations/availability.ts) and
+ * `isPendingReservationExpired()` (lib/server/reservations/pending-
+ * reservation-expiry.ts) already expect — both were intentionally kept
+ * snake_case-shaped so this migration wouldn't need to touch either shared
+ * helper. See `tables-service.ts` for the identical convention.
  */
 
 // Privilege checks (role === 'admin') live here in the service layer, not in
@@ -37,9 +40,6 @@ import type { SessionUser } from '@/lib/server/auth/auth'
 function requireAdminSession(session: SessionUser): void {
   if (session.role !== 'admin') serviceError('Forbidden', 403)
 }
-
-type ReservationRow = Tables<'reservations'>
-type EventBlockRow = Tables<'event_room_blocks'>
 
 /**
  * Runs a Drizzle query, translating any thrown DB/driver error into a
@@ -158,66 +158,73 @@ export async function getRoomTablesAvailability(roomId: string, date?: string | 
     return {}
   }
 
-  const admin = getAdminDb()
+  const db = getDrizzleAdminDb()
   const tableIds = roomTables.map((table) => table.id)
 
-  const [reservationsResult, eventBlocksResult, savedGamesResult, nowUtc] = await Promise.all([
-    admin
-      .from('reservations')
-      .select('id, table_id, date, start_time, end_time, status, surface, user_id, activated_at, created_at')
-      .eq('date', effectiveDate)
-      .in('status', ['active', 'pending'])
-      .in('table_id', tableIds),
-    admin
-      .from('event_room_blocks')
-      .select('id, event_id, room_id, table_id, date, start_time, end_time, all_day')
-      .eq('room_id', roomId)
-      .eq('date', effectiveDate),
-    admin
-      .from('saved_games')
-      .select('table_id')
-      .eq('status', 'active')
-      .lte('start_date', effectiveDate)
-      .gte('end_date', effectiveDate)
-      .in('table_id', tableIds),
-    getDatabaseNow(admin),
+  const [reservationRows, eventBlocks, savedGameRows, nowUtc] = await Promise.all([
+    runQuery(
+      db
+        .select({
+          table_id: reservations.tableId,
+          date: reservations.date,
+          start_time: reservations.startTime,
+          end_time: reservations.endTime,
+          status: reservations.status,
+          surface: reservations.surface,
+          activated_at: reservations.activatedAt,
+        })
+        .from(reservations)
+        .where(
+          and(
+            eq(reservations.date, effectiveDate),
+            inArray(reservations.status, ['active', 'pending']),
+            inArray(reservations.tableId, tableIds),
+          ),
+        ),
+    ),
+    runQuery(
+      db
+        .select({
+          event_id: eventRoomBlocks.eventId,
+          table_id: eventRoomBlocks.tableId,
+          start_time: eventRoomBlocks.startTime,
+          end_time: eventRoomBlocks.endTime,
+        })
+        .from(eventRoomBlocks)
+        .where(and(eq(eventRoomBlocks.roomId, roomId), eq(eventRoomBlocks.date, effectiveDate))),
+    ),
+    runQuery(
+      db
+        .select({ table_id: savedGames.tableId })
+        .from(savedGames)
+        .where(
+          and(
+            eq(savedGames.status, 'active'),
+            lte(savedGames.startDate, effectiveDate),
+            gte(savedGames.endDate, effectiveDate),
+            inArray(savedGames.tableId, tableIds),
+          ),
+        ),
+    ),
+    getDatabaseNow(db),
   ])
 
-  const { data, error } = reservationsResult
-
-  if (error) {
-    serviceError('Internal server error', 500)
-  }
-
-  const activeReservations = ((data ?? []) as ReservationRow[]).filter((row) =>
+  const activeReservations = reservationRows.filter((row) =>
     row.status !== 'pending' || row.activated_at !== null || !isPendingReservationExpired(row, nowUtc),
   )
-  const eventBlocks = (eventBlocksResult.data ?? []) as EventBlockRow[]
-
-  if (eventBlocksResult.error) {
-    serviceError('Internal server error', 500)
-  }
-  if (savedGamesResult.error) serviceError('Internal server error', 500)
-  const savedGameTableIds = new Set((savedGamesResult.data ?? []).map((row) => row.table_id))
+  const savedGameTableIds = new Set(savedGameRows.map((row) => row.table_id))
 
   let eventTitleById = new Map<string, string>()
   const eventIds = [...new Set(eventBlocks.map((block) => block.event_id))]
   if (eventIds.length > 0) {
-    const eventsResult = await admin
-      .from('events')
-      .select('id, title')
-      .in('id', eventIds)
-
-    if (eventsResult.error) {
-      serviceError('Internal server error', 500)
-    }
-
-    eventTitleById = new Map(
-      ((eventsResult.data ?? []) as Array<{ id: string; title: string }>).map((event) => [event.id, event.title]),
+    const eventRows = await runQuery(
+      db.select({ id: events.id, title: events.title }).from(events).where(inArray(events.id, eventIds)),
     )
+
+    eventTitleById = new Map(eventRows.map((event) => [event.id, event.title]))
   }
 
-  const reservationsByTable = new Map<string, ReservationRow[]>()
+  const reservationsByTable = new Map<string, typeof activeReservations>()
   for (const reservation of activeReservations) {
     const items = reservationsByTable.get(reservation.table_id) ?? []
     items.push(reservation)

--- a/lib/server/tables/tables-service.ts
+++ b/lib/server/tables/tables-service.ts
@@ -1,34 +1,35 @@
-import { eq } from 'drizzle-orm'
+import { and, eq, gte, inArray, lte } from 'drizzle-orm'
 import qrcode from 'qrcode'
 import type { GameTable } from '@/lib/types'
 import { uploadToStorage, getPublicStorageUrl } from '@/lib/storage/qr'
-import { getAdminDb, getDrizzleAdminDb, getDrizzleDb } from '@/lib/db'
-import { tables } from '@/lib/db/schema'
+import { getDrizzleAdminDb, getDrizzleDb } from '@/lib/db'
+import { eventRoomBlocks, events, reservations, savedGames, tables } from '@/lib/db/schema'
 import { serviceError } from '@/lib/server/shared/service-error'
 import { resolveDate, buildAvailability } from '@/lib/server/reservations/availability'
-import type { Tables } from '@/lib/supabase/types'
 import { toGameTable } from '@/lib/server/tables/table-mappers'
 import { getDatabaseNow } from '@/lib/server/shared/database-time'
 import { isPendingReservationExpired } from '@/lib/server/reservations/pending-reservation-expiry'
 import type { SessionUser } from '@/lib/server/auth/auth'
 
-type ReservationRow = Tables<'reservations'>
-type EventBlockRow = Tables<'event_room_blocks'>
-
 /**
- * KIM-434 (F3c) PR2: `tables` reads/writes below use the Drizzle/Neon seam
- * (`getDrizzleDb()` / `getDrizzleAdminDb()`), following the pilot pattern
- * established in `lib/server/equipment/equipment-service.ts` (PR1).
+ * GitHub #244 (KIM-434 F3c stack, split-brain follow-up to #238): finishes
+ * migrating this file off the legacy Supabase `getAdminDb()` seam onto the
+ * Drizzle/Neon client (`getDrizzleDb()` / `getDrizzleAdminDb()`). PR2 (KIM-434)
+ * already migrated `tables` reads/writes; `getTableAvailability()` below was
+ * the last holdout reading `reservations`, `event_room_blocks`, `saved_games`
+ * and `events` from Supabase — a live cross-backend read now that
+ * `reservations-service.ts` (#238) writes those same tables to Neon. All
+ * reads in this file now go through Drizzle/Neon; no Supabase client usage
+ * remains.
  *
- * `reservations`, `event_room_blocks`, `saved_games` and `events` are owned
- * by services NOT yet migrated (PR3-PR5), so those cross-domain reads
- * intentionally stay on the legacy Supabase seam (`getDb()` / `getAdminDb()`)
- * — their source of truth hasn't moved to Neon yet. Combining a Neon read
- * (the table row) with Supabase reads (reservations/blocks/saved games) here
- * is two independent round-trips joined in application code, same as
- * before this PR — not a single SQL join — but see the PR description's
- * "Split-brain disclosure" section for the consistency caveat this implies
- * during the migration window.
+ * Row-shape convention: query results below are selected with explicit
+ * snake_case column aliases (e.g. `table_id: reservations.tableId`) so they
+ * keep matching the structural, backend-agnostic `ReservationRow` shape
+ * `buildAvailability()` (lib/server/reservations/availability.ts) and
+ * `isPendingReservationExpired()` (lib/server/reservations/pending-
+ * reservation-expiry.ts) already expect — both were intentionally kept
+ * snake_case-shaped so this migration wouldn't need to touch either shared
+ * helper. See `rooms-service.ts` for the identical convention.
  */
 
 // Privilege checks (role === 'admin') live here in the service layer, not in
@@ -140,82 +141,89 @@ export async function getTableAvailability(tableId: string, date?: string | null
   }
 
   const effectiveDate = resolveDate(date)
-  const admin = getAdminDb()
+  const adminDb = getDrizzleAdminDb()
 
-  const [reservationsResult, eventBlocksResult, savedGameResult, nowUtc] = await Promise.all([
-    admin
-      .from('reservations')
-      .select('id, table_id, date, start_time, end_time, status, surface, user_id, activated_at, created_at')
-      .eq('table_id', tableId)
-      .eq('date', effectiveDate)
-      .in('status', ['active', 'pending']),
-    admin
-      .from('event_room_blocks')
-      .select('id, event_id, room_id, table_id, date, start_time, end_time, all_day')
-      .eq('room_id', table.roomId)
-      .eq('date', effectiveDate),
-    admin
-      .from('saved_games')
-      .select('id')
-      .eq('table_id', tableId)
-      .eq('status', 'active')
-      .lte('start_date', effectiveDate)
-      .gte('end_date', effectiveDate)
-      .limit(1),
-    getDatabaseNow(admin),
+  const [allReservations, eventBlocksResult, savedGameRows, nowUtc] = await Promise.all([
+    runQuery(
+      adminDb
+        .select({
+          start_time: reservations.startTime,
+          end_time: reservations.endTime,
+          status: reservations.status,
+          surface: reservations.surface,
+          date: reservations.date,
+          activated_at: reservations.activatedAt,
+        })
+        .from(reservations)
+        .where(
+          and(
+            eq(reservations.tableId, tableId),
+            eq(reservations.date, effectiveDate),
+            inArray(reservations.status, ['active', 'pending']),
+          ),
+        ),
+    ),
+    runQuery(
+      adminDb
+        .select({
+          event_id: eventRoomBlocks.eventId,
+          table_id: eventRoomBlocks.tableId,
+          start_time: eventRoomBlocks.startTime,
+          end_time: eventRoomBlocks.endTime,
+        })
+        .from(eventRoomBlocks)
+        .where(and(eq(eventRoomBlocks.roomId, table.roomId), eq(eventRoomBlocks.date, effectiveDate))),
+    ),
+    runQuery(
+      adminDb
+        .select({ id: savedGames.id })
+        .from(savedGames)
+        .where(
+          and(
+            eq(savedGames.tableId, tableId),
+            eq(savedGames.status, 'active'),
+            lte(savedGames.startDate, effectiveDate),
+            gte(savedGames.endDate, effectiveDate),
+          ),
+        )
+        .limit(1),
+    ),
+    getDatabaseNow(adminDb),
   ])
 
-  const allReservations = (reservationsResult.data ?? []) as ReservationRow[]
-  const reservationsError = reservationsResult.error
-
-  if (reservationsError) {
-    serviceError('Internal server error', 500)
-  }
-
   // Pending rows stop blocking availability only after their check-in deadline.
-  const reservations = allReservations.filter((row) => {
+  const reservationRows = allReservations.filter((row) => {
     if (row.status === 'pending' && row.activated_at === null) {
       return !isPendingReservationExpired(row, nowUtc)
     }
     return true
   })
 
-  if (eventBlocksResult.error) {
-    serviceError('Internal server error', 500)
-  }
-  if (savedGameResult.error) serviceError('Internal server error', 500)
-
   // OIR-208: a block with a table_id only blocks that single table; NULL
   // (the pre-OIR-208 default) blocks every table of the room, unchanged.
-  const eventBlocks = ((eventBlocksResult.data ?? []) as EventBlockRow[])
-    .filter((block) => block.table_id == null || block.table_id === tableId)
+  const eventBlocks = eventBlocksResult.filter(
+    (block) => block.table_id == null || block.table_id === tableId,
+  )
 
   let eventTitleById = new Map<string, string>()
   const eventIds = [...new Set(eventBlocks.map((block) => block.event_id))]
   if (eventIds.length > 0) {
-    const eventsResult = await admin
-      .from('events')
-      .select('id, title')
-      .in('id', eventIds)
-
-    if (eventsResult.error) {
-      serviceError('Internal server error', 500)
-    }
-
-    eventTitleById = new Map(
-      ((eventsResult.data ?? []) as Array<{ id: string; title: string }>).map((event) => [event.id, event.title]),
+    const eventRows = await runQuery(
+      adminDb.select({ id: events.id, title: events.title }).from(events).where(inArray(events.id, eventIds)),
     )
+
+    eventTitleById = new Map(eventRows.map((event) => [event.id, event.title]))
   }
 
   return buildAvailability(
     toGameTable(table),
     effectiveDate,
-    reservations,
+    reservationRows,
     eventBlocks.map((block) => ({
       start: block.start_time.slice(0, 5),
       end: block.end_time.slice(0, 5),
       label: eventTitleById.get(block.event_id) ?? null,
     })),
-    Boolean(savedGameResult.data?.length),
+    Boolean(savedGameRows.length),
   )
 }

--- a/tests/unit/mocks/drizzle-mock.ts
+++ b/tests/unit/mocks/drizzle-mock.ts
@@ -398,10 +398,10 @@ export function createDrizzleQueryBuilder() {
         return createDeleteWhereReturningMock()
       }),
     })),
-    // Raw SQL execution
+    // Raw SQL execution — returns whatever executeMock resolves to, allowing
+    // tests to configure the shape (e.g., { rows: [{ now: Date }] } for getDatabaseNow)
     execute: vi.fn((...args: unknown[]) => {
-      executeMock(...args)
-      return Promise.resolve({ rowCount: 0 })
+      return executeMock(...args)
     }),
     // Support db.transaction() wrapper for atomic operations.
     // The callback receives a query builder (tx) with the same chainable structure.

--- a/tests/unit/server/oir208-unified-events.test.ts
+++ b/tests/unit/server/oir208-unified-events.test.ts
@@ -806,6 +806,9 @@ describe('OIR-208: Unified Events', () => {
       // Real where(eq(tables.id, ...)) matching now, so both tables are
       // seeded once — each call finds its own row regardless of order.
       seedTable('tables', [mockTableRow('table-A', ROOM), mockTableRow('table-B', ROOM)])
+      // KIM-434 F3c: production code now queries event_room_blocks via getDrizzleAdminDb (Drizzle)
+      // instead of getAdminDb (Supabase). Must seed Drizzle mock with event block data.
+      seedTable('event_room_blocks', eventBlocks)
 
       const { getTableAvailability } = await import('@/lib/server/tables/tables-service')
 
@@ -831,6 +834,9 @@ describe('OIR-208: Unified Events', () => {
         buildAvailabilityAdminClient(eventBlocks) as any,
       )
       seedTable('tables', [mockTableRow('table-A', ROOM), mockTableRow('table-B', ROOM)])
+      // KIM-434 F3c: production code now queries event_room_blocks via getDrizzleAdminDb (Drizzle)
+      // instead of getAdminDb (Supabase). Must seed Drizzle mock with event block data.
+      seedTable('event_room_blocks', eventBlocks)
 
       const { getTableAvailability } = await import('@/lib/server/tables/tables-service')
 
@@ -852,6 +858,9 @@ describe('OIR-208: Unified Events', () => {
         buildAvailabilityAdminClient(eventBlocks) as any,
       )
       seedTable('tables', [mockTableRow('table-A', ROOM), mockTableRow('table-B', ROOM)])
+      // KIM-434 F3c: production code now queries event_room_blocks via getDrizzleAdminDb (Drizzle)
+      // instead of getAdminDb (Supabase). Must seed Drizzle mock with event block data.
+      seedTable('event_room_blocks', eventBlocks)
 
       const { getRoomTablesAvailability } = await import('@/lib/server/rooms/rooms-service')
 
@@ -872,6 +881,9 @@ describe('OIR-208: Unified Events', () => {
         buildAvailabilityAdminClient(eventBlocks) as any,
       )
       seedTable('tables', [mockTableRow('table-A', ROOM), mockTableRow('table-B', ROOM)])
+      // KIM-434 F3c: production code now queries event_room_blocks via getDrizzleAdminDb (Drizzle)
+      // instead of getAdminDb (Supabase). Must seed Drizzle mock with event block data.
+      seedTable('event_room_blocks', eventBlocks)
 
       const { getRoomTablesAvailability } = await import('@/lib/server/rooms/rooms-service')
 

--- a/tests/unit/server/rooms-service.test.ts
+++ b/tests/unit/server/rooms-service.test.ts
@@ -6,6 +6,7 @@ import {
   selectMock,
   insertMock,
   updateMock,
+  executeMock,
   createAdminSession,
   createMemberSession,
 } from '@/tests/unit/mocks/drizzle-mock'
@@ -348,20 +349,43 @@ describe('getRoomTablesAvailability', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
-    // Setup Drizzle mocks for tables table
-    selectMock.mockResolvedValue([
-      {
-        id: 't3',
-        roomId: '1',
-        name: 'Mesa 3',
-        type: 'removable_top',
-        qrCode: 'QR-3',
-        posX: 1,
-        posY: 1,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    ])
+
+    // Setup executeMock to handle getDatabaseNow query: select now() as now
+    executeMock.mockResolvedValue({ rows: [{ now: new Date('2025-01-01T09:00:00.000Z') }], rowCount: 1 })
+
+    // The production code makes multiple SELECT queries via Drizzle in this order:
+    // 1. listTablesByRoom() queries tables by roomId
+    // 2. Promise.all([reservations, eventRoomBlocks, savedGames, getDatabaseNow])
+    // Use mockResolvedValueOnce() for each query to return the right shape
+    selectMock
+      .mockResolvedValueOnce([
+        {
+          id: 't3',
+          roomId: '1',
+          name: 'Mesa 3',
+          type: 'removable_top',
+          qrCode: 'QR-3',
+          posX: 1,
+          posY: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'r2',
+          table_id: 't3',
+          date: '2025-01-01',
+          start_time: '10:00:00',
+          end_time: '12:00:00',
+          status: 'active',
+          surface: 'top',
+          activated_at: null,
+        },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+
     listReservationsMock.mockResolvedValue({
       data: [
         {
@@ -386,6 +410,37 @@ describe('getRoomTablesAvailability', () => {
 
   it('builds availability from Supabase rows', async () => {
     const { getRoomTablesAvailability } = await loadRoomsModules()
+
+    // Setup mocks AFTER loading modules (loadRoomsModules calls vi.resetModules)
+    executeMock.mockResolvedValue({ rows: [{ now: new Date('2025-01-01T09:00:00.000Z') }], rowCount: 1 })
+    selectMock
+      .mockResolvedValueOnce([
+        {
+          id: 't3',
+          roomId: '1',
+          name: 'Mesa 3',
+          type: 'removable_top',
+          qrCode: 'QR-3',
+          posX: 1,
+          posY: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'r2',
+          table_id: 't3',
+          date: '2025-01-01',
+          start_time: '10:00:00',
+          end_time: '12:00:00',
+          status: 'active',
+          surface: 'top',
+          activated_at: null,
+        },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
 
     const availability = await getRoomTablesAvailability('1', '2025-01-01')
 

--- a/tests/unit/server/tables-service.test.ts
+++ b/tests/unit/server/tables-service.test.ts
@@ -6,6 +6,7 @@ import {
   insertMock,
   updateMock,
   deleteMock,
+  executeMock,
   createAdminSession,
   createMemberSession,
 } from '@/tests/unit/mocks/drizzle-mock'
@@ -122,24 +123,49 @@ describe('getTableAvailability', () => {
     listSavedGamesMock.mockResolvedValue({ data: [], error: null })
     listEventBlocksMock.mockResolvedValue({ data: [], error: null })
     listEventsMock.mockResolvedValue({ data: [], error: null })
-    
-    // Setup default table fixture for select mock
-    selectMock.mockResolvedValue([
-      {
-        id: 'c3d4e5f6-a7b8-9012-cdef-012345678901',
-        roomId: '1',
-        name: 'Mesa 3',
-        type: 'removable_top',
-        qrCode: 'QR-3',
-        posX: 1,
-        posY: 1,
-      },
-    ])
+
+    // Setup executeMock to handle getDatabaseNow query: select now() as now
+    executeMock.mockResolvedValue({ rows: [{ now: new Date('2026-05-26T12:00:00Z') }], rowCount: 1 })
+
+    // The production code makes multiple SELECT queries via Drizzle in this order:
+    // 1. .from(tables) to check the table exists
+    // 2. Promise.all([reservations, eventRoomBlocks, savedGames, getDatabaseNow])
+    // Use mockResolvedValueOnce() for each query to return the right shape
+    selectMock
+      .mockResolvedValueOnce([
+        {
+          id: 'c3d4e5f6-a7b8-9012-cdef-012345678901',
+          roomId: '1',
+          name: 'Mesa 3',
+          type: 'removable_top',
+          qrCode: 'QR-3',
+          posX: 1,
+          posY: 1,
+        },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
   })
 
   it('builds removable-top availability from Supabase reservations', async () => {
-    listReservationsMock.mockResolvedValue({
-      data: [
+    const { getTableAvailability } = await loadTablesModules()
+
+    // Setup mocks AFTER loading modules (vi.resetModules() in loadTablesModules() clears all mocks)
+    executeMock.mockResolvedValue({ rows: [{ now: new Date('2025-01-01T09:00:00.000Z') }], rowCount: 1 })
+    selectMock
+      .mockResolvedValueOnce([
+        {
+          id: 'c3d4e5f6-a7b8-9012-cdef-012345678901',
+          roomId: '1',
+          name: 'Mesa 3',
+          type: 'removable_top',
+          qrCode: 'QR-3',
+          posX: 1,
+          posY: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
         {
           id: 'r2',
           table_id: 'c3d4e5f6-a7b8-9012-cdef-012345678901',
@@ -148,15 +174,11 @@ describe('getTableAvailability', () => {
           end_time: '12:00:00',
           status: 'active',
           surface: 'top',
-          user_id: '2',
-          created_at: '2025-01-01T00:00:00.000Z',
           activated_at: null,
         },
-      ],
-      error: null,
-    })
-    
-    const { getTableAvailability } = await loadTablesModules()
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
 
     const availability = await getTableAvailability('c3d4e5f6-a7b8-9012-cdef-012345678901', '2025-01-01')
 
@@ -165,8 +187,23 @@ describe('getTableAvailability', () => {
   })
 
   it('filters reservations with status in [active, pending]', async () => {
-    listReservationsMock.mockResolvedValue({
-      data: [
+    const { getTableAvailability } = await loadTablesModules()
+
+    // Setup mocks AFTER loading modules
+    executeMock.mockResolvedValue({ rows: [{ now: new Date('2026-05-26T12:00:00Z') }], rowCount: 1 })
+    selectMock
+      .mockResolvedValueOnce([
+        {
+          id: 'c3d4e5f6-a7b8-9012-cdef-012345678901',
+          roomId: '1',
+          name: 'Mesa 3',
+          type: 'removable_top',
+          qrCode: 'QR-3',
+          posX: 1,
+          posY: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
         {
           id: 'r2',
           table_id: 'c3d4e5f6-a7b8-9012-cdef-012345678901',
@@ -175,28 +212,35 @@ describe('getTableAvailability', () => {
           end_time: '12:00:00',
           status: 'active',
           surface: 'top',
-          user_id: '2',
-          created_at: '2025-01-01T00:00:00.000Z',
           activated_at: null,
         },
-      ],
-      error: null,
-    })
-    
-    const { getTableAvailability } = await loadTablesModules()
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
 
     await getTableAvailability('c3d4e5f6-a7b8-9012-cdef-012345678901', '2025-01-01')
 
-    expect(listReservationsMock).toHaveBeenCalled()
+    expect(selectMock).toHaveBeenCalled()
   })
 
   it('treats pending reservations as occupying time slots', async () => {
-    // Use a recent created_at time so isPendingReservationExpired doesn't filter it out
-    // If the pending reservation was created within ~24-48 hours of the current mock time
-    const recentCreatedAt = new Date('2026-05-25T14:00:00Z').toISOString()
-    
-    listReservationsMock.mockResolvedValue({
-      data: [
+    const { getTableAvailability } = await loadTablesModules()
+
+    // Setup mocks AFTER loading modules
+    executeMock.mockResolvedValue({ rows: [{ now: new Date('2026-05-26T12:00:00Z') }], rowCount: 1 })
+    selectMock
+      .mockResolvedValueOnce([
+        {
+          id: 'c3d4e5f6-a7b8-9012-cdef-012345678901',
+          roomId: '1',
+          name: 'Mesa 3',
+          type: 'removable_top',
+          qrCode: 'QR-3',
+          posX: 1,
+          posY: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
         {
           id: 'r_pending',
           table_id: 'c3d4e5f6-a7b8-9012-cdef-012345678901',
@@ -205,15 +249,11 @@ describe('getTableAvailability', () => {
           end_time: '15:00:00',
           status: 'pending',
           surface: 'top',
-          user_id: '2',
-          created_at: recentCreatedAt,
           activated_at: null,
         },
-      ],
-      error: null,
-    })
-
-    const { getTableAvailability } = await loadTablesModules()
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
 
     const availability = await getTableAvailability('c3d4e5f6-a7b8-9012-cdef-012345678901', '2026-05-26')
 
@@ -221,10 +261,25 @@ describe('getTableAvailability', () => {
   })
 
   it('blocks the lower surface for the full day when an active Saved Game covers the date', async () => {
-    listReservationsMock.mockResolvedValue({ data: [], error: null })
-    listSavedGamesMock.mockResolvedValue({ data: [{ id: 'sg-1' }], error: null })
-    
     const { getTableAvailability } = await loadTablesModules()
+
+    // Setup mocks AFTER loading modules
+    executeMock.mockResolvedValue({ rows: [{ now: new Date('2026-05-26T12:00:00Z') }], rowCount: 1 })
+    selectMock
+      .mockResolvedValueOnce([
+        {
+          id: 'c3d4e5f6-a7b8-9012-cdef-012345678901',
+          roomId: '1',
+          name: 'Mesa 3',
+          type: 'removable_top',
+          qrCode: 'QR-3',
+          posX: 1,
+          posY: 1,
+        },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'sg-1', table_id: 'c3d4e5f6-a7b8-9012-cdef-012345678901' }])
 
     const availability = await getTableAvailability('c3d4e5f6-a7b8-9012-cdef-012345678901', '2026-05-26')
 

--- a/tests/unit/server/tables-service.test.ts
+++ b/tests/unit/server/tables-service.test.ts
@@ -127,25 +127,10 @@ describe('getTableAvailability', () => {
     // Setup executeMock to handle getDatabaseNow query: select now() as now
     executeMock.mockResolvedValue({ rows: [{ now: new Date('2026-05-26T12:00:00Z') }], rowCount: 1 })
 
-    // The production code makes multiple SELECT queries via Drizzle in this order:
-    // 1. .from(tables) to check the table exists
-    // 2. Promise.all([reservations, eventRoomBlocks, savedGames, getDatabaseNow])
-    // Use mockResolvedValueOnce() for each query to return the right shape
-    selectMock
-      .mockResolvedValueOnce([
-        {
-          id: 'c3d4e5f6-a7b8-9012-cdef-012345678901',
-          roomId: '1',
-          name: 'Mesa 3',
-          type: 'removable_top',
-          qrCode: 'QR-3',
-          posX: 1,
-          posY: 1,
-        },
-      ])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
+    // NOTE: Each individual test will load modules (calling vi.resetModules()), which clears
+    // these mocks. Tests must set up their own selectMock values AFTER loading modules.
+    // This beforeEach is here only for setup of other mocks (executeMock, rpcMock, etc.)
+    // that don't need per-test customization.
   })
 
   it('builds removable-top availability from Supabase reservations', async () => {


### PR DESCRIPTION
## Summary
- Finishes migrating `lib/server/rooms/rooms-service.ts` and `lib/server/tables/tables-service.ts` off the legacy Supabase `getAdminDb()`/`getDb()` seam onto the Drizzle/Neon client (`getDrizzleDb()` / `getDrizzleAdminDb()`).
- `getRoomTablesAvailability()` and `getTableAvailability()` were the last holdouts reading `reservations`, `event_room_blocks`, `saved_games`, and `events` from Supabase — a live cross-backend read now that `reservations-service.ts` (#238) writes those same tables to Neon.
- Both files consistently use explicit snake_case column-aliasing in Drizzle `.select({...})` calls to keep matching the structural, backend-agnostic `ReservationRow` shape already expected by the shared `buildAvailability()` / `isPendingReservationExpired()` helpers.
- No Supabase client usage remains in either production file (verified via grep for `supabase|getDb(|getAdminDb(` — only doc comments referencing the pre-migration state remain).

## Security review notes
- `getRoomTablesAvailability()` and `getTableAvailability()` are genuinely public/unscoped availability reads: no `user_id` filter, no `assertMemberRowsScoped()` requirement applies. Confirmed directly from the code — neither the Drizzle `.select({...})` column lists nor the `buildAvailability()` output include any per-user identifying data (only `table_id`, `date`, `start_time`, `end_time`, `status`, `surface`, `activated_at`, and event titles). No PII/ownership leak.
- Admin-gated mutations (`createRoomEntry`, `updateRoom`, `createTableEntry`, `generateTableQrCode`, `regenerateQrCodes`) keep the existing `requireAdminSession()` service-layer check.
- `getDrizzleAdminDb()` / `getDrizzleDb()` are unchanged in this PR (pre-existing seam from #238's `lib/db/index.ts`) — Neon has no RLS so both currently resolve to the same pooled connection; this is a documented, already-reviewed architectural decision, not a new grant of broader access introduced here.
- No secrets found in the diff.

## Test plan
- [x] `pnpm typecheck` — passes, zero errors
- [x] `pnpm lint` — no ESLint warnings or errors
- [x] `pnpm test -- --run` — **1202/1202 tests passed** (77 test files), run independently in an isolated `git worktree` off `origin/feat/issue-244-rooms-tables-drizzle`
- [x] `pnpm build` — production build succeeds
- [x] Spot-checked `oir208-unified-events.test.ts`'s 4 event-block conflict tests and several "previously failing" tests in `rooms-service.test.ts` / `tables-service.test.ts` — all contain real assertions against real seeded `event_room_blocks`/`reservations`/`saved_games` mock data proving the availability/conflict logic (not stubs or no-ops).
- [x] Diff scope confirmed limited to `lib/server/rooms/rooms-service.ts`, `lib/server/tables/tables-service.ts`, and their test files (`tests/unit/server/rooms-service.test.ts`, `tests/unit/server/tables-service.test.ts`, `tests/unit/server/oir208-unified-events.test.ts`, `tests/unit/mocks/drizzle-mock.ts`).

Closes #244
References #248 (does not close — `club-events-service.ts` migration is still pending under that umbrella). This PR closes the last MAJOR cross-backend read surface for reservation conflict detection: `rooms-service.ts` and `tables-service.ts` now read `reservations`/`event_room_blocks`/`saved_games` from the same Neon backend as `reservations-service.ts` and `saved-games-service.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)