### PR TITLE
fix: finish remaining Supabase RPC cutover

### DIFF
--- a/docs/TRIGGERS-AUDIT-F3e.md
+++ b/docs/TRIGGERS-AUDIT-F3e.md
@@ -42,10 +42,9 @@ Confirmed by reading the current code (file:line references against
   era itself (KIM-366), replaced by lazy evaluation;
   `app/api/cron/cancel-pending/route.ts` returns `410 Gone`.
 - **`get_database_time()`** → confirmed via grep:
-  `lib/server/shared/database-time.ts`'s `getDatabaseNow()` now understands
-  both the Drizzle/Neon seam (`select now()`, line 50) and the legacy
-  Supabase RPC seam (`admin.rpc('get_database_time')`, line 62, kept only
-  for the 11 not-yet-migrated services per that file's own doc comment).
+  `lib/server/shared/database-time.ts`'s `getDatabaseNow()` executes
+  `select now()` through Drizzle/Neon. The legacy Supabase RPC path has been
+  removed; callers may still pass a Drizzle client/transaction explicitly.
 
 ## 2. Escalated — not implemented in this PR, needs product decision
 

--- a/lib/server/shared/database-time.ts
+++ b/lib/server/shared/database-time.ts
@@ -1,30 +1,10 @@
 import 'server-only'
-import { sql } from 'drizzle-orm'
-import { getAdminDb } from '@/lib/db'
+import { sql, type SQL } from 'drizzle-orm'
+import { getDrizzleAdminDb } from '@/lib/db'
 import { serviceError } from '@/lib/server/shared/service-error'
 
-type SupabaseRpcClient = {
-  rpc: (fn: string, args?: unknown) => Promise<{ data?: unknown; error?: unknown } | undefined>
-}
-
 type DrizzleExecutableClient = {
-  execute: (query: unknown) => Promise<{ rows: unknown[] }>
-}
-
-/**
- * Duck-types the resolved client: Drizzle clients expose `.execute()` and no
- * `.rpc()`; legacy Supabase clients expose `.rpc()`. Kept intentionally
- * loose (not imported types) so this helper keeps working for both the
- * legacy Supabase clients still passed in by the 11 not-yet-migrated
- * services (KIM-434 PR2-PR5) and the new Drizzle clients.
- */
-function isDrizzleClient(candidate: unknown): candidate is DrizzleExecutableClient {
-  return (
-    typeof candidate === 'object' &&
-    candidate !== null &&
-    typeof (candidate as { execute?: unknown }).execute === 'function' &&
-    typeof (candidate as { rpc?: unknown }).rpc !== 'function'
-  )
+  execute: (query: SQL) => PromiseLike<{ rows: unknown[] }>
 }
 
 function parseDatabaseNow(rawValue: unknown) {
@@ -52,55 +32,13 @@ async function getDatabaseNowFromDrizzle(db: DrizzleExecutableClient) {
   return parseDatabaseNow(row?.now)
 }
 
-async function getDatabaseNowFromSupabase(client: unknown) {
-  const admin = client as Partial<SupabaseRpcClient>
-
-  if (typeof admin.rpc !== 'function') {
-    serviceError('Internal server error', 500)
-  }
-
-  const response = await admin.rpc('get_database_time')
-  if (!response || typeof response !== 'object') {
-    serviceError('Internal server error', 500)
-  }
-
-  const { data, error } = response
-
-  if (error || !data) {
-    serviceError('Internal server error', 500)
-  }
-
-  return parseDatabaseNow(data)
-}
-
 /**
  * Returns the current database server time (used instead of app-server time
  * to avoid clock-skew issues, e.g. when deciding if a pending reservation
  * has expired).
- *
- * KIM-434 (F3c) note: this helper now understands BOTH the legacy Supabase
- * seam and the new Drizzle/Neon seam (see `lib/db/index.ts`). The DEFAULT
- * (no `client` argument) still resolves via the legacy `getAdminDb()` —
- * unchanged from before this PR. That default is intentionally NOT switched
- * to Drizzle here: `checkUserSlotOverlap()` in
- * `lib/server/reservations/reservations-service.ts` (one of the 11 services
- * not yet migrated, out of scope for this PR) calls `getDatabaseNow()` with
- * no arguments, so redirecting the default path to Neon would silently
- * change that untouched file's runtime behavior (and would throw if
- * `POSTGRES_URL` isn't configured in an environment that still only has
- * Supabase set up). Once every caller is migrated (KIM-434 PR2-PR5), this
- * default can safely switch to `getDrizzleAdminDb()` and the Supabase branch
- * can be deleted.
- *
- * Migrated/new callers (e.g. once a future service moves to Drizzle) should
- * pass a Drizzle client explicitly: `getDatabaseNow(getDrizzleAdminDb())`.
+ * Defaults to the Drizzle/Neon admin client. A transaction/client may be
+ * passed explicitly so the timestamp comes from the same database operation.
  */
-export async function getDatabaseNow(client?: unknown) {
-  const resolved = client ?? getAdminDb()
-
-  if (isDrizzleClient(resolved)) {
-    return getDatabaseNowFromDrizzle(resolved)
-  }
-
-  return getDatabaseNowFromSupabase(resolved)
+export async function getDatabaseNow(client?: DrizzleExecutableClient) {
+  return getDatabaseNowFromDrizzle(client ?? getDrizzleAdminDb())
 }

--- a/tests/unit/server/database-time.test.ts
+++ b/tests/unit/server/database-time.test.ts
@@ -1,10 +1,12 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderSql } from '@/tests/unit/mocks/drizzle-mock'
 
-const createSupabaseServerAdminClient = vi.fn()
+const executeMock = vi.fn()
+const getDrizzleAdminDb = vi.fn(() => ({ execute: executeMock }))
 
-vi.mock('@/lib/supabase/server', () => ({
-  createSupabaseServerAdminClient,
+vi.mock('@/lib/db', () => ({
+  getDrizzleAdminDb,
 }))
 
 async function loadModule() {
@@ -17,18 +19,29 @@ describe('database-time', () => {
     vi.clearAllMocks()
   })
 
-  it('returns the parsed database timestamp from rpc', async () => {
-    createSupabaseServerAdminClient.mockReturnValue({
-      rpc: vi.fn(async () => ({ data: '2026-04-15T16:00:00.000Z', error: null })),
-    })
+  it('uses the default Drizzle/Neon client and returns database time', async () => {
+    executeMock.mockResolvedValue({ rows: [{ now: new Date('2026-04-15T16:00:00.123Z') }] })
 
     const { getDatabaseNow } = await loadModule()
 
-    await expect(getDatabaseNow()).resolves.toEqual(new Date('2026-04-15T16:00:00.000Z'))
+    await expect(getDatabaseNow()).resolves.toEqual(new Date('2026-04-15T16:00:00.123Z'))
+    expect(getDrizzleAdminDb).toHaveBeenCalledOnce()
+    expect(executeMock).toHaveBeenCalledOnce()
+    expect(renderSql(executeMock.mock.calls[0]![0])).toContain('select now() as now')
   })
 
-  it('throws when the admin client cannot provide rpc access', async () => {
-    createSupabaseServerAdminClient.mockReturnValue({})
+  it('uses an explicitly supplied Drizzle client', async () => {
+    const execute = vi.fn(async () => ({ rows: [{ now: '2026-04-15T16:00:00.000Z' }] }))
+
+    const { getDatabaseNow } = await loadModule()
+
+    await expect(getDatabaseNow({ execute })).resolves.toEqual(new Date('2026-04-15T16:00:00.000Z'))
+    expect(getDrizzleAdminDb).not.toHaveBeenCalled()
+    expect(execute).toHaveBeenCalledOnce()
+  })
+
+  it('throws when the database result has no timestamp', async () => {
+    executeMock.mockResolvedValue({ rows: [] })
 
     const { getDatabaseNow } = await loadModule()
 
@@ -38,10 +51,8 @@ describe('database-time', () => {
     })
   })
 
-  it('throws when rpc returns an unexpected payload', async () => {
-    createSupabaseServerAdminClient.mockReturnValue({
-      rpc: vi.fn(async () => undefined),
-    })
+  it('throws when the database timestamp is invalid', async () => {
+    executeMock.mockResolvedValue({ rows: [{ now: 'not-a-date' }] })
 
     const { getDatabaseNow } = await loadModule()
 
@@ -49,5 +60,16 @@ describe('database-time', () => {
       name: 'ServiceError',
       statusCode: 500,
     })
+  })
+
+  it('propagates Neon query failures without falling back to Supabase', async () => {
+    const failure = new Error('Neon unavailable')
+    executeMock.mockRejectedValue(failure)
+
+    const { getDatabaseNow } = await loadModule()
+
+    await expect(getDatabaseNow()).rejects.toBe(failure)
+    expect(getDrizzleAdminDb).toHaveBeenCalledOnce()
+    expect(executeMock).toHaveBeenCalledOnce()
   })
 })

--- a/tests/unit/server/reservations-service.test.ts
+++ b/tests/unit/server/reservations-service.test.ts
@@ -1468,7 +1468,7 @@ describe('reservations service', () => {
   })
 
   describe('markNoShowReservations', () => {
-    it('calls admin.rpc with mark_no_show_reservations and returns count', async () => {
+    it('executes the Neon no-show sweep and returns the affected count', async () => {
       const { markNoShowReservations } = await loadReservationModules()
 
       executeMock.mockResolvedValueOnce({ rowCount: 3 })
@@ -1479,7 +1479,7 @@ describe('reservations service', () => {
       expect(executeMock).toHaveBeenCalled()
     })
 
-    it('returns 0 when rpc returns null data without error', async () => {
+    it('returns 0 when the update affects no rows', async () => {
       const { markNoShowReservations } = await loadReservationModules()
 
       executeMock.mockResolvedValueOnce({ rowCount: 0 })
@@ -1489,17 +1489,25 @@ describe('reservations service', () => {
       expect(count).toBe(0)
     })
 
-    it('returns 0 when no reservations need marking', async () => {
+    it('preserves the slot-relative expiry rules from the former RPC', async () => {
       const { markNoShowReservations } = await loadReservationModules()
 
       executeMock.mockResolvedValueOnce({ rowCount: 0 })
 
-      const count = await markNoShowReservations()
+      await markNoShowReservations()
 
-      expect(count).toBe(0)
+      const rendered = renderSql(executeMock.mock.calls[0]![0] as Parameters<typeof renderSql>[0])
+      expect(rendered).toContain("SET status = 'no_show'")
+      expect(rendered).toContain("status = 'pending'")
+      expect(rendered).toContain('activated_at IS NULL')
+      expect(rendered).toContain('LEAST')
+      expect(rendered).toContain(process.env.CLUB_TIMEZONE ?? 'Atlantic/Canary')
+      expect(rendered).toContain("interval '1 minute'")
+      expect(rendered).toContain('60')
+      expect(rendered).toContain('< now()')
     })
 
-    it('throws serviceError when rpc returns error', async () => {
+    it('throws serviceError when the Neon update fails', async () => {
       const { markNoShowReservations } = await loadReservationModules()
 
       failNextQuery({ op: 'execute', error: new Error('Database error') })


### PR DESCRIPTION
## Summary

- switch `getDatabaseNow()` default access from the legacy Supabase RPC to Drizzle/Neon `select now()`
- remove the Supabase RPC compatibility branch and narrow the helper to Drizzle clients/transactions
- strengthen database-time and no-show parity coverage
- update the trigger audit to reflect the completed cutover

## Scope note

`mark_no_show_reservations` was already ported to a parameterized Drizzle/Neon update on `develop`; this PR verifies its slot-relative expiry behavior and removes stale RPC-oriented test names.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 77 files, 1225 tests
- `pnpm build`
- focused security scan of the complete diff

Closes #251