### PR TITLE
fix: finish split-brain reservation cutover

### DIFF
--- a/lib/server/events/club-events-service.ts
+++ b/lib/server/events/club-events-service.ts
@@ -36,14 +36,10 @@ type AdminTx = Parameters<Parameters<AdminDbClient['transaction']>[0]>[0]
  * below use the Drizzle/Neon seam (`getDrizzleDb()` / `getDrizzleAdminDb()`),
  * following the pattern established in `lib/server/events/events-service.ts`
  * (KIM-434 PR3) and `lib/server/reservations/reservations-service.ts`
- * (#238). Unlike events-service.ts's `cancelOverlappingReservationsForBlocks`
- * (written while `reservations` was still on the legacy Supabase seam and
- * therefore had to run as a non-transactional follow-up call), `reservations`
- * is now also on Drizzle/Neon (#238) — so the reservation-cancellation for a
- * blocked room/table below runs INSIDE the same `db.transaction()` as the
- * event/block write, giving true all-or-nothing atomicity again (matching
- * the atomicity the removed `apply_club_event_room_blocks` Postgres RPC used
- * to provide).
+ * (#238). `reservations` is also on Drizzle/Neon, so reservation cancellation
+ * for blocked rooms/tables runs inside the same transaction as event/block
+ * writes here and in `events-service.ts`. Both paths now preserve the
+ * all-or-nothing behavior of the removed Postgres RPCs.
  */
 
 /**
@@ -517,11 +513,8 @@ async function assertClubEventBlocksTableRoomConsistency(
  * `tableId` (OIR-208) or the whole room's tables when it doesn't — same
  * overlap predicate the removed `apply_club_event_room_blocks` RPC used.
  *
- * KIM-438: unlike `events-service.ts`'s `cancelOverlappingReservationsForBlocks`
- * (written while `reservations` was still on the legacy Supabase seam and
- * had to run as a non-transactional follow-up call), `reservations` is now
- * also on Drizzle/Neon (#238) — so this runs INSIDE the caller's `tx`,
- * restoring true same-transaction atomicity with the event/block write.
+ * Reservations are on Drizzle/Neon (#238), so this runs inside the caller's
+ * transaction and remains atomic with the event/block write.
  */
 async function cancelOverlappingReservationsForClubEventBlocks(
   tx: AdminTx,

--- a/lib/server/events/events-service.ts
+++ b/lib/server/events/events-service.ts
@@ -1,7 +1,7 @@
 import 'server-only'
-import { and, asc, eq, gt, gte, inArray, isNull, lt, lte, or, sql } from 'drizzle-orm'
-import { getAdminDb, getDrizzleAdminDb, getDrizzleDb, type AdminDbClient } from '@/lib/db'
-import { events, eventRoomBlocks, savedGames, tables } from '@/lib/db/schema'
+import { and, asc, count, eq, gt, gte, inArray, isNull, lt, lte, or, sql } from 'drizzle-orm'
+import { getDrizzleAdminDb, getDrizzleDb, type AdminDbClient } from '@/lib/db'
+import { events, eventRoomBlocks, reservations, savedGames, tables } from '@/lib/db/schema'
 import { ServiceError, serviceError } from '@/lib/server/shared/service-error'
 import type { AdminEvent, AdminEventRoomBlock, AdminEventSchedule } from '@/lib/types'
 import type { SessionUser } from '@/lib/server/auth/auth'
@@ -14,16 +14,14 @@ export type { AdminEvent, AdminEventRoomBlock, AdminEventSchedule }
  * the pattern established in `lib/server/equipment/equipment-service.ts`
  * (PR1) and `lib/server/tables/tables-service.ts` (PR2).
  *
- * `reservations` is owned by a service NOT yet migrated (PR5), so it
- * intentionally stays on the legacy Supabase seam (`getAdminDb()`) — see
- * `cancelOverlappingReservationsForBlocks()` below for the resulting
- * cross-database reservation-cancellation tradeoff, and the PR description's
- * "Split-brain disclosure" section for the full consistency caveat this
- * implies during the migration window.
+ * `reservations` is now on the same Drizzle/Neon seam. Event/block writes
+ * and their reservation-cancellation cascades therefore share one database
+ * transaction, preserving the atomicity of the removed Postgres RPCs.
  */
 
 type EventRow = typeof events.$inferSelect
 type EventRoomBlockRow = typeof eventRoomBlocks.$inferSelect
+type AdminTx = Parameters<Parameters<AdminDbClient['transaction']>[0]>[0]
 type EventAnchorFields = Pick<
   EventRow,
   'id' | 'title' | 'description' | 'date' | 'startTime' | 'endTime' | 'createdBy' | 'createdAt'
@@ -218,35 +216,10 @@ export function validateAndNormaliseSchedule(
 }
 
 // ---------------------------------------------------------------------------
-// Reservation-cancellation split-brain (KIM-434 PR3, architectural tradeoff
-// — NOT a bug, see PR description's "Split-brain disclosure" section).
-//
-// The legacy Postgres RPCs this PR replaces (create_event_atomic,
-// update_event_atomic, create_event_with_blocks, update_event_with_blocks,
-// apply_club_event_room_blocks — see lib/server/events/club-events-service.ts)
-// used to cancel overlapping `reservations` rows INSIDE the SAME Postgres
-// transaction as the event/block write, so the whole operation was atomic on
-// one database.
-//
-// `reservations` has not been migrated to Neon yet (KIM-434 PR5) — its
-// source of truth is still Supabase. Since the event/block write now targets
-// Neon (this PR) while reservations still live on Supabase, no single
-// database transaction can span both anymore. This function therefore runs
-// the reservation-cancellation step as a SEPARATE, NON-TRANSACTIONAL
-// follow-up call, invoked AFTER the Neon transaction that wrote the
-// event/blocks has already committed.
-//
-// Consequence: if this follow-up call fails (network blip, Supabase outage,
-// etc.) after the Neon transaction committed, the event/block rows remain
-// committed on Neon with their overlapping reservations NOT cancelled — a
-// new inconsistency window that did not exist before this migration. This
-// function does not attempt to "fix" that: it logs a failure loudly per
-// block and keeps going instead of throwing, since the primary (event/block)
-// write already succeeded and must not be reported as failed to the caller.
-//
-// Exported so lib/server/events/club-events-service.ts's
-// applyClubEventRoomBlocksAndMaterials (the apply_club_event_room_blocks
-// replacement) can reuse the same follow-up instead of duplicating it.
+// Reservation cancellation formerly ran as a post-commit Supabase follow-up
+// while reservations were still on the legacy backend. With reservations now
+// migrated to Neon, callers use the in-transaction helper below so event/block
+// writes and cancellation succeed or roll back together.
 // ---------------------------------------------------------------------------
 export interface EventBlockForCancellation {
   roomId: string
@@ -257,7 +230,8 @@ export interface EventBlockForCancellation {
   endTime: string
 }
 
-export async function cancelOverlappingReservationsForBlocks(
+async function cancelOverlappingReservationsForBlocksInTx(
+  tx: AdminTx,
   blocks: EventBlockForCancellation[],
 ): Promise<void> {
   if (blocks.length === 0) return
@@ -271,51 +245,43 @@ export async function cancelOverlappingReservationsForBlocks(
 
   const roomTableMap = new Map<string, string[]>()
   if (roomIdsNeedingLookup.length > 0) {
-    try {
-      const drizzleDb = getDrizzleDb()
-      const tableRows = await drizzleDb
-        .select({ id: tables.id, roomId: tables.roomId })
-        .from(tables)
-        .where(inArray(tables.roomId, roomIdsNeedingLookup))
+    const tableRows = await tx
+      .select({ id: tables.id, roomId: tables.roomId })
+      .from(tables)
+      .where(inArray(tables.roomId, roomIdsNeedingLookup))
 
-      for (const t of tableRows) {
-        const list = roomTableMap.get(t.roomId) ?? []
-        list.push(t.id)
-        roomTableMap.set(t.roomId, list)
-      }
-    } catch (error) {
-      console.error(
-        '[events] cancelOverlappingReservationsForBlocks: failed to resolve room -> table ids from Neon; ' +
-          'whole-room blocks below will skip reservation cancellation entirely for this call',
-        error,
-      )
+    for (const t of tableRows) {
+      const list = roomTableMap.get(t.roomId) ?? []
+      list.push(t.id)
+      roomTableMap.set(t.roomId, list)
     }
   }
-
-  const admin = getAdminDb()
 
   for (const block of blocks) {
     const tableIds = block.tableId ? [block.tableId] : (roomTableMap.get(block.roomId) ?? [])
     if (tableIds.length === 0) continue
 
-    const { error } = await admin
-      .from('reservations')
-      .update({ status: 'cancelled' })
-      .in('table_id', tableIds)
-      .eq('date', block.date)
-      .lt('start_time', block.endTime)
-      .gt('end_time', block.startTime)
-      .in('status', ['active', 'pending'])
-
-    if (error) {
-      console.error(
-        '[events] cancelOverlappingReservationsForBlocks: failed to cancel overlapping reservations for a ' +
-          'block — the event/block rows on Neon are already committed and will NOT be rolled back',
-        { roomId: block.roomId, tableId: block.tableId, date: block.date, startTime: block.startTime, endTime: block.endTime },
-        error,
+    await tx
+      .update(reservations)
+      .set({ status: 'cancelled' })
+      .where(
+        and(
+          inArray(reservations.tableId, tableIds),
+          eq(reservations.date, block.date),
+          lt(reservations.startTime, block.endTime),
+          gt(reservations.endTime, block.startTime),
+          inArray(reservations.status, ['active', 'pending']),
+        ),
       )
-    }
   }
+}
+
+export async function cancelOverlappingReservationsForBlocks(
+  blocks: EventBlockForCancellation[],
+): Promise<void> {
+  if (blocks.length === 0) return
+  const db = getDrizzleAdminDb()
+  await runQuery(db.transaction((tx) => cancelOverlappingReservationsForBlocksInTx(tx, blocks)))
 }
 
 // ---------------------------------------------------------------------------
@@ -342,12 +308,10 @@ export async function cancelOverlappingReservationsForBlocks(
 //       AND saved.status = 'active'
 //       AND NEW.date BETWEEN saved.start_date AND saved.end_date;
 //
-// Unlike cancelOverlappingReservationsForBlocks() above (which must run
-// post-commit, against the still-Supabase `reservations` table), saved_games
-// is already on the Drizzle/Neon seam (PR1 — lib/db/schema/saved-games.ts),
-// so this runs INSIDE the caller's transaction, alongside the
-// event_room_blocks insert, giving true all-or-nothing atomicity: a rollback
-// of the block write also rolls back this cascade.
+// Both saved_games and reservations now use Drizzle/Neon, so their
+// cancellation cascades run inside the caller's transaction alongside the
+// event_room_blocks insert. A rollback of the block write rolls back both
+// cascades as well.
 //
 // Concurrency guard (reimplemented, not dropped — see decision writeup in
 // the PR description / handoff notes for the full reasoning): the
@@ -456,10 +420,8 @@ export async function cancelSavedGamesForBlockedRoom(
 // ---------------------------------------------------------------------------
 // Atomic (Neon-transaction) event+blocks write helpers, replacing the
 // removed Supabase RPCs create_event_atomic / update_event_atomic /
-// create_event_with_blocks / update_event_with_blocks. The reservation
-// cancellation these RPCs used to perform in-transaction now runs as a
-// separate follow-up call via cancelOverlappingReservationsForBlocks() —
-// see that function's doc comment above.
+// create_event_with_blocks / update_event_with_blocks. Reservation and
+// saved-game cancellation share the same transaction as the block write.
 // ---------------------------------------------------------------------------
 
 async function createEventAtomic(
@@ -489,20 +451,11 @@ async function createEventAtomic(
           tx,
           insertedBlocks.map((b) => ({ roomId: b.roomId, tableId: b.tableId, date: b.date })),
         )
+        await cancelOverlappingReservationsForBlocksInTx(tx, insertedBlocks)
       }
 
       return { eventRow, insertedBlocks }
     }),
-  )
-
-  await cancelOverlappingReservationsForBlocks(
-    result.insertedBlocks.map((b) => ({
-      roomId: b.roomId,
-      tableId: b.tableId,
-      date: b.date,
-      startTime: b.startTime,
-      endTime: b.endTime,
-    })),
   )
 
   return toAdminEvent(result.eventRow, result.insertedBlocks)
@@ -543,20 +496,11 @@ async function updateEventAtomic(
           tx,
           insertedBlocks.map((b) => ({ roomId: b.roomId, tableId: b.tableId, date: b.date })),
         )
+        await cancelOverlappingReservationsForBlocksInTx(tx, insertedBlocks)
       }
 
       return { eventRow, insertedBlocks }
     }),
-  )
-
-  await cancelOverlappingReservationsForBlocks(
-    result.insertedBlocks.map((b) => ({
-      roomId: b.roomId,
-      tableId: b.tableId,
-      date: b.date,
-      startTime: b.startTime,
-      endTime: b.endTime,
-    })),
   )
 
   return toAdminEvent(result.eventRow, result.insertedBlocks)
@@ -572,8 +516,6 @@ async function updateEventAtomic(
 // since a table_id from an unrelated room still passes FK checks. This
 // Drizzle rewrite must reimplement that same guard explicitly.
 // ---------------------------------------------------------------------------
-type AdminTx = Parameters<Parameters<AdminDbClient['transaction']>[0]>[0]
-
 async function assertBlocksTableRoomConsistency(
   tx: AdminTx,
   blocksWithRoom: Array<{ room_id: string; table_id: string | null }>,
@@ -652,6 +594,7 @@ async function createEventWithBlocksAtomic(
           tx,
           insertedBlocks.map((b) => ({ roomId: b.roomId, tableId: b.tableId, date: b.date })),
         )
+        await cancelOverlappingReservationsForBlocksInTx(tx, insertedBlocks)
       }
 
       return { eventRow, insertedBlocks }
@@ -664,16 +607,6 @@ async function createEventWithBlocksAtomic(
     }
     serviceError('Internal server error', 500)
   }
-
-  await cancelOverlappingReservationsForBlocks(
-    result.insertedBlocks.map((b) => ({
-      roomId: b.roomId,
-      tableId: b.tableId,
-      date: b.date,
-      startTime: b.startTime,
-      endTime: b.endTime,
-    })),
-  )
 
   return toAdminEvent(result.eventRow, result.insertedBlocks)
 }
@@ -733,6 +666,7 @@ async function updateEventWithBlocksAtomic(
           tx,
           insertedBlocks.map((b) => ({ roomId: b.roomId, tableId: b.tableId, date: b.date })),
         )
+        await cancelOverlappingReservationsForBlocksInTx(tx, insertedBlocks)
       }
 
       return { eventRow, insertedBlocks }
@@ -746,16 +680,6 @@ async function updateEventWithBlocksAtomic(
     serviceError('Internal server error', 500)
   }
 
-  await cancelOverlappingReservationsForBlocks(
-    result.insertedBlocks.map((b) => ({
-      roomId: b.roomId,
-      tableId: b.tableId,
-      date: b.date,
-      startTime: b.startTime,
-      endTime: b.endTime,
-    })),
-  )
-
   return toAdminEvent(result.eventRow, result.insertedBlocks)
 }
 
@@ -768,16 +692,13 @@ async function updateEventWithBlocksAtomic(
  * above — before calling this directly, so it must NOT go through the
  * `isClubEventRow` check in `deleteEvent`).
  *
- * KIM-434 PR3: signature changed from `(admin, id)` to `(id)` — no longer
- * takes a Supabase client parameter, since the event/block delete now runs
- * on the Drizzle/Neon seam. See `cancelOverlappingReservationsForBlocks()`
- * above for why the reservation cancellation below still runs separately,
- * non-transactionally, against the legacy Supabase seam.
+ * Reservation cancellation and deletion share the same Drizzle/Neon
+ * transaction, so either both succeed or both roll back.
  */
 export async function deleteEventCascade(id: string): Promise<void> {
   const db = getDrizzleAdminDb()
 
-  const blocks = await runQuery(
+  await runQuery(
     db.transaction(async (tx) => {
       const rows = await tx
         .select({
@@ -790,14 +711,12 @@ export async function deleteEventCascade(id: string): Promise<void> {
         .from(eventRoomBlocks)
         .where(eq(eventRoomBlocks.eventId, id))
 
+      await cancelOverlappingReservationsForBlocksInTx(tx, rows)
+
       // event_room_blocks / event_equipment cascade-delete via FK ON DELETE CASCADE.
       await tx.delete(events).where(eq(events.id, id))
-
-      return rows
     }),
   )
-
-  await cancelOverlappingReservationsForBlocks(blocks)
 }
 
 // ---------------------------------------------------------------------------
@@ -1084,10 +1003,6 @@ export async function previewEventConflicts(body: {
     roomTableMap.set(t.roomId, list)
   }
 
-  // `reservations` is not yet migrated (PR5) — its source of truth is still
-  // Supabase, so the count itself must be read from there.
-  const admin = getAdminDb()
-
   const resultBlocks: EventConflictBlock[] = []
   let total = 0
 
@@ -1105,18 +1020,22 @@ export async function previewEventConflicts(body: {
       continue
     }
 
-    const { count, error: countError } = await admin
-      .from('reservations')
-      .select('id', { count: 'exact', head: true })
-      .in('table_id', tableIds)
-      .eq('date', block.date)
-      .lt('start_time', block.end_time)
-      .gt('end_time', block.start_time)
-      .in('status', ['active', 'pending'])
+    const [countRow] = await runQuery(
+      drizzleDb
+        .select({ value: count() })
+        .from(reservations)
+        .where(
+          and(
+            inArray(reservations.tableId, tableIds),
+            eq(reservations.date, block.date),
+            lt(reservations.startTime, block.end_time),
+            gt(reservations.endTime, block.start_time),
+            inArray(reservations.status, ['active', 'pending']),
+          ),
+        ),
+    )
 
-    if (countError) serviceError('Internal server error', 500)
-
-    const blockCount = count ?? 0
+    const blockCount = countRow?.value ?? 0
     total += blockCount
     resultBlocks.push({ date: block.date, roomId: block.room_id, count: blockCount })
   }

--- a/tests/unit/mocks/drizzle-mock.test.ts
+++ b/tests/unit/mocks/drizzle-mock.test.ts
@@ -20,7 +20,7 @@
  * objects held in a `Map`.
  */
 import { beforeEach, describe, expect, it } from 'vitest'
-import { and, asc, count, desc, eq, gte, ilike, inArray, isNull, lte, ne, or, sql } from 'drizzle-orm'
+import { and, asc, count, desc, eq, gt, gte, ilike, inArray, isNull, lt, lte, ne, or, sql } from 'drizzle-orm'
 
 import { profiles } from '@/lib/db/schema/profiles'
 import { reservations } from '@/lib/db/schema/reservations'
@@ -155,6 +155,24 @@ describe('AC1 state-driven resolution', () => {
 
     // An empty IN list matches nothing, rather than everything.
     expect(await db().select().from(profiles).where(inArray(profiles.id, []))).toHaveLength(0)
+  })
+
+  it('compares PostgreSQL time strings by value across HH:MM and HH:MM:SS shapes', async () => {
+    seed({
+      reservations: [
+        { id: 'before', endTime: '13:59:59' },
+        { id: 'equal-short', endTime: '14:00' },
+        { id: 'equal-long', endTime: '14:00:00' },
+        { id: 'after', endTime: '14:00:01' },
+      ],
+    })
+
+    await expect(db().select().from(reservations).where(eq(reservations.endTime, '14:00')))
+      .resolves.toHaveLength(2)
+    await expect(db().select().from(reservations).where(gt(reservations.endTime, '14:00')))
+      .resolves.toEqual([expect.objectContaining({ id: 'after' })])
+    await expect(db().select().from(reservations).where(lt(reservations.endTime, '14:00')))
+      .resolves.toEqual([expect.objectContaining({ id: 'before' })])
   })
 
   it('applies projection, ordering, limit/offset and aggregates', async () => {

--- a/tests/unit/mocks/drizzle-mock.test.ts
+++ b/tests/unit/mocks/drizzle-mock.test.ts
@@ -173,6 +173,10 @@ describe('AC1 state-driven resolution', () => {
       .resolves.toEqual([expect.objectContaining({ id: 'after' })])
     await expect(db().select().from(reservations).where(lt(reservations.endTime, '14:00')))
       .resolves.toEqual([expect.objectContaining({ id: 'before' })])
+
+    seed({ profiles: [{ id: 'text-value', memberNumber: '14:00:00' }] })
+    await expect(db().select().from(profiles).where(eq(profiles.memberNumber, '14:00')))
+      .resolves.toEqual([])
   })
 
   it('applies projection, ordering, limit/offset and aggregates', async () => {

--- a/tests/unit/mocks/drizzle-mock.ts
+++ b/tests/unit/mocks/drizzle-mock.ts
@@ -729,6 +729,20 @@ function asTime(value: unknown): number | null {
   return null
 }
 
+const SQL_TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d)(?:\.(\d{1,6}))?)?$/
+
+/** Normalise PostgreSQL `time` strings so HH:MM and HH:MM:SS compare by value. */
+function asSqlTime(value: unknown): number | null {
+  if (typeof value !== 'string') return null
+  const match = SQL_TIME_PATTERN.exec(value)
+  if (!match) return null
+  const [, hours, minutes, seconds = '0', fraction = ''] = match
+  return (
+    ((Number(hours) * 60 + Number(minutes)) * 60 + Number(seconds)) * 1_000_000 +
+    Number(fraction.padEnd(6, '0'))
+  )
+}
+
 function isNumericLike(value: unknown): boolean {
   if (typeof value === 'number') return Number.isFinite(value)
   if (typeof value === 'string') return value.trim() !== '' && !Number.isNaN(Number(value))
@@ -738,6 +752,9 @@ function isNumericLike(value: unknown): boolean {
 /** SQL `=` semantics, tolerant of the string/number/Date shapes rows carry. */
 function looseEquals(left: unknown, right: unknown): boolean {
   if (isNil(left) || isNil(right)) return false
+  const leftSqlTime = asSqlTime(left)
+  const rightSqlTime = asSqlTime(right)
+  if (leftSqlTime !== null && rightSqlTime !== null) return leftSqlTime === rightSqlTime
   if (left instanceof Date || right instanceof Date) {
     const a = asTime(left)
     const b = asTime(right)
@@ -752,6 +769,11 @@ function looseEquals(left: unknown, right: unknown): boolean {
 /** Returns -1/0/1, or `null` when the comparison is unknown (SQL NULL). */
 function compareValues(left: unknown, right: unknown): number | null {
   if (isNil(left) || isNil(right)) return null
+  const leftSqlTime = asSqlTime(left)
+  const rightSqlTime = asSqlTime(right)
+  if (leftSqlTime !== null && rightSqlTime !== null) {
+    return leftSqlTime === rightSqlTime ? 0 : leftSqlTime < rightSqlTime ? -1 : 1
+  }
   if (left instanceof Date || right instanceof Date) {
     const a = asTime(left)
     const b = asTime(right)

--- a/tests/unit/mocks/drizzle-mock.ts
+++ b/tests/unit/mocks/drizzle-mock.ts
@@ -750,11 +750,13 @@ function isNumericLike(value: unknown): boolean {
 }
 
 /** SQL `=` semantics, tolerant of the string/number/Date shapes rows carry. */
-function looseEquals(left: unknown, right: unknown): boolean {
+function looseEquals(left: unknown, right: unknown, compareAsSqlTime = false): boolean {
   if (isNil(left) || isNil(right)) return false
-  const leftSqlTime = asSqlTime(left)
-  const rightSqlTime = asSqlTime(right)
-  if (leftSqlTime !== null && rightSqlTime !== null) return leftSqlTime === rightSqlTime
+  if (compareAsSqlTime) {
+    const leftSqlTime = asSqlTime(left)
+    const rightSqlTime = asSqlTime(right)
+    if (leftSqlTime !== null && rightSqlTime !== null) return leftSqlTime === rightSqlTime
+  }
   if (left instanceof Date || right instanceof Date) {
     const a = asTime(left)
     const b = asTime(right)
@@ -767,12 +769,14 @@ function looseEquals(left: unknown, right: unknown): boolean {
 }
 
 /** Returns -1/0/1, or `null` when the comparison is unknown (SQL NULL). */
-function compareValues(left: unknown, right: unknown): number | null {
+function compareValues(left: unknown, right: unknown, compareAsSqlTime = false): number | null {
   if (isNil(left) || isNil(right)) return null
-  const leftSqlTime = asSqlTime(left)
-  const rightSqlTime = asSqlTime(right)
-  if (leftSqlTime !== null && rightSqlTime !== null) {
-    return leftSqlTime === rightSqlTime ? 0 : leftSqlTime < rightSqlTime ? -1 : 1
+  if (compareAsSqlTime) {
+    const leftSqlTime = asSqlTime(left)
+    const rightSqlTime = asSqlTime(right)
+    if (leftSqlTime !== null && rightSqlTime !== null) {
+      return leftSqlTime === rightSqlTime ? 0 : leftSqlTime < rightSqlTime ? -1 : 1
+    }
   }
   if (left instanceof Date || right instanceof Date) {
     const a = asTime(left)
@@ -833,6 +837,15 @@ function stripOuterParens(tokens: Token[]): Token[] {
   return current
 }
 
+function tokensUseSqlTimeColumn(tokens: Token[]): boolean {
+  return stripOuterParens(tokens).some((token) => {
+    if (token.t === 'sql') return tokensUseSqlTimeColumn(tokenize(token.v.queryChunks))
+    if (token.t !== 'col') return false
+    const getSQLType = (token.v as Column & { getSQLType?: () => string }).getSQLType
+    return typeof getSQLType === 'function' && /^time(?:\(|\s|$)/i.test(getSQLType.call(token.v))
+  })
+}
+
 function splitOnConnective(tokens: Token[], word: 'and' | 'or'): Token[][] | null {
   const parts: Token[][] = []
   let current: Token[] = []
@@ -875,13 +888,14 @@ function evaluateTokens(rawTokens: Token[], ctx: QueryContext, source: SQL): boo
   if (betweenIndex > 0) {
     const negated = (tokens[betweenIndex] as { v: string }).v.toLowerCase().startsWith('not')
     const subject = evaluateOperand(tokens.slice(0, betweenIndex), ctx)
+    const compareAsSqlTime = tokensUseSqlTimeColumn(tokens.slice(0, betweenIndex))
     const rest = tokens.slice(betweenIndex + 1)
     const andIndex = rest.findIndex((token) => token.t === 'text' && token.v.toLowerCase() === 'and')
     if (andIndex === -1) throw mockError(`malformed BETWEEN in: ${renderSql(source)}`)
     const lower = evaluateOperand(rest.slice(0, andIndex), ctx)
     const upper = evaluateOperand(rest.slice(andIndex + 1), ctx)
-    const low = compareValues(subject, lower)
-    const high = compareValues(subject, upper)
+    const low = compareValues(subject, lower, compareAsSqlTime)
+    const high = compareValues(subject, upper, compareAsSqlTime)
     if (low === null || high === null) return false
     const inRange = low >= 0 && high <= 0
     return negated ? !inRange : inRange
@@ -929,6 +943,10 @@ function evaluateComparison(tokens: Token[], ctx: QueryContext, source: SQL): bo
   const operator = (tokens[operatorIndex] as { v: string }).v.toLowerCase()
   const left = evaluateOperand(tokens.slice(0, operatorIndex), ctx)
   const rightTokens = tokens.slice(operatorIndex + 1)
+  const compareAsSqlTime = tokensUseSqlTimeColumn([
+    ...tokens.slice(0, operatorIndex),
+    ...rightTokens,
+  ])
 
   switch (operator) {
     case 'is null':
@@ -947,15 +965,15 @@ function evaluateComparison(tokens: Token[], ctx: QueryContext, source: SQL): bo
 
   switch (operator) {
     case '=':
-      return looseEquals(left, right)
+      return looseEquals(left, right, compareAsSqlTime)
     case '<>':
     case '!=':
-      return !isNil(left) && !isNil(right) && !looseEquals(left, right)
+      return !isNil(left) && !isNil(right) && !looseEquals(left, right, compareAsSqlTime)
     case '>':
     case '>=':
     case '<':
     case '<=': {
-      const order = compareValues(left, right)
+      const order = compareValues(left, right, compareAsSqlTime)
       if (order === null) return false
       if (operator === '>') return order > 0
       if (operator === '>=') return order >= 0
@@ -965,7 +983,7 @@ function evaluateComparison(tokens: Token[], ctx: QueryContext, source: SQL): bo
     case 'in':
     case 'not in': {
       const list = Array.isArray(right) ? right : [right]
-      const contained = list.some((candidate) => looseEquals(left, candidate))
+      const contained = list.some((candidate) => looseEquals(left, candidate, compareAsSqlTime))
       return operator === 'in' ? contained : !isNil(left) && !contained
     }
     case 'like':

--- a/tests/unit/server/events-preview.test.ts
+++ b/tests/unit/server/events-preview.test.ts
@@ -1,595 +1,224 @@
 // @vitest-environment node
-/**
- * KIM-383: previewEventConflicts service tests
- *
- * Covers:
- * - All null-room schedules → { total: 0, blocks: [] }, no DB queries needed
- * - Room set but no overlapping reservations → total: 0, per-block count 0
- * - Room + overlapping active/pending reservations → correct total and per-block count
- * - Multiple blocks sharing one room → tables lookup is batched (single .in call)
- * - Empty schedules array → early return (not an error); > 366 schedules → 400
- * - Overlap predicate: end_time == block.start_time is NOT counted; real overlap IS counted
- * - Room with no tables → count 0, block still included
- * - Invalid schedule entries propagate 400
- */
-
-import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
-import type { ServiceError } from '@/lib/server/shared/service-error'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createMockServiceError,
+  createStatefulDrizzleDb,
+  getQueryLog,
+  MockServiceError,
+  resetDb,
+  seed,
+} from '@/tests/unit/mocks/drizzle-mock'
 
 vi.mock('server-only', () => ({}))
 
-// Mock Drizzle database
-const drizzleSelectMock = vi.fn()
-const mockAdminClient = {
-  from: vi.fn(),
-}
-
 vi.mock('@/lib/db', () => ({
-  getDrizzleDb: vi.fn(() => ({
-    select: vi.fn(() => ({
-      from: vi.fn(() => ({
-        where: vi.fn(() => drizzleSelectMock()),
-      })),
-    })),
-  })),
-  getAdminDb: vi.fn(() => mockAdminClient),
-}))
-
-vi.mock('@/lib/supabase/server', () => ({
-  createSupabaseServerAdminClient: vi.fn(),
-  createSupabaseServerClient: vi.fn(),
+  getDrizzleDb: vi.fn(() => createStatefulDrizzleDb()),
+  getDrizzleAdminDb: vi.fn(() => createStatefulDrizzleDb()),
 }))
 
 vi.mock('@/lib/server/shared/service-error', () => ({
-  serviceError: vi.fn((message: string, statusCode: number) => {
-    const err = new Error(message) as ServiceError
-    err.name = 'ServiceError'
-    err.statusCode = statusCode
-    throw err
-  }),
+  ServiceError: MockServiceError,
+  serviceError: createMockServiceError(),
 }))
 
-// ---------------------------------------------------------------------------
-// Mock builder
-// ---------------------------------------------------------------------------
-
-/**
- * Builds a minimal Supabase admin client mock for previewEventConflicts.
- *
- * The reservations count query chain is:
- *   .select('id', { count: 'exact', head: true })
- *   .in('table_id', tableIds)   ← first .in
- *   .eq('date', ...)
- *   .lt('start_time', ...)
- *   .gt('end_time', ...)
- *   .in('status', [...])        ← second .in (terminal, resolves)
- *
- * `tablesResult` – what `.from('tables').select().in()` resolves to
- * `reservationCountFactory` – called per reservations count query (by call index)
- */
-function buildPreviewMock({
-  tablesResult = { data: [] as { id: string; room_id: string }[], error: null },
-  reservationCountFactory = (_idx: number): { count: number | null; error: unknown } =>
-    ({ count: 0, error: null }),
-}: {
-  tablesResult?: { data: { id: string; room_id: string }[] | null; error: unknown }
-  reservationCountFactory?: (idx: number) => { count: number | null; error: unknown }
-} = {}) {
-  let reservationCallIndex = 0
-
-  // Track the `in` call on the tables mock
-  const tablesInMock = vi.fn().mockResolvedValue(tablesResult)
-  const tablesSelectMock = vi.fn().mockReturnValue({ in: tablesInMock })
-
-  /**
-   * For each reservations count query, build a chainable object where:
-   * - .in() (first call) → returns chain (table_id filter)
-   * - .eq() → returns chain
-   * - .lt() → returns chain
-   * - .gt() → returns chain
-   * - .in() (second call) → returns Promise (status filter, terminal)
-   *
-   * We track how many times `.in` has been called on this specific chain instance.
-   */
-  const makeReservationsChain = () => {
-    const idx = reservationCallIndex++
-    const resolveWith = { ...reservationCountFactory(idx), data: null }
-
-    let inCallCount = 0
-
-    const chain: Record<string, unknown> = {}
-    chain['in'] = vi.fn((..._args: unknown[]) => {
-      inCallCount++
-      if (inCallCount >= 2) {
-        // Second .in() → terminal, resolves with count
-        return Promise.resolve(resolveWith)
-      }
-      // First .in() → chainable
-      return chain
-    })
-    chain['eq'] = vi.fn(() => chain)
-    chain['lt'] = vi.fn(() => chain)
-    chain['gt'] = vi.fn(() => chain)
-    return chain
-  }
-
-  const reservationsSelectMock = vi.fn((_fields: string, opts?: { count?: string; head?: boolean }) => {
-    if (opts?.count === 'exact') {
-      return makeReservationsChain()
-    }
-    // Fallback (not reached in preview path)
-    return { in: vi.fn().mockResolvedValue({ data: [], error: null }) }
-  })
-
-  const mock = {
-    from: vi.fn((table: string) => {
-      if (table === 'tables') {
-        return { select: tablesSelectMock }
-      }
-      if (table === 'reservations') {
-        return { select: reservationsSelectMock }
-      }
-      return {
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
-        in: vi.fn().mockResolvedValue({ data: [], error: null }),
-      }
-    }),
-  }
-
-  return { mock, tablesInMock, tablesSelectMock, reservationsSelectMock }
+function table(id: string, roomId: string) {
+  return { id, roomId }
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+function reservation(overrides: Record<string, unknown>) {
+  return {
+    id: crypto.randomUUID(),
+    tableId: 'table-1',
+    userId: crypto.randomUUID(),
+    date: '2026-08-01',
+    startTime: '10:00:00',
+    endTime: '12:00:00',
+    status: 'active',
+    surface: null,
+    activatedAt: null,
+    createdAt: new Date(),
+    ...overrides,
+  }
+}
+
+async function preview(schedules: unknown[]) {
+  const { previewEventConflicts } = await import('@/lib/server/events/events-service')
+  return previewEventConflicts({ schedules })
+}
 
 describe('events-service — previewEventConflicts', () => {
   beforeEach(() => {
-    vi.resetModules()
+    resetDb()
     vi.clearAllMocks()
+    vi.resetModules()
   })
 
-  afterEach(() => {
-    vi.resetModules()
-    vi.clearAllMocks()
+  it('returns no conflicts without querying when every schedule has no room', async () => {
+    await expect(preview([
+      { date: '2026-07-10', startTime: '10:00', endTime: '12:00', roomId: null, allDay: false },
+      { date: '2026-07-11', startTime: '14:00', endTime: '16:00', roomId: null, allDay: false },
+    ])).resolves.toEqual({ total: 0, blocks: [] })
+
+    expect(getQueryLog()).toEqual([])
   })
 
-  // -------------------------------------------------------------------------
-  // 1. All null-room schedules → early return, no DB queries
-  // -------------------------------------------------------------------------
+  it('returns zero when a room has tables but no overlapping reservations', async () => {
+    seed({ tables: [table('table-1', 'room-A')] })
 
-  it('returns { total: 0, blocks: [] } when all schedules have null room_id', async () => {
-    const { mock, tablesInMock, reservationsSelectMock } = buildPreviewMock()
+    await expect(preview([
+      { date: '2026-08-01', startTime: '10:00', endTime: '12:00', roomId: 'room-A', allDay: false },
+    ])).resolves.toEqual({
+      total: 0,
+      blocks: [{ date: '2026-08-01', roomId: 'room-A', count: 0 }],
+    })
+  })
 
-    const { getAdminDb } = await import('@/lib/db')
-    vi.mocked(getAdminDb).mockReturnValue(mock as any)
-
-    const { previewEventConflicts } = await import('@/lib/server/events/events-service')
-
-    const result = await previewEventConflicts({
-      schedules: [
-        { date: '2026-07-10', startTime: '10:00', endTime: '12:00', roomId: null, allDay: false },
-        { date: '2026-07-11', startTime: '14:00', endTime: '16:00', roomId: null, allDay: false },
+  it('counts active and pending overlaps per block using Neon state', async () => {
+    seed({
+      tables: [table('table-1', 'room-B'), table('table-2', 'room-B')],
+      reservations: [
+        reservation({ id: 'r1', tableId: 'table-1', date: '2026-09-01', status: 'active' }),
+        reservation({ id: 'r2', tableId: 'table-1', date: '2026-09-01', status: 'pending' }),
+        reservation({ id: 'r3', tableId: 'table-2', date: '2026-09-01', status: 'active' }),
+        reservation({ id: 'r4', tableId: 'table-1', date: '2026-09-02', status: 'active' }),
+        reservation({ id: 'r5', tableId: 'table-2', date: '2026-09-02', status: 'pending' }),
+        reservation({ id: 'ignored', tableId: 'table-2', date: '2026-09-02', status: 'cancelled' }),
       ],
     })
 
-    expect(result).toEqual({ total: 0, blocks: [] })
-    // No DB queries should have been issued
-    expect(tablesInMock).not.toHaveBeenCalled()
-    expect(reservationsSelectMock).not.toHaveBeenCalled()
-  })
-
-  // -------------------------------------------------------------------------
-  // 2. Room set but no overlapping reservations → total 0, count 0 per block
-  // -------------------------------------------------------------------------
-
-  it('returns total: 0 when room has tables but no overlapping reservations', async () => {
-    const { mock } = buildPreviewMock({
-      tablesResult: {
-        data: [{ id: 'table-1', room_id: 'room-A' }],
-        error: null,
-      },
-      reservationCountFactory: () => ({ count: 0, error: null }),
-    })
-
-    drizzleSelectMock.mockResolvedValue([{ id: 'table-1', roomId: 'room-A' }])
-
-    const { getAdminDb } = await import('@/lib/db')
-    vi.mocked(getAdminDb).mockReturnValue(mock as any)
-
-    const { previewEventConflicts } = await import('@/lib/server/events/events-service')
-
-    const result = await previewEventConflicts({
-      schedules: [
-        { date: '2026-08-01', startTime: '10:00', endTime: '12:00', roomId: 'room-A', allDay: false },
+    await expect(preview([
+      { date: '2026-09-01', startTime: '10:00', endTime: '14:00', roomId: 'room-B', allDay: false },
+      { date: '2026-09-02', startTime: '10:00', endTime: '14:00', roomId: 'room-B', allDay: false },
+    ])).resolves.toEqual({
+      total: 5,
+      blocks: [
+        { date: '2026-09-01', roomId: 'room-B', count: 3 },
+        { date: '2026-09-02', roomId: 'room-B', count: 2 },
       ],
     })
-
-    expect(result.total).toBe(0)
-    expect(result.blocks).toHaveLength(1)
-    expect(result.blocks[0]).toEqual({ date: '2026-08-01', roomId: 'room-A', count: 0 })
   })
 
-  // -------------------------------------------------------------------------
-  // 3. Room + overlapping active/pending reservations → correct total & count
-  // -------------------------------------------------------------------------
+  it('batches the table lookup for multiple blocks', async () => {
+    seed({ tables: [table('table-1', 'room-C')] })
 
-  it('returns correct total and per-block count when overlapping reservations exist', async () => {
-    // Two blocks in the same room; block 0 has 3 overlapping reservations, block 1 has 2.
-    const { mock } = buildPreviewMock({
-      tablesResult: {
-        data: [
-          { id: 'table-1', room_id: 'room-B' },
-          { id: 'table-2', room_id: 'room-B' },
-        ],
-        error: null,
-      },
-      reservationCountFactory: (idx) => ({ count: [3, 2][idx] ?? 0, error: null }),
-    })
-
-    drizzleSelectMock.mockResolvedValue([
-      { id: 'table-1', roomId: 'room-B' },
-      { id: 'table-2', roomId: 'room-B' },
+    await preview([
+      { date: '2026-10-01', startTime: '10:00', endTime: '12:00', roomId: 'room-C', allDay: false },
+      { date: '2026-10-02', startTime: '10:00', endTime: '12:00', roomId: 'room-C', allDay: false },
+      { date: '2026-10-03', startTime: '10:00', endTime: '12:00', roomId: 'room-C', allDay: false },
     ])
 
-    const { getAdminDb } = await import('@/lib/db')
-    vi.mocked(getAdminDb).mockReturnValue(mock as any)
+    expect(getQueryLog().filter((entry) => entry.op === 'select' && entry.table === 'tables')).toHaveLength(1)
+  })
 
-    const { previewEventConflicts } = await import('@/lib/server/events/events-service')
+  it('returns no conflicts for an empty schedules array', async () => {
+    await expect(preview([])).resolves.toEqual({ total: 0, blocks: [] })
+  })
 
-    const result = await previewEventConflicts({
-      schedules: [
-        { date: '2026-09-01', startTime: '10:00', endTime: '14:00', roomId: 'room-B', allDay: false },
-        { date: '2026-09-02', startTime: '10:00', endTime: '14:00', roomId: 'room-B', allDay: false },
+  it('rejects more than 366 schedules', async () => {
+    const schedules = Array.from({ length: 367 }, (_, i) => ({
+      date: new Date(2026, 0, 1 + (i % 365)).toISOString().slice(0, 10),
+      startTime: '10:00',
+      endTime: '12:00',
+      roomId: 'room-1',
+      allDay: false,
+    }))
+
+    await expect(preview(schedules)).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('does not count a reservation ending exactly when the block starts', async () => {
+    seed({
+      tables: [table('table-1', 'room-D')],
+      reservations: [reservation({ tableId: 'table-1', date: '2026-11-01', startTime: '12:00:00', endTime: '14:00:00' })],
+    })
+
+    await expect(preview([
+      { date: '2026-11-01', startTime: '14:00', endTime: '18:00', roomId: 'room-D', allDay: false },
+    ])).resolves.toEqual({
+      total: 0,
+      blocks: [{ date: '2026-11-01', roomId: 'room-D', count: 0 }],
+    })
+  })
+
+  it('counts genuine overlaps', async () => {
+    seed({
+      tables: [table('table-1', 'room-E')],
+      reservations: [
+        reservation({ id: 'r1', tableId: 'table-1', date: '2026-11-02', startTime: '13:00:00', endTime: '15:00:00' }),
+        reservation({ id: 'r2', tableId: 'table-1', date: '2026-11-02', startTime: '17:00:00', endTime: '19:00:00', status: 'pending' }),
       ],
     })
 
-    expect(result.total).toBe(5)
-    expect(result.blocks).toHaveLength(2)
-    expect(result.blocks[0]).toEqual({ date: '2026-09-01', roomId: 'room-B', count: 3 })
-    expect(result.blocks[1]).toEqual({ date: '2026-09-02', roomId: 'room-B', count: 2 })
+    await expect(preview([
+      { date: '2026-11-02', startTime: '14:00', endTime: '18:00', roomId: 'room-E', allDay: false },
+    ])).resolves.toEqual({
+      total: 2,
+      blocks: [{ date: '2026-11-02', roomId: 'room-E', count: 2 }],
+    })
   })
 
-  // -------------------------------------------------------------------------
-  // 4. Multiple blocks sharing one room → tables lookup is batched (single .in call)
-  // -------------------------------------------------------------------------
+  it('includes a zero-count block when a room has no tables', async () => {
+    await expect(preview([
+      { date: '2026-12-01', startTime: '10:00', endTime: '12:00', roomId: 'room-empty', allDay: false },
+    ])).resolves.toEqual({
+      total: 0,
+      blocks: [{ date: '2026-12-01', roomId: 'room-empty', count: 0 }],
+    })
+  })
 
-  it('performs a single batched tables lookup for multiple blocks sharing the same room', async () => {
-    const { mock, tablesInMock } = buildPreviewMock({
-      tablesResult: {
-        data: [{ id: 'table-1', room_id: 'room-C' }],
-        error: null,
+  it('rejects invalid dates', async () => {
+    await expect(preview([
+      { date: 'not-a-date', startTime: '10:00', endTime: '12:00', roomId: 'room-1', allDay: false },
+    ])).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('rejects schedules whose end is not after their start', async () => {
+    await expect(preview([
+      { date: '2026-07-10', startTime: '18:00', endTime: '10:00', roomId: 'room-1', allDay: false },
+    ])).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('skips null-room blocks while counting real-room blocks', async () => {
+    seed({
+      tables: [table('table-1', 'room-F')],
+      reservations: Array.from({ length: 4 }, (_, i) => reservation({
+        id: `r${i}`,
+        tableId: 'table-1',
+        date: '2026-08-11',
+      })),
+    })
+
+    await expect(preview([
+      { date: '2026-08-10', startTime: '10:00', endTime: '12:00', roomId: null, allDay: false },
+      { date: '2026-08-11', startTime: '10:00', endTime: '12:00', roomId: 'room-F', allDay: false },
+      { date: '2026-08-12', startTime: '10:00', endTime: '12:00', roomId: null, allDay: false },
+    ])).resolves.toEqual({
+      total: 4,
+      blocks: [{ date: '2026-08-11', roomId: 'room-F', count: 4 }],
+    })
+  })
+
+  it('scopes table-level blocks to that table instead of the whole room', async () => {
+    seed({
+      tables: [table('table-Y1', 'room-Y'), table('table-Y2', 'room-Y')],
+      reservations: [
+        reservation({ id: 'target', tableId: 'table-Y1', date: '2027-01-01' }),
+        reservation({ id: 'other', tableId: 'table-Y2', date: '2027-01-01' }),
+      ],
+    })
+
+    await expect(preview([
+      {
+        date: '2027-01-01',
+        startTime: '10:00',
+        endTime: '12:00',
+        roomId: 'room-Y',
+        tableId: 'table-Y1',
+        allDay: false,
       },
-      reservationCountFactory: () => ({ count: 1, error: null }),
+    ])).resolves.toEqual({
+      total: 1,
+      blocks: [{ date: '2027-01-01', roomId: 'room-Y', count: 1 }],
     })
-
-    drizzleSelectMock.mockResolvedValue([{ id: 'table-1', roomId: 'room-C' }])
-
-    const { getAdminDb } = await import('@/lib/db')
-    vi.mocked(getAdminDb).mockReturnValue(mock as any)
-
-    const { previewEventConflicts } = await import('@/lib/server/events/events-service')
-
-    await previewEventConflicts({
-      schedules: [
-        { date: '2026-10-01', startTime: '10:00', endTime: '12:00', roomId: 'room-C', allDay: false },
-        { date: '2026-10-02', startTime: '10:00', endTime: '12:00', roomId: 'room-C', allDay: false },
-        { date: '2026-10-03', startTime: '10:00', endTime: '12:00', roomId: 'room-C', allDay: false },
-      ],
-    })
-
-    // Batching is now handled at the Drizzle layer, not Supabase
-  })
-
-  // -------------------------------------------------------------------------
-  // 5a. Empty schedules array → early return (no error per implementation)
-  // -------------------------------------------------------------------------
-
-  it('returns { total: 0, blocks: [] } for empty schedules array (early exit, not 400)', async () => {
-    const { mock } = buildPreviewMock()
-
-    const { getAdminDb } = await import('@/lib/db')
-    vi.mocked(getAdminDb).mockReturnValue(mock as any)
-
-    const { previewEventConflicts } = await import('@/lib/server/events/events-service')
-
-    // The service implementation: `!Array.isArray(schedules) || schedules.length === 0` → early return
-    const result = await previewEventConflicts({ schedules: [] })
-    expect(result).toEqual({ total: 0, blocks: [] })
-  })
-
-  // -------------------------------------------------------------------------
-  // 5b. > 366 schedules → 400
-  // -------------------------------------------------------------------------
-
-  it('throws 400 when schedules array has more than 366 entries', async () => {
-    const { mock } = buildPreviewMock()
-
-    const { getAdminDb } = await import('@/lib/db')
-    vi.mocked(getAdminDb).mockReturnValue(mock as any)
-
-    const { previewEventConflicts } = await import('@/lib/server/events/events-service')
-
-    const schedules = Array.from({ length: 367 }, (_, i) => {
-      const dateStr = new Date(2026, 0, 1 + (i % 365)).toISOString().slice(0, 10)
-      return { date: dateStr, startTime: '10:00', endTime: '12:00', roomId: 'room-1', allDay: false }
-    })
-
-    let caught: ServiceError | undefined
-    try {
-      await previewEventConflicts({ schedules })
-    } catch (err) {
-      caught = err as ServiceError
-    }
-
-    expect(caught).toBeDefined()
-    expect(caught?.statusCode).toBe(400)
-    expect(caught?.message).toMatch(/Too many schedule blocks/)
-  })
-
-  // -------------------------------------------------------------------------
-  // 6a. Overlap predicate: boundary-touching reservation is NOT counted
-  // -------------------------------------------------------------------------
-
-  it('does not count a reservation whose end_time equals the block start_time (strict boundary)', async () => {
-    // The service uses: .lt('start_time', block.end_time).gt('end_time', block.start_time)
-    // A reservation with end_time == '14:00' does NOT satisfy gt('end_time', '14:00').
-    // We simulate this by returning count: 0 from the mock (the DB would do the same).
-    const { mock } = buildPreviewMock({
-      tablesResult: {
-        data: [{ id: 'table-1', room_id: 'room-D' }],
-        error: null,
-      },
-      reservationCountFactory: () => ({ count: 0, error: null }),
-    })
-
-    drizzleSelectMock.mockResolvedValue([{ id: 'table-1', roomId: 'room-D' }])
-
-    const { getAdminDb } = await import('@/lib/db')
-    vi.mocked(getAdminDb).mockReturnValue(mock as any)
-
-    const { previewEventConflicts } = await import('@/lib/server/events/events-service')
-
-    // Block: 14:00–18:00; a boundary-touch reservation ends exactly at 14:00 → not counted.
-    const result = await previewEventConflicts({
-      schedules: [
-        { date: '2026-11-01', startTime: '14:00', endTime: '18:00', roomId: 'room-D', allDay: false },
-      ],
-    })
-
-    expect(result.total).toBe(0)
-    expect(result.blocks[0].count).toBe(0)
-  })
-
-  // -------------------------------------------------------------------------
-  // 6b. Genuine overlap IS counted
-  // -------------------------------------------------------------------------
-
-  it('counts a reservation that genuinely overlaps the block window', async () => {
-    // A reservation 13:00–15:00 overlaps block 14:00–18:00: 13:00 < 18:00 AND 15:00 > 14:00
-    const { mock } = buildPreviewMock({
-      tablesResult: {
-        data: [{ id: 'table-1', room_id: 'room-E' }],
-        error: null,
-      },
-      reservationCountFactory: () => ({ count: 2, error: null }),
-    })
-
-    drizzleSelectMock.mockResolvedValue([{ id: 'table-1', roomId: 'room-E' }])
-
-    const { getAdminDb } = await import('@/lib/db')
-    vi.mocked(getAdminDb).mockReturnValue(mock as any)
-
-    const { previewEventConflicts } = await import('@/lib/server/events/events-service')
-
-    const result = await previewEventConflicts({
-      schedules: [
-        { date: '2026-11-02', startTime: '14:00', endTime: '18:00', roomId: 'room-E', allDay: false },
-      ],
-    })
-
-    expect(result.total).toBe(2)
-    expect(result.blocks[0].count).toBe(2)
-  })
-
-  // -------------------------------------------------------------------------
-  // 7. Room with no tables → count 0, block still appears in result
-  // -------------------------------------------------------------------------
-
-  it('includes a block with count: 0 when the room has no tables in the DB', async () => {
-    const { mock } = buildPreviewMock({
-      tablesResult: { data: [], error: null },
-      // factory won't be called since there are no table ids to filter on
-      reservationCountFactory: () => ({ count: 99, error: null }),
-    })
-
-    drizzleSelectMock.mockResolvedValue([])
-
-    const { getAdminDb } = await import('@/lib/db')
-    vi.mocked(getAdminDb).mockReturnValue(mock as any)
-
-    const { previewEventConflicts } = await import('@/lib/server/events/events-service')
-
-    const result = await previewEventConflicts({
-      schedules: [
-        { date: '2026-12-01', startTime: '10:00', endTime: '12:00', roomId: 'room-empty', allDay: false },
-      ],
-    })
-
-    expect(result.total).toBe(0)
-    expect(result.blocks).toHaveLength(1)
-    expect(result.blocks[0]).toEqual({ date: '2026-12-01', roomId: 'room-empty', count: 0 })
-  })
-
-  // -------------------------------------------------------------------------
-  // 8. Invalid schedule entries propagate 400
-  // -------------------------------------------------------------------------
-
-  it('throws 400 when a schedule has an invalid date format', async () => {
-    const { mock } = buildPreviewMock()
-
-    const { getAdminDb } = await import('@/lib/db')
-    vi.mocked(getAdminDb).mockReturnValue(mock as any)
-
-    const { previewEventConflicts } = await import('@/lib/server/events/events-service')
-
-    let caught: ServiceError | undefined
-    try {
-      await previewEventConflicts({
-        schedules: [
-          { date: 'not-a-date', startTime: '10:00', endTime: '12:00', roomId: 'room-1', allDay: false },
-        ],
-      })
-    } catch (err) {
-      caught = err as ServiceError
-    }
-
-    expect(caught).toBeDefined()
-    expect(caught?.statusCode).toBe(400)
-    expect(caught?.message).toMatch(/date must be in YYYY-MM-DD format/)
-  })
-
-  it('throws 400 when a schedule has endTime <= startTime', async () => {
-    const { mock } = buildPreviewMock()
-
-    const { getAdminDb } = await import('@/lib/db')
-    vi.mocked(getAdminDb).mockReturnValue(mock as any)
-
-    const { previewEventConflicts } = await import('@/lib/server/events/events-service')
-
-    let caught: ServiceError | undefined
-    try {
-      await previewEventConflicts({
-        schedules: [
-          { date: '2026-07-10', startTime: '18:00', endTime: '10:00', roomId: 'room-1', allDay: false },
-        ],
-      })
-    } catch (err) {
-      caught = err as ServiceError
-    }
-
-    expect(caught).toBeDefined()
-    expect(caught?.statusCode).toBe(400)
-    expect(caught?.message).toMatch(/endTime must be after startTime/)
-  })
-
-  // -------------------------------------------------------------------------
-  // 9. Mixed null-room and real-room blocks
-  // -------------------------------------------------------------------------
-
-  it('skips null-room blocks but counts conflicts for real-room blocks in the same call', async () => {
-    const { mock } = buildPreviewMock({
-      tablesResult: {
-        data: [{ id: 'table-1', room_id: 'room-F' }],
-        error: null,
-      },
-      reservationCountFactory: () => ({ count: 4, error: null }),
-    })
-
-    drizzleSelectMock.mockResolvedValue([{ id: 'table-1', roomId: 'room-F' }])
-
-    const { getAdminDb } = await import('@/lib/db')
-    vi.mocked(getAdminDb).mockReturnValue(mock as any)
-
-    const { previewEventConflicts } = await import('@/lib/server/events/events-service')
-
-    const result = await previewEventConflicts({
-      schedules: [
-        { date: '2026-08-10', startTime: '10:00', endTime: '12:00', roomId: null, allDay: false },
-        { date: '2026-08-11', startTime: '10:00', endTime: '12:00', roomId: 'room-F', allDay: false },
-        { date: '2026-08-12', startTime: '10:00', endTime: '12:00', roomId: null, allDay: false },
-      ],
-    })
-
-    // Only the real-room block appears in results
-    expect(result.total).toBe(4)
-    expect(result.blocks).toHaveLength(1)
-    expect(result.blocks[0]).toEqual({ date: '2026-08-11', roomId: 'room-F', count: 4 })
-  })
-
-  // -------------------------------------------------------------------------
-  // 10. KIM-434 PR #182 review fix: a table-level block (table_id set) must
-  //     only count conflicts against that ONE table, not every table in the
-  //     room — matching cancelOverlappingReservationsForBlocks()'s scoping.
-  //     Before the fix, `tableIds = roomTableMap.get(block.room_id)` counted
-  //     against every table in the room regardless of the block's table_id.
-  // -------------------------------------------------------------------------
-
-  it('scopes conflict count to the block\'s specific table_id, not every table in the room', async () => {
-    // room-Y has two tables; the schedule below is a table-level block that
-    // only targets table-Y1. We capture the actual filter args passed to the
-    // reservations count query's first `.in('table_id', tableIds)` call so
-    // this test fails if the implementation regresses to counting the whole
-    // room's tables for a table-scoped block.
-    let capturedTableIds: string[] | undefined
-
-    const tablesInMock = vi.fn().mockResolvedValue({
-      data: [
-        { id: 'table-Y1', room_id: 'room-Y' },
-        { id: 'table-Y2', room_id: 'room-Y' },
-      ],
-      error: null,
-    })
-    const tablesSelectMock = vi.fn().mockReturnValue({ in: tablesInMock })
-
-    let inCallCount = 0
-    const reservationsChain: Record<string, unknown> = {}
-    reservationsChain['in'] = vi.fn((...args: unknown[]) => {
-      inCallCount++
-      if (inCallCount === 1) {
-        // First .in() call is the table_id filter — capture it.
-        capturedTableIds = args[1] as string[]
-        return reservationsChain
-      }
-      // Second .in() call is the status filter — terminal, resolves.
-      return Promise.resolve({ count: 5, error: null, data: null })
-    })
-    reservationsChain['eq'] = vi.fn(() => reservationsChain)
-    reservationsChain['lt'] = vi.fn(() => reservationsChain)
-    reservationsChain['gt'] = vi.fn(() => reservationsChain)
-
-    const reservationsSelectMock = vi.fn(() => reservationsChain)
-
-    const mock = {
-      from: vi.fn((table: string) => {
-        if (table === 'tables') return { select: tablesSelectMock }
-        if (table === 'reservations') return { select: reservationsSelectMock }
-        return {
-          select: vi.fn().mockReturnThis(),
-          eq: vi.fn().mockReturnThis(),
-          in: vi.fn().mockResolvedValue({ data: [], error: null }),
-        }
-      }),
-    }
-
-    drizzleSelectMock.mockResolvedValue([
-      { id: 'table-Y1', roomId: 'room-Y' },
-      { id: 'table-Y2', roomId: 'room-Y' },
-    ])
-
-    const { getAdminDb } = await import('@/lib/db')
-    vi.mocked(getAdminDb).mockReturnValue(mock as any)
-
-    const { previewEventConflicts } = await import('@/lib/server/events/events-service')
-
-    const result = await previewEventConflicts({
-      schedules: [
-        {
-          date: '2027-01-01',
-          startTime: '10:00',
-          endTime: '12:00',
-          roomId: 'room-Y',
-          tableId: 'table-Y1',
-          allDay: false,
-        },
-      ],
-    })
-
-    // The bug would pass ['table-Y1', 'table-Y2'] here (whole room).
-    expect(capturedTableIds).toEqual(['table-Y1'])
-    expect(result.total).toBe(5)
-    expect(result.blocks).toHaveLength(1)
-    expect(result.blocks[0]).toEqual({ date: '2027-01-01', roomId: 'room-Y', count: 5 })
   })
 })

--- a/tests/unit/server/events-service-multiday.test.ts
+++ b/tests/unit/server/events-service-multiday.test.ts
@@ -6,6 +6,7 @@ import {
   seed,
   seedTable,
   getQueryLog,
+  getRows,
   failNextQuery,
   createMockServiceError,
   MockServiceError,
@@ -33,21 +34,6 @@ vi.mock('server-only', () => ({}))
 vi.mock('@/lib/db', () => ({
   getDrizzleDb: vi.fn(() => createStatefulDrizzleDb()),
   getDrizzleAdminDb: vi.fn(() => createStatefulDrizzleDb()),
-  getAdminDb: vi.fn(() => ({
-    from: vi.fn(() => ({
-      update: vi.fn(() => ({
-        in: vi.fn(() => ({
-          eq: vi.fn(() => ({
-            lt: vi.fn(() => ({
-              gt: vi.fn(() => ({
-                in: vi.fn(async () => ({ data: null, error: null })),
-              })),
-            })),
-          })),
-        })),
-      })),
-    })),
-  })),
 }))
 
 vi.mock('@/lib/server/shared/service-error', () => ({
@@ -615,6 +601,84 @@ describe('events-service — deleteEvent multi-day cancellation', () => {
     const { deleteEvent } = await loadEventsService()
 
     await expect(deleteEvent(adminSession, 'evt-cancel-multi')).resolves.not.toThrow()
+  })
+
+  it('cancels only overlapping pending/active reservations for a table-scoped block', async () => {
+    seed({
+      tables: [
+        { id: 'table-1', roomId: 'room-1' },
+        { id: 'table-2', roomId: 'room-1' },
+      ],
+      reservations: [
+        { id: 'active-overlap', tableId: 'table-1', date: '2026-07-10', startTime: '10:00:00', endTime: '12:00:00', status: 'active' },
+        { id: 'pending-overlap', tableId: 'table-1', date: '2026-07-10', startTime: '11:00:00', endTime: '13:00:00', status: 'pending' },
+        { id: 'completed-overlap', tableId: 'table-1', date: '2026-07-10', startTime: '10:00:00', endTime: '12:00:00', status: 'completed' },
+        { id: 'boundary', tableId: 'table-1', date: '2026-07-10', startTime: '08:00:00', endTime: '09:00:00', status: 'active' },
+        { id: 'other-table', tableId: 'table-2', date: '2026-07-10', startTime: '10:00:00', endTime: '12:00:00', status: 'active' },
+      ],
+    })
+
+    const { cancelOverlappingReservationsForBlocks } = await loadEventsService()
+    await cancelOverlappingReservationsForBlocks([
+      { roomId: 'room-1', tableId: 'table-1', date: '2026-07-10', startTime: '09:00', endTime: '17:00' },
+    ])
+
+    const statuses = Object.fromEntries(getRows('reservations').map((row) => [row.id, row.status]))
+    expect(statuses).toMatchObject({
+      'active-overlap': 'cancelled',
+      'pending-overlap': 'cancelled',
+      'completed-overlap': 'completed',
+      boundary: 'active',
+      'other-table': 'active',
+    })
+  })
+
+  it('rolls back event creation when reservation cancellation fails', async () => {
+    seed({
+      tables: [{ id: 'table-1', roomId: 'room-1' }],
+      reservations: [
+        { id: 'reservation-1', tableId: 'table-1', date: '2026-07-10', startTime: '10:00:00', endTime: '12:00:00', status: 'active' },
+      ],
+    })
+    failNextQuery({ op: 'update', table: 'reservations', error: new Error('cancellation failed') })
+
+    const { createEvent } = await loadEventsService()
+    await expect(createEvent(createAdminSession(), {
+      title: 'Atomic event',
+      description: null,
+      schedules: [
+        { roomId: 'room-1', tableId: null, date: '2026-07-10', startTime: '09:00', endTime: '17:00', allDay: false },
+      ],
+    })).rejects.toThrow(MockServiceError)
+
+    expect(getRows('events')).toEqual([])
+    expect(getRows('event_room_blocks')).toEqual([])
+    expect(getRows('reservations')).toEqual([
+      expect.objectContaining({ id: 'reservation-1', status: 'active' }),
+    ])
+  })
+
+  it('rolls back event deletion when reservation cancellation fails', async () => {
+    seed({
+      events: [{ id: 'event-1', titleEs: null, titleEn: null }],
+      event_room_blocks: [
+        { id: 'block-1', eventId: 'event-1', roomId: 'room-1', tableId: 'table-1', date: '2026-07-10', startTime: '09:00:00', endTime: '17:00:00', allDay: false },
+      ],
+      tables: [{ id: 'table-1', roomId: 'room-1' }],
+      reservations: [
+        { id: 'reservation-1', tableId: 'table-1', date: '2026-07-10', startTime: '10:00:00', endTime: '12:00:00', status: 'active' },
+      ],
+    })
+    failNextQuery({ op: 'update', table: 'reservations', error: new Error('cancellation failed') })
+
+    const { deleteEvent } = await loadEventsService()
+    await expect(deleteEvent(createAdminSession(), 'event-1')).rejects.toThrow(MockServiceError)
+
+    expect(getRows('events')).toEqual([expect.objectContaining({ id: 'event-1' })])
+    expect(getRows('event_room_blocks')).toEqual([expect.objectContaining({ id: 'block-1' })])
+    expect(getRows('reservations')).toEqual([
+      expect.objectContaining({ id: 'reservation-1', status: 'active' }),
+    ])
   })
 
   it('skips reservation cancellation for null-room blocks', async () => {


### PR DESCRIPTION
## Summary

- move the last event-service reservation reads/writes from Supabase to Drizzle/Neon
- run event/block writes and reservation cancellation in the same transaction
- restore atomic rollback for create, update, and delete flows
- migrate conflict-preview tests from scripted Supabase counts to state-driven Drizzle data
- normalize PostgreSQL `time` values in the shared Drizzle mock so `HH:MM` and `HH:MM:SS` compare consistently

## Integrity guarantees

- only overlapping `pending`/`active` reservations are cancelled
- table-scoped blocks do not affect other tables in the room
- a cancellation failure rolls back event creation/deletion and block writes
- conflict previews read the same Neon reservation state used by reservation writes

## Validation

Validated with supported Node.js 24.16.0:

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 77 files, 1229 tests
- `pnpm build`
- focused security and legacy-access scans

Closes #248