### PR TITLE
feat(db): Neon raw-SQL connection layer + schema (N0-1)

### DIFF
--- a/__tests__/lib/db/client.test.ts
+++ b/__tests__/lib/db/client.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+describe('lib/db/client — Neon raw-SQL connection helper', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('exports a tagged-template sql function when DATABASE_URL is set', async () => {
+    process.env.DATABASE_URL = 'postgresql://user:pass@localhost/db'
+
+    // Mock @neondatabase/serverless neon() export
+    vi.doMock('@neondatabase/serverless', () => ({
+      neon: vi.fn((url: string) => {
+        return vi.fn(async (strings: TemplateStringsArray, ...values: unknown[]) => ({
+          rows: [],
+        }))
+      }),
+    }))
+
+    const { sql } = await import('@/lib/db/client')
+
+    // Verify sql is a function (tagged template)
+    expect(typeof sql).toBe('function')
+
+    // Verify it can be called as a tagged template
+    const result = await sql`SELECT 1`
+    expect(result).toBeDefined()
+  })
+
+  it('throws an error when DATABASE_URL is not set', async () => {
+    delete process.env.DATABASE_URL
+
+    // Mock @neondatabase/serverless
+    vi.doMock('@neondatabase/serverless', () => ({
+      neon: vi.fn(),
+    }))
+
+    // Importing should throw immediately due to the guard at module level
+    await expect(async () => {
+      await import('@/lib/db/client')
+    }).rejects.toThrow('DATABASE_URL is not set')
+  })
+
+  it('throws an error with helpful message when DATABASE_URL is empty string', async () => {
+    process.env.DATABASE_URL = ''
+
+    // Mock @neondatabase/serverless
+    vi.doMock('@neondatabase/serverless', () => ({
+      neon: vi.fn(),
+    }))
+
+    // Importing should throw immediately due to the guard at module level
+    await expect(async () => {
+      await import('@/lib/db/client')
+    }).rejects.toThrow('DATABASE_URL is not set')
+  })
+
+  it('passes the DATABASE_URL to the neon driver', async () => {
+    const testUrl = 'postgresql://neon-user:neon-pass@test-host/test-db'
+    process.env.DATABASE_URL = testUrl
+
+    let capturedUrl: string | undefined
+
+    vi.doMock('@neondatabase/serverless', () => ({
+      neon: vi.fn((url: string) => {
+        capturedUrl = url
+        return vi.fn(async () => ({ rows: [] }))
+      }),
+    }))
+
+    await import('@/lib/db/client')
+
+    expect(capturedUrl).toBe(testUrl)
+  })
+
+  it('exports only the sql function (no wrapper, no query builder)', async () => {
+    process.env.DATABASE_URL = 'postgresql://user:pass@localhost/db'
+
+    vi.doMock('@neondatabase/serverless', () => ({
+      neon: vi.fn((url: string) => vi.fn(async () => ({ rows: [] }))),
+    }))
+
+    const module = await import('@/lib/db/client')
+
+    // Should only export 'sql', nothing else
+    expect(Object.keys(module)).toEqual(['sql'])
+  })
+})

--- a/__tests__/server/availability.test.ts
+++ b/__tests__/server/availability.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import type { GameTable } from '@/lib/types'
 import type { Tables } from '@/lib/supabase/types'
 import { resolveDate, normalizeTime, generateDaySlots, buildAvailability } from '@/lib/server/availability'
@@ -34,24 +34,34 @@ function makeGameTable(overrides?: Partial<GameTable>): GameTable {
 }
 
 describe('resolveDate', () => {
+  beforeEach(() => {
+    // Pin clock to a fixed instant within the historical flake window:
+    // 2025-06-15T23:30:00Z = June 15 23:30 UTC
+    // Atlantic/Canary is UTC+1 in June (WEST), so local time is June 16 00:30
+    // getCurrentClubDate() will return "2025-06-16" at this UTC instant
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-06-15T23:30:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('returns today when input is null', () => {
-    const today = new Date().toISOString().split('T')[0]
-    expect(resolveDate(null)).toBe(today)
+    // At this fixed instant (2025-06-15T23:30:00Z), club-local date is 2025-06-16
+    expect(resolveDate(null)).toBe('2025-06-16')
   })
 
   it('returns today when input is undefined', () => {
-    const today = new Date().toISOString().split('T')[0]
-    expect(resolveDate(undefined)).toBe(today)
+    expect(resolveDate(undefined)).toBe('2025-06-16')
   })
 
   it('returns today when input is empty string', () => {
-    const today = new Date().toISOString().split('T')[0]
-    expect(resolveDate('')).toBe(today)
+    expect(resolveDate('')).toBe('2025-06-16')
   })
 
   it('returns today when input is whitespace only', () => {
-    const today = new Date().toISOString().split('T')[0]
-    expect(resolveDate('   ')).toBe(today)
+    expect(resolveDate('   ')).toBe('2025-06-16')
   })
 
   it('returns the date when a valid YYYY-MM-DD is provided', () => {

--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -1,0 +1,26 @@
+import { neon, type NeonQueryFunction } from "@neondatabase/serverless";
+
+/**
+ * Raw-SQL Neon connection helper (#296).
+ *
+ * This intentionally does NOT wrap `sql` in any string-concatenation query
+ * builder. Callers must always use the tagged-template form —
+ * `sql\`SELECT * FROM foo WHERE id = ${id}\`` — which the underlying driver
+ * auto-parameterizes. Building queries via string concatenation on top of
+ * this would defeat that protection and reintroduce SQL injection risk.
+ */
+
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error(
+    "DATABASE_URL is not set. Add it to your environment (.env.local) before using lib/db."
+  );
+}
+
+/**
+ * Tagged-template SQL query function backed by Neon's HTTP driver.
+ * Neon's serverless driver is HTTP-based, so no connection pool is needed
+ * or managed here.
+ */
+export const sql: NeonQueryFunction<false, false> = neon(databaseUrl);

--- a/lib/db/schema/001_extensions.sql
+++ b/lib/db/schema/001_extensions.sql
@@ -1,0 +1,15 @@
+-- Neon schema setup (#296).
+-- Extensions needed by the structural DDL below. Both are standard Postgres
+-- contrib extensions available on Neon (no Supabase-specific extensions are
+-- carried over — pg_net/pg_graphql/pg_stat_statements/supabase_vault are
+-- Supabase platform internals and are intentionally not reproduced here).
+
+-- gen_random_uuid() default values used across (nearly) every table's "id"
+-- column. Native in Postgres 13+, but installing pgcrypto explicitly keeps
+-- this schema portable to older Postgres versions too.
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Provides the "gist_uuid_ops" operator class used by the GIST EXCLUDE
+-- constraints on public.reservations and public.saved_games (overlap
+-- prevention).
+CREATE EXTENSION IF NOT EXISTS "btree_gist";

--- a/lib/db/schema/002_types.sql
+++ b/lib/db/schema/002_types.sql
@@ -1,0 +1,42 @@
+-- Enum types, reconstructed from supabase/migrations/20260417000003_baseline.sql.
+-- No later migration altered these enums.
+--
+-- Postgres has no "CREATE TYPE IF NOT EXISTS", so each type is wrapped in a
+-- DO block that swallows duplicate_object (re-running this file against a
+-- database that already has these types is a safe no-op).
+
+DO $$ BEGIN
+    CREATE TYPE "reservation_status" AS ENUM (
+        'active',
+        'cancelled',
+        'completed',
+        'pending',
+        'no_show'
+    );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TYPE "role" AS ENUM (
+        'member',
+        'admin'
+    );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TYPE "table_surface" AS ENUM (
+        'top',
+        'bottom'
+    );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TYPE "table_type" AS ENUM (
+        'small',
+        'large',
+        'removable_top'
+    );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/lib/db/schema/003_profiles.sql
+++ b/lib/db/schema/003_profiles.sql
@@ -1,0 +1,35 @@
+-- public.profiles, reconstructed from supabase/migrations/20260417000003_baseline.sql
+-- (final shape as of the latest migration touching this table).
+--
+-- Scope note: in Supabase, "profiles.id" carried a FOREIGN KEY to
+-- "auth"."users"("id") (Supabase Auth's internal table). This migration is
+-- part of the Supabase -> Neon + Clerk auth cutover, and "auth.users" has no
+-- equivalent in this database, so that FK is intentionally dropped here.
+-- "profiles.id" remains the app-level user identifier (still a plain uuid,
+-- NOT NULL, primary key) — how it is populated/synced from Clerk is an
+-- app-layer concern for a later issue (#298), not a schema change.
+--
+-- Also out of scope here (per issue #296): RLS policies, GRANTs to
+-- Supabase's anon/authenticated/service_role roles, and the
+-- "profiles_updated_at" trigger (handle_updated_at() trigger function).
+
+CREATE TABLE IF NOT EXISTS "profiles" (
+    "id" uuid NOT NULL,
+    "member_number" character varying(20) NOT NULL,
+    "email" text,
+    "role" "role" DEFAULT 'member'::"role" NOT NULL,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "is_active" boolean DEFAULT false NOT NULL,
+    "no_show_count" integer DEFAULT 0 NOT NULL,
+    "blocked_until" timestamp with time zone,
+    "auth_email" text NOT NULL,
+    "full_name" text,
+    "active_from" timestamp with time zone,
+    "psw_changed" timestamp with time zone,
+    "phone" text,
+    CONSTRAINT "profiles_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "profiles_member_number_key" UNIQUE ("member_number")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "profiles_auth_email_key" ON "profiles" USING btree ("auth_email");

--- a/lib/db/schema/004_rooms.sql
+++ b/lib/db/schema/004_rooms.sql
@@ -1,0 +1,11 @@
+-- public.rooms, reconstructed from supabase/migrations/20260417000003_baseline.sql.
+-- No later migration altered this table's structure.
+
+CREATE TABLE IF NOT EXISTS "rooms" (
+    "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+    "name" text NOT NULL,
+    "table_count" integer DEFAULT 0 NOT NULL,
+    "description" text,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT "rooms_pkey" PRIMARY KEY ("id")
+);

--- a/lib/db/schema/005_tables.sql
+++ b/lib/db/schema/005_tables.sql
@@ -1,0 +1,19 @@
+-- public.tables, reconstructed from supabase/migrations/20260417000003_baseline.sql.
+-- No later migration altered this table's structure ("qr_code_inf" was added
+-- in the baseline; migration 20260417000007 only backfilled data, no DDL).
+
+CREATE TABLE IF NOT EXISTS "tables" (
+    "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+    "room_id" uuid NOT NULL,
+    "name" text NOT NULL,
+    "type" "table_type" DEFAULT 'small'::"table_type" NOT NULL,
+    "qr_code" text,
+    "pos_x" integer,
+    "pos_y" integer,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "qr_code_inf" text,
+    CONSTRAINT "tables_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "tables_room_id_fkey" FOREIGN KEY ("room_id") REFERENCES "rooms"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "tables_room_id_idx" ON "tables" USING btree ("room_id");

--- a/lib/db/schema/006_equipment.sql
+++ b/lib/db/schema/006_equipment.sql
@@ -1,0 +1,10 @@
+-- public.equipment, reconstructed from
+-- supabase/migrations/20260417000005_create_equipment_table.sql.
+
+CREATE TABLE IF NOT EXISTS "equipment" (
+    "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+    "name" text NOT NULL,
+    "description" text,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT "equipment_pkey" PRIMARY KEY ("id")
+);

--- a/lib/db/schema/007_room_default_equipment.sql
+++ b/lib/db/schema/007_room_default_equipment.sql
@@ -1,0 +1,14 @@
+-- public.room_default_equipment, reconstructed from
+-- supabase/migrations/20260417000006_create_room_default_equipment_table.sql.
+-- "room_default_equipment_equipment_id_idx" was added later in
+-- 20260528000006_supabase_linter_fixes.sql (unindexed FK fix).
+
+CREATE TABLE IF NOT EXISTS "room_default_equipment" (
+    "room_id" uuid NOT NULL,
+    "equipment_id" uuid NOT NULL,
+    CONSTRAINT "room_default_equipment_pkey" PRIMARY KEY ("room_id", "equipment_id"),
+    CONSTRAINT "room_default_equipment_room_id_fkey" FOREIGN KEY ("room_id") REFERENCES "rooms"("id") ON DELETE CASCADE,
+    CONSTRAINT "room_default_equipment_equipment_id_fkey" FOREIGN KEY ("equipment_id") REFERENCES "equipment"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "room_default_equipment_equipment_id_idx" ON "room_default_equipment" USING btree ("equipment_id");

--- a/lib/db/schema/008_events.sql
+++ b/lib/db/schema/008_events.sql
@@ -1,0 +1,46 @@
+-- public.events, reconstructed from:
+--   20260417000003_baseline.sql (base columns)
+--   20260703000001_oir202_extend_events_for_public_landing.sql
+--     (bilingual/display columns for the public landing page)
+--
+-- Scope note: "events.created_by" originally FK'd "auth"."users"("id")
+-- (Supabase Auth). That table has no equivalent in this database (see
+-- 003_profiles.sql), and "created_by" is an admin/profile identifier in
+-- practice, so it now FKs "profiles"("id") instead.
+--
+-- Out of scope here: RLS policies, GRANTs, and the create_event_atomic /
+-- update_event_atomic / create_event_with_blocks / update_event_with_blocks
+-- RPC functions (business logic, not table structure).
+
+CREATE TABLE IF NOT EXISTS "events" (
+    "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+    "title" text NOT NULL,
+    "description" text,
+    "date" date NOT NULL,
+    "start_time" time without time zone NOT NULL,
+    "end_time" time without time zone NOT NULL,
+    "created_by" uuid,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "title_es" text,
+    "title_en" text,
+    "blurb_es" text,
+    "blurb_en" text,
+    "description_es" text,
+    "description_en" text,
+    "date_kind" text DEFAULT 'single' NOT NULL,
+    "end_date" date,
+    "recurrence_label_es" text,
+    "recurrence_label_en" text,
+    "image_url" text,
+    "link_url" text,
+    "category_es" text,
+    "category_en" text,
+    CONSTRAINT "events_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "events_valid_time_range" CHECK (("end_time" > "start_time")),
+    CONSTRAINT "events_valid_date_kind" CHECK (("date_kind" IN ('single', 'range', 'recurring'))),
+    CONSTRAINT "events_valid_end_date" CHECK (("end_date" IS NULL OR "end_date" >= "date")),
+    CONSTRAINT "events_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "profiles"("id") ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS "events_date_idx" ON "events" USING btree ("date");
+CREATE INDEX IF NOT EXISTS "events_created_by_idx" ON "events" USING btree ("created_by");

--- a/lib/db/schema/009_event_room_blocks.sql
+++ b/lib/db/schema/009_event_room_blocks.sql
@@ -1,0 +1,24 @@
+-- public.event_room_blocks, reconstructed from:
+--   20260417000003_baseline.sql (base columns)
+--   20260617000001_kim383_multi_day_events.sql (event_room_blocks_unique_block)
+--   20260704000006_oir208_table_blocks_and_materials.sql ("table_id" column)
+
+CREATE TABLE IF NOT EXISTS "event_room_blocks" (
+    "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+    "event_id" uuid NOT NULL,
+    "room_id" uuid NOT NULL,
+    "date" date NOT NULL,
+    "start_time" time without time zone NOT NULL,
+    "end_time" time without time zone NOT NULL,
+    "all_day" boolean DEFAULT false NOT NULL,
+    "table_id" uuid,
+    CONSTRAINT "event_room_blocks_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "event_room_blocks_valid_time_range" CHECK (("end_time" > "start_time")),
+    CONSTRAINT "event_room_blocks_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "events"("id") ON DELETE CASCADE,
+    CONSTRAINT "event_room_blocks_room_id_fkey" FOREIGN KEY ("room_id") REFERENCES "rooms"("id") ON DELETE CASCADE,
+    CONSTRAINT "event_room_blocks_table_id_fkey" FOREIGN KEY ("table_id") REFERENCES "tables"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "event_room_blocks_event_id_idx" ON "event_room_blocks" USING btree ("event_id");
+CREATE INDEX IF NOT EXISTS "event_room_blocks_room_id_idx" ON "event_room_blocks" USING btree ("room_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "event_room_blocks_unique_block" ON "event_room_blocks" USING btree ("event_id", "room_id", "date", "start_time", "end_time");

--- a/lib/db/schema/010_event_equipment.sql
+++ b/lib/db/schema/010_event_equipment.sql
@@ -1,0 +1,12 @@
+-- public.event_equipment, reconstructed from
+-- supabase/migrations/20260704000006_oir208_table_blocks_and_materials.sql.
+
+CREATE TABLE IF NOT EXISTS "event_equipment" (
+    "event_id" uuid NOT NULL,
+    "equipment_id" uuid NOT NULL,
+    "quantity" integer DEFAULT 1 NOT NULL,
+    CONSTRAINT "event_equipment_pkey" PRIMARY KEY ("event_id", "equipment_id"),
+    CONSTRAINT "event_equipment_quantity_check" CHECK (("quantity" > 0)),
+    CONSTRAINT "event_equipment_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "events"("id") ON DELETE CASCADE,
+    CONSTRAINT "event_equipment_equipment_id_fkey" FOREIGN KEY ("equipment_id") REFERENCES "equipment"("id") ON DELETE CASCADE
+);

--- a/lib/db/schema/011_reservations.sql
+++ b/lib/db/schema/011_reservations.sql
@@ -1,0 +1,51 @@
+-- public.reservations, reconstructed (final shape) from:
+--   20260417000003_baseline.sql (base columns, original single EXCLUDE
+--     constraint "reservations_no_active_overlap")
+--   20260527120003_move_btree_gist_to_postgres_schema.sql (recreated the
+--     same EXCLUDE constraint after an extension schema move)
+--   20260619000001_kim375_atomic_reservation_overlap_constraints.sql
+--     (DROPPED "reservations_no_active_overlap" and replaced it with two
+--     surface-aware EXCLUDE constraints — this is the final, current shape
+--     reproduced below; the earlier single constraint is NOT reproduced)
+--
+-- Scope note: "user_id" originally carried TWO foreign keys — one to
+-- "auth"."users"("id") (Supabase Auth) and one to "profiles"("id"). Only the
+-- "profiles" FK is reproduced here; "auth.users" has no equivalent in this
+-- database (see 003_profiles.sql for the same auth-cutover rationale).
+--
+-- Out of scope here: RLS policies, GRANTs, and the
+-- cancel_expired_pending_reservations / mark_no_show_reservations RPC
+-- functions (business logic, not table structure).
+
+CREATE TABLE IF NOT EXISTS "reservations" (
+    "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+    "table_id" uuid NOT NULL,
+    "user_id" uuid NOT NULL,
+    "date" date NOT NULL,
+    "start_time" time without time zone NOT NULL,
+    "end_time" time without time zone NOT NULL,
+    "surface" "table_surface",
+    "status" "reservation_status" DEFAULT 'pending'::"reservation_status" NOT NULL,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "activated_at" timestamp with time zone,
+    CONSTRAINT "reservations_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "reservation_times_valid" CHECK (("end_time" > "start_time")),
+    CONSTRAINT "reservations_table_id_fkey" FOREIGN KEY ("table_id") REFERENCES "tables"("id") ON DELETE CASCADE,
+    CONSTRAINT "reservations_user_id_fkey_profiles" FOREIGN KEY ("user_id") REFERENCES "profiles"("id") ON DELETE CASCADE,
+    CONSTRAINT "reservations_no_pending_active_overlap_top" EXCLUDE USING gist (
+        "table_id" WITH =,
+        tsrange(("date" + "start_time"), ("date" + "end_time"), '[)') WITH &&
+    ) WHERE (("status" = ANY (ARRAY['pending'::"reservation_status", 'active'::"reservation_status"])) AND ("surface" IS NULL OR "surface" = 'top'::"table_surface")),
+    CONSTRAINT "reservations_no_pending_active_overlap_bottom" EXCLUDE USING gist (
+        "table_id" WITH =,
+        tsrange(("date" + "start_time"), ("date" + "end_time"), '[)') WITH &&
+    ) WHERE (("status" = ANY (ARRAY['pending'::"reservation_status", 'active'::"reservation_status"])) AND ("surface" IS NULL OR "surface" = 'bottom'::"table_surface"))
+);
+
+CREATE INDEX IF NOT EXISTS "reservations_activation_lookup_idx" ON "reservations" USING btree ("table_id", "date", "user_id", "status");
+CREATE INDEX IF NOT EXISTS "reservations_date_idx" ON "reservations" USING btree ("date");
+CREATE INDEX IF NOT EXISTS "reservations_pending_date_idx" ON "reservations" USING btree ("date", "start_time") WHERE ("status" = 'pending'::"reservation_status");
+CREATE INDEX IF NOT EXISTS "reservations_pending_no_show_idx" ON "reservations" USING btree ("date", "end_time") WHERE (("status" = 'pending'::"reservation_status") AND ("activated_at" IS NULL));
+CREATE INDEX IF NOT EXISTS "reservations_table_date_idx" ON "reservations" USING btree ("table_id", "date");
+CREATE INDEX IF NOT EXISTS "reservations_user_date_status_idx" ON "reservations" USING btree ("user_id", "date", "status") WHERE ("status" = ANY (ARRAY['pending'::"reservation_status", 'active'::"reservation_status"]));
+CREATE INDEX IF NOT EXISTS "reservations_user_id_idx" ON "reservations" USING btree ("user_id");

--- a/lib/db/schema/012_reservation_equipment.sql
+++ b/lib/db/schema/012_reservation_equipment.sql
@@ -1,0 +1,14 @@
+-- public.reservation_equipment, reconstructed from
+-- supabase/migrations/20260417000025_create_reservation_equipment_table.sql.
+-- "reservation_equipment_equipment_id_idx" was added later in
+-- 20260528000006_supabase_linter_fixes.sql (unindexed FK fix).
+
+CREATE TABLE IF NOT EXISTS "reservation_equipment" (
+    "reservation_id" uuid NOT NULL,
+    "equipment_id" uuid NOT NULL,
+    CONSTRAINT "reservation_equipment_pkey" PRIMARY KEY ("reservation_id", "equipment_id"),
+    CONSTRAINT "reservation_equipment_reservation_id_fkey" FOREIGN KEY ("reservation_id") REFERENCES "reservations"("id") ON DELETE CASCADE,
+    CONSTRAINT "reservation_equipment_equipment_id_fkey" FOREIGN KEY ("equipment_id") REFERENCES "equipment"("id") ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS "reservation_equipment_equipment_id_idx" ON "reservation_equipment" USING btree ("equipment_id");

--- a/lib/db/schema/013_activation_tokens.sql
+++ b/lib/db/schema/013_activation_tokens.sql
@@ -1,0 +1,26 @@
+-- public.activation_tokens, reconstructed from
+-- supabase/migrations/20260417000003_baseline.sql.
+-- "activation_tokens_created_by_idx" was added later in
+-- 20260528000006_supabase_linter_fixes.sql (unindexed FK fix).
+--
+-- Out of scope here: RLS policies, GRANTs, and the
+-- "activation_tokens_updated_at" trigger (handle_updated_at() trigger
+-- function).
+
+CREATE TABLE IF NOT EXISTS "activation_tokens" (
+    "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+    "profile_id" uuid NOT NULL,
+    "token_hash" text NOT NULL,
+    "expires_at" timestamp with time zone NOT NULL,
+    "used_at" timestamp with time zone,
+    "created_by" uuid,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT "activation_tokens_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "activation_tokens_profile_id_key" UNIQUE ("profile_id"),
+    CONSTRAINT "activation_tokens_token_hash_key" UNIQUE ("token_hash"),
+    CONSTRAINT "activation_tokens_profile_id_fkey" FOREIGN KEY ("profile_id") REFERENCES "profiles"("id") ON DELETE CASCADE,
+    CONSTRAINT "activation_tokens_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "profiles"("id") ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS "activation_tokens_created_by_idx" ON "activation_tokens" USING btree ("created_by");

--- a/lib/db/schema/014_saved_games.sql
+++ b/lib/db/schema/014_saved_games.sql
@@ -1,0 +1,31 @@
+-- public.saved_games, reconstructed from:
+--   20260619000003_kim384_create_saved_games.sql (table + inline constraints)
+--   20260619000005_kim384_saved_game_indexes.sql (partial indexes)
+--
+-- Out of scope here: RLS policies, GRANTs, and the validate_saved_game() /
+-- increment_saved_game_attendance() / cancel_saved_games_for_event_block()
+-- trigger functions (business logic, not table structure).
+
+CREATE TABLE IF NOT EXISTS "saved_games" (
+    "id" uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    "table_id" uuid NOT NULL REFERENCES "tables"("id") ON DELETE CASCADE,
+    "user_id" uuid NOT NULL REFERENCES "profiles"("id") ON DELETE CASCADE,
+    "start_date" date NOT NULL,
+    "end_date" date NOT NULL,
+    "status" text NOT NULL DEFAULT 'active',
+    "attendance_count" integer NOT NULL DEFAULT 0,
+    "renewed_from_id" uuid UNIQUE REFERENCES "saved_games"("id") ON DELETE SET NULL,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "saved_games_valid_status" CHECK ("status" IN ('active', 'cancelled', 'completed')),
+    CONSTRAINT "saved_games_valid_dates" CHECK ("end_date" >= "start_date"),
+    CONSTRAINT "saved_games_max_duration" CHECK ("end_date" < ("start_date" + interval '3 months')),
+    CONSTRAINT "saved_games_attendance_nonnegative" CHECK ("attendance_count" >= 0),
+    CONSTRAINT "saved_games_no_active_overlap" EXCLUDE USING gist (
+        "table_id" WITH =,
+        daterange("start_date", "end_date", '[]') WITH &&
+    ) WHERE ("status" = 'active')
+);
+
+CREATE INDEX IF NOT EXISTS "saved_games_user_dates_idx" ON "saved_games" ("user_id", "start_date", "end_date") WHERE "status" = 'active';
+CREATE INDEX IF NOT EXISTS "saved_games_table_dates_idx" ON "saved_games" ("table_id", "start_date", "end_date") WHERE "status" = 'active';

--- a/lib/db/schema/015_saved_game_attendances.sql
+++ b/lib/db/schema/015_saved_game_attendances.sql
@@ -1,0 +1,13 @@
+-- public.saved_game_attendances, reconstructed from:
+--   20260619000004_kim384_create_saved_game_attendances.sql (table)
+--   20260619000005_kim384_saved_game_indexes.sql (index)
+
+CREATE TABLE IF NOT EXISTS "saved_game_attendances" (
+    "id" uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    "saved_game_id" uuid NOT NULL REFERENCES "saved_games"("id") ON DELETE CASCADE,
+    "play_reservation_id" uuid NOT NULL UNIQUE REFERENCES "reservations"("id") ON DELETE CASCADE,
+    "attended_on" date NOT NULL,
+    "scanned_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "saved_game_attendances_saved_game_id_idx" ON "saved_game_attendances" ("saved_game_id");

--- a/lib/db/schema/016_partners.sql
+++ b/lib/db/schema/016_partners.sql
@@ -1,0 +1,17 @@
+-- public.partners, reconstructed from
+-- supabase/migrations/20260704000002_oir204_partners_table.sql.
+-- Seed data (the current 20 landing partners) is intentionally not
+-- reproduced here — out of scope for #296 (no data migration).
+
+CREATE TABLE IF NOT EXISTS "partners" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "name" text NOT NULL,
+    "img_url" text NOT NULL,
+    "link_url" text,
+    "desc_es" text,
+    "desc_en" text,
+    "sort_order" integer NOT NULL DEFAULT 0,
+    "active" boolean NOT NULL DEFAULT true,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);

--- a/lib/db/schema/017_library_games.sql
+++ b/lib/db/schema/017_library_games.sql
@@ -1,0 +1,20 @@
+-- public.library_games, reconstructed from:
+--   20260704000003_oir205_library_games_table.sql (table)
+--   20260704000005_oir207_landing_media_bucket.sql ("img_url" column)
+-- Seed data (the current 8 featured games) is intentionally not reproduced
+-- here — out of scope for #296 (no data migration).
+
+CREATE TABLE IF NOT EXISTS "library_games" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "title" text NOT NULL,
+    "category_es" text NOT NULL,
+    "category_en" text NOT NULL,
+    "players" text NOT NULL,
+    "play_time" text NOT NULL,
+    "weight" numeric(2,1) NOT NULL,
+    "sort_order" integer NOT NULL DEFAULT 0,
+    "active" boolean NOT NULL DEFAULT true,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "img_url" text
+);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
+    "@neondatabase/serverless": "^1.1.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.72.1(react@19.2.1))
+      '@neondatabase/serverless':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -764,6 +767,10 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@neondatabase/serverless@1.1.0':
+    resolution: {integrity: sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==}
+    engines: {node: '>=19.0.0'}
 
   '@next/env@15.5.19':
     resolution: {integrity: sha512-sWWluFvcv5v3Fxznmf2ZfjyoVQt/64oCnYqS90inQWGzMPK1VjvekPiz3OPHKmFT30EnHrjlbyaHLt3M0vWabw==}
@@ -4586,6 +4593,8 @@ snapshots:
       '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@neondatabase/serverless@1.1.0': {}
 
   '@next/env@15.5.19': {}
 

--- a/scripts/apply-neon-schema.mjs
+++ b/scripts/apply-neon-schema.mjs
@@ -15,6 +15,22 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, "..");
 const schemaDir = join(rootDir, "lib", "db", "schema");
 
+// Schemas known to come from a previous/other stack (e.g. Supabase) that has
+// nothing to do with this project's own schema. Their presence means the
+// target database is not a fresh/owned-by-us database.
+const KNOWN_LEFTOVER_SCHEMAS = [
+  "auth",
+  "storage",
+  "drizzle",
+  "supabase_migrations",
+  "realtime",
+  "internal",
+  "pgbouncer",
+  "graphql",
+  "graphql_public",
+  "vault",
+];
+
 function loadEnvLocal() {
   const envPath = join(rootDir, ".env.local");
   if (!existsSync(envPath)) return;
@@ -88,6 +104,62 @@ function splitStatements(sqlText) {
   return statements;
 }
 
+// Parses `CREATE TABLE [IF NOT EXISTS] "name"` out of this script's own
+// schema files, so the preflight check always stays in sync with the actual
+// schema definitions without needing a separately maintained list.
+function extractExpectedTableNames(files) {
+  const names = new Set();
+  for (const file of files) {
+    const text = readFileSync(join(schemaDir, file), "utf8");
+    for (const match of text.matchAll(/CREATE TABLE(?:\s+IF NOT EXISTS)?\s+"([^"]+)"/gi)) {
+      names.add(match[1]);
+    }
+  }
+  return names;
+}
+
+// Read-only preflight: aborts if the target database has state that did not
+// come from this script, so a "successful" run can't silently apply on top
+// of (and thereby appear to validate) an unrelated/leftover database.
+async function assertDatabaseIsCleanOrOwned(sql, expectedTables) {
+  if (process.argv.includes("--force") || process.env.ALLOW_NON_EMPTY_DB === "1") {
+    console.log("Preflight check skipped (--force / ALLOW_NON_EMPTY_DB=1).");
+    return;
+  }
+
+  console.log("Running preflight check (target database must be empty or already owned by this schema)...");
+
+  const leftoverSchemas = await sql.query(
+    `SELECT "nspname" FROM "pg_catalog"."pg_namespace" WHERE "nspname" = ANY($1)`,
+    [KNOWN_LEFTOVER_SCHEMAS],
+  );
+  if (leftoverSchemas.length > 0) {
+    const names = leftoverSchemas.map((row) => row.nspname).join(", ");
+    console.error(
+      `Preflight check failed: target database has pre-existing non-Alea schema(s): ${names}.\n` +
+        "This script only replays CREATE/IF NOT EXISTS statements and does not verify a clean target on its own.\n" +
+        "Run it against a fresh empty database, or pass --force / set ALLOW_NON_EMPTY_DB=1 if you have already verified this is expected.",
+    );
+    process.exit(1);
+  }
+
+  const publicTables = await sql.query(
+    `SELECT "tablename" FROM "pg_catalog"."pg_tables" WHERE "schemaname" = 'public'`,
+  );
+  const unexpectedTables = publicTables
+    .map((row) => row.tablename)
+    .filter((name) => !expectedTables.has(name));
+  if (unexpectedTables.length > 0) {
+    console.error(
+      `Preflight check failed: "public" schema has pre-existing table(s) not defined by lib/db/schema/: ${unexpectedTables.join(", ")}.\n` +
+        "Run it against a fresh empty database, or pass --force / set ALLOW_NON_EMPTY_DB=1 if you have already verified this is expected.",
+    );
+    process.exit(1);
+  }
+
+  console.log("Preflight check passed.");
+}
+
 async function main() {
   loadEnvLocal();
 
@@ -103,16 +175,28 @@ async function main() {
     .filter((f) => f.endsWith(".sql"))
     .sort();
 
+  await assertDatabaseIsCleanOrOwned(sql, extractExpectedTableNames(files));
+
   console.log(`Applying ${files.length} schema file(s) from lib/db/schema/ ...`);
 
+  const allStatements = [];
   for (const file of files) {
     const filePath = join(schemaDir, file);
     const text = readFileSync(filePath, "utf8");
     const statements = splitStatements(text);
     console.log(`-> ${file} (${statements.length} statement(s))`);
-    for (const stmt of statements) {
-      await sql.query(stmt);
-    }
+    allStatements.push(...statements);
+  }
+
+  // Apply every statement from every file as a single Postgres transaction
+  // (one HTTP round-trip via the neon() driver's transaction() helper), so a
+  // mid-way failure rolls back all DDL instead of leaving the database
+  // partially migrated.
+  try {
+    await sql.transaction((txn) => allStatements.map((stmt) => txn.query(stmt)));
+  } catch (err) {
+    console.error("Schema application failed — transaction rolled back, no changes were committed.");
+    throw err;
   }
 
   console.log("Schema applied successfully.");

--- a/scripts/apply-neon-schema.mjs
+++ b/scripts/apply-neon-schema.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * One-off script (#296) to apply lib/db/schema/*.sql against a Neon
+ * database. Reads DATABASE_URL from the environment / .env.local — never
+ * hardcode credentials here.
+ *
+ * Usage: node scripts/apply-neon-schema.mjs
+ */
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { neon } from "@neondatabase/serverless";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, "..");
+const schemaDir = join(rootDir, "lib", "db", "schema");
+
+function loadEnvLocal() {
+  const envPath = join(rootDir, ".env.local");
+  if (!existsSync(envPath)) return;
+  const content = readFileSync(envPath, "utf8");
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+}
+
+// Splits a .sql file into individual top-level statements on ";", while
+// treating dollar-quoted blocks (e.g. `DO $$ ... $$;`, used for idempotent
+// CREATE TYPE) as opaque — semicolons inside a dollar-quoted block never
+// split the statement.
+function splitStatements(sqlText) {
+  const withoutComments = sqlText
+    .split(/\r?\n/)
+    .filter((line) => !line.trim().startsWith("--"))
+    .join("\n");
+
+  const statements = [];
+  let current = "";
+  let dollarTag = null; // e.g. "$$" or "$tag$" when inside a dollar-quoted block
+
+  for (let i = 0; i < withoutComments.length; i++) {
+    const char = withoutComments[i];
+    current += char;
+
+    if (dollarTag) {
+      if (withoutComments.startsWith(dollarTag, i)) {
+        current += dollarTag.slice(1); // already added one char above
+        i += dollarTag.length - 1;
+        dollarTag = null;
+      }
+      continue;
+    }
+
+    if (char === "$") {
+      const match = withoutComments.slice(i).match(/^\$[a-zA-Z_]*\$/);
+      if (match) {
+        dollarTag = match[0];
+        current += withoutComments.slice(i + 1, i + dollarTag.length);
+        i += dollarTag.length - 1;
+      }
+      continue;
+    }
+
+    if (char === ";") {
+      const stmt = current.slice(0, -1).trim();
+      if (stmt) statements.push(stmt);
+      current = "";
+    }
+  }
+
+  const rest = current.trim();
+  if (rest) statements.push(rest);
+
+  return statements;
+}
+
+async function main() {
+  loadEnvLocal();
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL is not set (checked process.env and .env.local).");
+    process.exit(1);
+  }
+
+  const sql = neon(databaseUrl);
+
+  const files = readdirSync(schemaDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+
+  console.log(`Applying ${files.length} schema file(s) from lib/db/schema/ ...`);
+
+  for (const file of files) {
+    const filePath = join(schemaDir, file);
+    const text = readFileSync(filePath, "utf8");
+    const statements = splitStatements(text);
+    console.log(`-> ${file} (${statements.length} statement(s))`);
+    for (const stmt of statements) {
+      await sql.query(stmt);
+    }
+  }
+
+  console.log("Schema applied successfully.");
+}
+
+main().catch((err) => {
+  console.error("Failed to apply schema:", err.message);
+  process.exit(1);
+});

--- a/scripts/apply-neon-schema.mjs
+++ b/scripts/apply-neon-schema.mjs
@@ -15,21 +15,20 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, "..");
 const schemaDir = join(rootDir, "lib", "db", "schema");
 
-// Schemas known to come from a previous/other stack (e.g. Supabase) that has
-// nothing to do with this project's own schema. Their presence means the
-// target database is not a fresh/owned-by-us database.
-const KNOWN_LEFTOVER_SCHEMAS = [
-  "auth",
-  "storage",
-  "drizzle",
-  "supabase_migrations",
-  "realtime",
-  "internal",
-  "pgbouncer",
-  "graphql",
-  "graphql_public",
-  "vault",
-];
+// Postgres-internal schemas that are always present in every database and
+// are not evidence of leftover state from another stack/project. Anything
+// else besides "public" (this project's own schema) fails the preflight
+// check — an allowlist, not a denylist of specific known-bad names, so an
+// arbitrary unlisted schema (e.g. "legacy") is caught too.
+const SYSTEM_SCHEMAS = ["pg_catalog", "information_schema", "pg_toast"];
+
+// Safely quotes a Postgres identifier for interpolation into SQL text.
+// Only ever called with table names sourced from this script's own trusted
+// inputs (pg_catalog.pg_tables query results, or names parsed out of this
+// script's own lib/db/schema/*.sql files) — never external/user input.
+function quoteIdent(name) {
+  return `"${String(name).replace(/"/g, '""')}"`;
+}
 
 function loadEnvLocal() {
   const envPath = join(rootDir, ".env.local");
@@ -129,29 +128,61 @@ async function assertDatabaseIsCleanOrOwned(sql, expectedTables) {
 
   console.log("Running preflight check (target database must be empty or already owned by this schema)...");
 
-  const leftoverSchemas = await sql.query(
-    `SELECT "nspname" FROM "pg_catalog"."pg_namespace" WHERE "nspname" = ANY($1)`,
-    [KNOWN_LEFTOVER_SCHEMAS],
+  // 1. Schema allowlist: only "public" plus Postgres-internal system schemas
+  // are acceptable. Any other schema at all — a known leftover stack schema
+  // (auth, storage, drizzle, ...) or an arbitrary one (legacy, ...) — means
+  // the target database is not a fresh/owned-by-us database.
+  const unexpectedSchemas = await sql.query(
+    `SELECT "nspname" FROM "pg_catalog"."pg_namespace"
+     WHERE "nspname" <> 'public'
+       AND "nspname" <> ALL($1)
+       AND "nspname" !~ '^pg_temp_'
+       AND "nspname" !~ '^pg_toast_temp_'`,
+    [SYSTEM_SCHEMAS],
   );
-  if (leftoverSchemas.length > 0) {
-    const names = leftoverSchemas.map((row) => row.nspname).join(", ");
+  if (unexpectedSchemas.length > 0) {
+    const names = unexpectedSchemas.map((row) => row.nspname).join(", ");
     console.error(
-      `Preflight check failed: target database has pre-existing non-Alea schema(s): ${names}.\n` +
-        "This script only replays CREATE/IF NOT EXISTS statements and does not verify a clean target on its own.\n" +
+      `Preflight check failed: target database has unexpected schema(s) not owned by this project: ${names}.\n` +
+        'Only "public" plus Postgres-internal system schemas are allowed.\n' +
         "Run it against a fresh empty database, or pass --force / set ALLOW_NON_EMPTY_DB=1 if you have already verified this is expected.",
     );
     process.exit(1);
   }
 
+  // 2. Unexpected-table check: any table in "public" whose name is not
+  // produced by this script's own schema files is a hard fail.
   const publicTables = await sql.query(
     `SELECT "tablename" FROM "pg_catalog"."pg_tables" WHERE "schemaname" = 'public'`,
   );
-  const unexpectedTables = publicTables
-    .map((row) => row.tablename)
-    .filter((name) => !expectedTables.has(name));
+  const publicTableNames = publicTables.map((row) => row.tablename);
+  const unexpectedTables = publicTableNames.filter((name) => !expectedTables.has(name));
   if (unexpectedTables.length > 0) {
     console.error(
       `Preflight check failed: "public" schema has pre-existing table(s) not defined by lib/db/schema/: ${unexpectedTables.join(", ")}.\n` +
+        "Run it against a fresh empty database, or pass --force / set ALLOW_NON_EMPTY_DB=1 if you have already verified this is expected.",
+    );
+    process.exit(1);
+  }
+
+  // 3. Row-emptiness check: an expected table that already exists must be
+  // empty — non-empty means stale/leftover data from a prior run, not a
+  // fresh database. Tables that don't exist yet (first run) have nothing to
+  // check and are skipped. Uses a cheap EXISTS/LIMIT 1 probe per table
+  // instead of COUNT(*), since expected tables could hold real data.
+  const existingExpectedTables = publicTableNames.filter((name) => expectedTables.has(name));
+  const nonEmptyTables = [];
+  for (const tableName of existingExpectedTables) {
+    const rows = await sql.query(
+      `SELECT EXISTS (SELECT 1 FROM ${quoteIdent(tableName)} LIMIT 1) AS "has_rows"`,
+    );
+    if (rows[0]?.has_rows) {
+      nonEmptyTables.push(tableName);
+    }
+  }
+  if (nonEmptyTables.length > 0) {
+    console.error(
+      `Preflight check failed: pre-existing table(s) already contain data: ${nonEmptyTables.join(", ")}.\n` +
         "Run it against a fresh empty database, or pass --force / set ALLOW_NON_EMPTY_DB=1 if you have already verified this is expected.",
     );
     process.exit(1);


### PR DESCRIPTION
## Summary

- Closes #296

- Adds `@neondatabase/serverless` as the only new DB dependency (no ORM — no drizzle-orm/drizzle-kit/prisma/pg).
- `lib/db/client.ts`: raw-SQL Neon connection helper. Exports the `neon()` tagged-template `sql` function directly (parameters auto-parameterized by the driver — no string-concatenation wrapper that would defeat that safety property). Throws a clear error if `DATABASE_URL` is unset.
- `lib/db/schema/001_extensions.sql` … `017_library_games.sql`: 17 plain DDL files reconstructing table structure from `supabase/migrations/` (85 files). Pure `CREATE TABLE` / `CREATE TYPE` / index / FK statements — no seed data, no hardcoded secrets.
- `scripts/apply-neon-schema.mjs`: one-off script to apply the schema files to a Neon database. Reads `DATABASE_URL` from env / `.env.local` only — no hardcoded credentials.
- `__tests__/lib/db/client.test.ts`: 5 new tests (mocked `@neondatabase/serverless`, no live DB) covering the connection guard and tagged-template export shape.

## Deliberate scope exclusion

RLS policies, Supabase role GRANTs, and business-logic triggers (e.g. `handle_updated_at`, `create_event_atomic`, `validate_saved_game`) are intentionally **not** included in this schema — table structure only. This is called out explicitly in code comments in the schema files and is deferred to #298.

## Pre-existing DB state (reviewer awareness, not a blocker for this issue)

The Neon `DATABASE_URL` used for the smoke test / schema-apply already contained leftover schemas/data (`auth`, `storage`, `drizzle` schemas, ~156 rows in `profiles`/`auth.users`) from an earlier, since-reset migration attempt. Nothing was dropped or altered destructively — the apply script only runs additive `CREATE ... IF NOT EXISTS` statements. This is being escalated separately to the coordinator and does not change what's in scope for #296.

## Security review

- No secrets committed — no `.env.local` or real `DATABASE_URL` in the diff; only the pre-existing `.env.example` is unaffected.
- `lib/db/client.ts` exports the raw `neon()` tagged-template directly — confirmed no string-concatenation wrapper defeating driver auto-parameterization.
- `scripts/apply-neon-schema.mjs` reads credentials from env/`.env.local` only, never hardcodes them.
- Schema `.sql` files are pure DDL — no `INSERT`, no seed data, no hardcoded secret/token default values.
- Confirmed no ORM (drizzle-orm/drizzle-kit/prisma) added to `package.json` — only `@neondatabase/serverless`.
- Spot-checked `supabase/migrations/` for `reservations` — confirmed source migrations do contain RLS/GRANT/POLICY statements, none of which were carried over into the new schema files (only exclusion comments remain), matching the stated deliberate scope cut.

## Test plan

- [x] `973` tests passing (65 files) per QA
- [x] Typecheck clean
- [x] Build clean
- [x] Schema fidelity spot-checked against 4 tables (profiles, events, reservations, rooms)
- [x] Security review completed (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)