### PR TITLE
test(319): fix availability.test.ts UTC/local timezone flake

### DIFF
--- a/__tests__/server/availability.test.ts
+++ b/__tests__/server/availability.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import type { GameTable } from '@/lib/types'
 import type { Tables } from '@/lib/supabase/types'
 import { resolveDate, normalizeTime, generateDaySlots, buildAvailability } from '@/lib/server/availability'
@@ -34,24 +34,34 @@ function makeGameTable(overrides?: Partial<GameTable>): GameTable {
 }
 
 describe('resolveDate', () => {
+  beforeEach(() => {
+    // Pin clock to a fixed instant within the historical flake window:
+    // 2025-06-15T23:30:00Z = June 15 23:30 UTC
+    // Atlantic/Canary is UTC+1 in June (WEST), so local time is June 16 00:30
+    // getCurrentClubDate() will return "2025-06-16" at this UTC instant
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-06-15T23:30:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('returns today when input is null', () => {
-    const today = new Date().toISOString().split('T')[0]
-    expect(resolveDate(null)).toBe(today)
+    // At this fixed instant (2025-06-15T23:30:00Z), club-local date is 2025-06-16
+    expect(resolveDate(null)).toBe('2025-06-16')
   })
 
   it('returns today when input is undefined', () => {
-    const today = new Date().toISOString().split('T')[0]
-    expect(resolveDate(undefined)).toBe(today)
+    expect(resolveDate(undefined)).toBe('2025-06-16')
   })
 
   it('returns today when input is empty string', () => {
-    const today = new Date().toISOString().split('T')[0]
-    expect(resolveDate('')).toBe(today)
+    expect(resolveDate('')).toBe('2025-06-16')
   })
 
   it('returns today when input is whitespace only', () => {
-    const today = new Date().toISOString().split('T')[0]
-    expect(resolveDate('   ')).toBe(today)
+    expect(resolveDate('   ')).toBe('2025-06-16')
   })
 
   it('returns the date when a valid YYYY-MM-DD is provided', () => {


### PR DESCRIPTION
## Summary

Fixes a flaky test in `__tests__/server/availability.test.ts` that computed its expected "today" via `new Date().toISOString().split('T')[0]` (UTC), while the code under test (`resolveDate()` in `lib/server/availability.ts`) resolves "today" via `getCurrentClubDate()` in the club's local timezone (`CLUB_TIMEZONE`, default `Atlantic/Canary`).

**Root cause:** these two "today" computations diverge during the UTC/local rollover window, causing consistent CI / pre-push-hook failures roughly 22:00-00:00 UTC and blocking pushes on unrelated branches.

**Fix:** pins the clock with `vi.useFakeTimers()` + `vi.setSystemTime()` in the `resolveDate` describe block (via `beforeEach`, restored with `vi.useRealTimers()` in `afterEach`), and replaces the 4 dynamic UTC-based expectations with a hardcoded club-local date, proven against a fixed instant (`2025-06-15T23:30:00.000Z`) inside the old failure window.

Closes #319

## Test plan
- [x] `__tests__/server/availability.test.ts` only file changed (19 insertions, 9 deletions)
- [x] Test count unchanged: 29 -> 29
- [x] Fake-timer setup/teardown correctly scoped to `resolveDate` describe block only (no leakage into `normalizeTime`, `generateDaySlots`, `buildAvailability`)
- [x] Timezone math verified: `Atlantic/Canary` is UTC+1 (WEST) in June, so UTC 23:30 June 15 -> club-local 00:30 June 16
- [x] Full suite reported green (968 passed), typecheck/lint/build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)