### PR TITLE
fix: switch mark-no-show cron to daily schedule for Vercel Hobby plan

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
   "crons": [
     {
       "path": "/api/cron/mark-no-show",
-      "schedule": "*/15 * * * *"
+      "schedule": "0 3 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- The `/api/cron/mark-no-show` cron job was configured to run every 15 minutes (`*/15 * * * *`), which exceeds the Vercel Hobby plan's limit of daily-only cron schedules, blocking deploys.
- Updates the schedule to run once daily at 3am UTC (`0 3 * * *`), which is within the Hobby plan's allowed frequency.

## Fix
Single-line change in `vercel.json`:
```diff
-      "schedule": "*/15 * * * *"
+      "schedule": "0 3 * * *"
```

This is a dev-only deploy with no production traffic yet, so the reduced frequency has no user-facing impact at this stage.

Closes #314

## Test plan
- [x] qa-engineer confirmed diff scoped to exactly this one line
- [x] qa-engineer confirmed no test asserts the old schedule value
- [x] Build, typecheck, lint, and full test suite pass (968 tests, 64 files, all green)
- [x] security-reviewer confirmed no security concern: no secrets, no auth logic touched, no changes under lib/db/, lib/server/, or migration paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)